### PR TITLE
move fixes

### DIFF
--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -198,11 +198,14 @@ defmodule Cinegraph.Movies do
     case get_movie_by_tmdb_id(tmdb_data["id"]) do
       nil ->
         Repo.insert(changeset)
-      existing_movie ->
-        # If movie exists but was soft imported, we could upgrade it later
+      %Movie{import_status: "soft"} = existing_movie ->
+        # Only re-soft-import if it was already soft
         existing_movie
         |> Movie.changeset(%{import_status: "soft"})
         |> Repo.update()
+      existing_movie ->
+        # Leave full imports untouched
+        {:ok, existing_movie}
     end
   end
 


### PR DESCRIPTION
### TL;DR

Improved the two-degree connection query and refined movie import logic.

### What changed?

- Optimized the two-degree connection query in `collaboration_deep_dive.exs` by:
  - First identifying all unique intermediaries (direct connections to person1)
  - Then finding second-degree connections through those intermediaries
  - Using more precise SQL fragments to ensure correct relationship mapping

- Enhanced the movie import logic in `cinegraph/movies.ex` to:
  - Only update movies with "soft" import status
  - Leave fully imported movies untouched when encountering duplicates

### How to test?

1. Run the collaboration deep dive script to verify the two-degree connection query returns accurate results
2. Test movie imports with both new and existing movies:
   - Import a new movie and verify it's created
   - Re-import a "soft" imported movie and verify it updates
   - Re-import a fully imported movie and verify it remains unchanged

### Why make this change?

The previous two-degree connection query had potential for inaccuracies in relationship mapping. The new implementation provides more precise results by clearly identifying intermediaries first.

The movie import logic now properly respects the import status, preventing accidental downgrades of fully imported movies to "soft" status when re-importing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for counting second-degree connections in collaboration graphs for greater clarity and correctness.

* **Bug Fixes**
  * Adjusted movie import handling to ensure fully imported movies are not overwritten by soft imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->