### PR TITLE
small fixes

### DIFF
--- a/lib/cinegraph/imports/import_stats.ex
+++ b/lib/cinegraph/imports/import_stats.ex
@@ -73,7 +73,10 @@ defmodule Cinegraph.Imports.ImportStats do
     current_time = DateTime.utc_now()
     current_movie_count = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count)
     
-    [{:current_stats, prev_stats}] = :ets.lookup(@table_name, :current_stats)
+    prev_stats = case :ets.lookup(@table_name, :current_stats) do
+      [{:current_stats, stats}] -> stats
+      [] -> %{movies_per_minute: 0.0, last_movie_count: 0, last_check_time: current_time}
+    end
     
     # Calculate rate
     time_diff = DateTime.diff(current_time, prev_stats.last_check_time, :second)


### PR DESCRIPTION
### TL;DR

Fix potential crash in import stats when ETS table doesn't have current stats.

### What changed?

Added error handling in `ImportStats` module to gracefully handle the case when the `:current_stats` key doesn't exist in the ETS table. Instead of assuming the key exists and potentially crashing, the code now returns a default stats map with initial values when the lookup returns an empty list.

### How to test?

1. Start a fresh instance of the application
2. Trigger an import process
3. Verify that the import stats are properly calculated without errors
4. Check logs to ensure no crashes occur during the first stats calculation

### Why make this change?

The previous implementation assumed that the `:current_stats` key always existed in the ETS table, which could cause crashes when the application first starts or if the ETS table is cleared. This change makes the code more robust by providing default values when the stats haven't been initialized yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving import statistics by handling cases where no previous data exists, preventing potential errors during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->