### PR TITLE
small

### DIFF
--- a/lib/cinegraph_web/components/collaboration_components.ex
+++ b/lib/cinegraph_web/components/collaboration_components.ex
@@ -14,17 +14,24 @@ defmodule CinegraphWeb.CollaborationComponents do
   def humanize_strength(_), do: "Moderate"
   
   @doc """
-  Formats a number with its ordinal suffix (1st, 2nd, 3rd, etc.)
+  Returns the ordinal suffix for a number (st, nd, rd, th)
   """
-  def format_ordinal(n) when is_integer(n) do
-    suffix = cond do
+  def ordinal_suffix(n) when is_integer(n) do
+    cond do
       rem(n, 100) in [11, 12, 13] -> "th"
       rem(n, 10) == 1 -> "st"
       rem(n, 10) == 2 -> "nd"
       rem(n, 10) == 3 -> "rd"
       true -> "th"
     end
-    "#{n}#{suffix}"
+  end
+  def ordinal_suffix(_), do: ""
+
+  @doc """
+  Formats a number with its ordinal suffix (1st, 2nd, 3rd, etc.)
+  """
+  def format_ordinal(n) when is_integer(n) do
+    "#{n}#{ordinal_suffix(n)}"
   end
   def format_ordinal(_), do: ""
 end

--- a/lib/cinegraph_web/live/movie_live/show.ex
+++ b/lib/cinegraph_web/live/movie_live/show.ex
@@ -1,6 +1,6 @@
 defmodule CinegraphWeb.MovieLive.Show do
   use CinegraphWeb, :live_view
-  import CinegraphWeb.CollaborationComponents, only: [format_ordinal: 1]
+  import CinegraphWeb.CollaborationComponents, only: [format_ordinal: 1, ordinal_suffix: 1]
 
   alias Cinegraph.Movies
   alias Cinegraph.Cultural
@@ -149,19 +149,4 @@ defmodule CinegraphWeb.MovieLive.Show do
     }
   end
   
-  # Helper functions for template
-  defp ordinal_suffix(number) do
-    case rem(number, 100) do
-      11 -> "th"
-      12 -> "th" 
-      13 -> "th"
-      _ ->
-        case rem(number, 10) do
-          1 -> "st"
-          2 -> "nd"
-          3 -> "rd"
-          _ -> "th"
-        end
-    end
-  end
 end


### PR DESCRIPTION
### TL;DR

Extract ordinal suffix logic into a reusable function and remove duplicate implementation.

### What changed?

- Created a new `ordinal_suffix/1` function in `CollaborationComponents` that returns just the suffix (st, nd, rd, th) for a given number
- Modified `format_ordinal/1` to use the new `ordinal_suffix/1` function
- Imported the new `ordinal_suffix/1` function in `MovieLive.Show`
- Removed the duplicate `ordinal_suffix/1` private function from `MovieLive.Show`

### How to test?

- Verify that ordinal numbers are still displayed correctly throughout the application
- Check that both `1st`, `2nd`, `3rd`, `4th`, etc. appear correctly
- Verify edge cases like `11th`, `12th`, and `13th` display the correct suffix

### Why make this change?

This refactoring eliminates code duplication by centralizing the ordinal suffix logic in one place. The new implementation is more maintainable and follows the DRY principle, making it easier to reuse the suffix functionality independently from the full ordinal formatting when needed.