### PR TITLE
fixes

### DIFF
--- a/lib/cinegraph/jobs/import_movie_job.ex.disabled
+++ b/lib/cinegraph/jobs/import_movie_job.ex.disabled
@@ -39,10 +39,13 @@ defmodule Cinegraph.Jobs.ImportMovieJob do
   # Helper function to convert string keys to atoms
   defp atomize_keys(map) when is_map(map) do
     Map.new(map, fn
-      {key, value} when is_binary(key) -> {String.to_existing_atom(key), value}
+      {key, value} when is_binary(key) -> 
+        try do
+          {String.to_existing_atom(key), value}
+        rescue
+          ArgumentError -> {key, value}
+        end
       {key, value} -> {key, value}
     end)
-  rescue
-    ArgumentError -> map  # If atom doesn't exist, return original map
   end
 end

--- a/lib/cinegraph/movie_importer.ex
+++ b/lib/cinegraph/movie_importer.ex
@@ -71,7 +71,7 @@ defmodule Cinegraph.MovieImporter do
     
     if queue do
       Enum.each(movies, &queue_api_job(&1.id, api, []))
-      {:ok, count}
+      {:ok, count, count}  # All queued successfully
     else
       results = Enum.map(movies, fn movie ->
         case process_api_immediately(movie.id, api, []) do
@@ -145,7 +145,10 @@ defmodule Cinegraph.MovieImporter do
     case Movies.get_movie_by_tmdb_id(tmdb_id) do
       nil ->
         # Create a basic movie record first
-        case Movies.create_movie(%{tmdb_id: tmdb_id, title: "Loading..."}) do
+        case Movies.create_movie(%{
+          tmdb_id: tmdb_id, 
+          title: "Pending Import - TMDb ID: #{tmdb_id}"
+        }) do
           {:ok, movie} -> {:ok, movie}
           error -> error
         end
@@ -206,14 +209,4 @@ defmodule Cinegraph.MovieImporter do
   defp get_processor("tmdb"), do: ApiProcessors.TMDb
   defp get_processor("omdb"), do: ApiProcessors.OMDb
   defp get_processor(_), do: nil
-  
-  defp stringify_keys(map) when is_map(map) do
-    Map.new(map, fn
-      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
-      {key, value} -> {key, value}
-    end)
-  end
-  defp stringify_keys(keyword) when is_list(keyword) do
-    keyword |> Enum.into(%{}) |> stringify_keys()
-  end
 end


### PR DESCRIPTION
### TL;DR

Improved error handling in movie import process and enhanced placeholder titles for pending imports.

### What changed?

- Refined the `atomize_keys` function in `ImportMovieJob` to handle non-existing atoms more gracefully by preserving the original key instead of failing
- Updated the return value of the movie import function when queuing to include the count twice for consistency
- Enhanced the placeholder title for movies pending import to include the TMDb ID for better identification
- Removed unused `stringify_keys` functions from the `MovieImporter` module

### How to test?

1. Import a movie using the TMDb API and verify the placeholder title shows "Pending Import - TMDb ID: [id]"
2. Test importing movies with unusual field names to ensure the atomize_keys function handles them properly
3. Verify that queued imports return the expected tuple format with count repeated

### Why make this change?

These changes improve error resilience during the import process and provide better visibility into pending imports. The placeholder title enhancement makes it easier to identify which TMDb ID is being imported while the process is running. The atomize_keys refinement prevents crashes when encountering unexpected field names from external APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reliability when processing imported movie data, reducing potential errors during import.
  * Updated placeholder titles for newly created movies to display the TMDb ID, making it easier to identify pending imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->