### PR TITLE
almost

### DIFF
--- a/lib/cinegraph/canonical_lists.ex
+++ b/lib/cinegraph/canonical_lists.ex
@@ -36,6 +36,19 @@ defmodule Cinegraph.CanonicalLists do
         "reliability" => "95%",
         "note" => "Updated annually after official announcements"
       }
+    },
+    "cannes_winners" => %{
+      list_id: "ls527026601",
+      source_key: "cannes_winners",
+      name: "Cannes Film Festival Award Winners: 2023-1939",
+      metadata: %{
+        "festival" => "Cannes Film Festival",
+        "source" => "IMDB User List",
+        "awards_included" => "Palme d'Or, Grand Prix, Jury Prize, Caméra d'Or, Best Director, Best Actor, Best Actress",
+        "data_extraction" => "Enhanced extraction required for award details",
+        "reliability" => "85%",
+        "note" => "Winners only - no nominees. Award details mixed in descriptions."
+      }
     }
   }
 

--- a/lib/cinegraph/workers/tmdb_details_worker.ex
+++ b/lib/cinegraph/workers/tmdb_details_worker.ex
@@ -186,16 +186,23 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
   end
   
   defp handle_post_creation_tasks(tmdb_id, args) do
+    Logger.info("Post-creation tasks for TMDb ID #{tmdb_id}, args: #{inspect(args)}")
+    
     # Handle any post-creation tasks for movies
     cond do
       # Oscar import - create nominations
       args["source"] == "oscar_import" && args["metadata"] ->
         metadata = args["metadata"]
+        Logger.info("Oscar import detected - metadata: #{inspect(metadata)}")
+        
         if metadata["ceremony_year"] && metadata["category"] do
           Logger.info("Creating Oscar nomination for movie with TMDb ID #{tmdb_id}")
-          create_oscar_nomination(tmdb_id, metadata)
+          result = create_oscar_nomination(tmdb_id, metadata)
+          Logger.info("Oscar nomination creation result: #{inspect(result)}")
+          result
         else
-          Logger.error("Invalid Oscar metadata: missing ceremony_year or category")
+          Logger.error("Invalid Oscar metadata: missing ceremony_year or category. Metadata: #{inspect(metadata)}")
+          {:error, :invalid_metadata}
         end
       
       # Canonical import - mark as canonical source  
@@ -209,27 +216,38 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
       
       true ->
         # No special post-processing needed
+        Logger.debug("No post-processing needed for TMDb ID #{tmdb_id}, source: #{args["source"]}")
         :ok
     end
-    
-    :ok
   end
   
   defp create_oscar_nomination(tmdb_id, metadata) do
+    Logger.info("Creating Oscar nomination for TMDb ID #{tmdb_id} with metadata: #{inspect(metadata)}")
+    
     # Find the movie by TMDb ID
     case Repo.get_by(Movies.Movie, tmdb_id: tmdb_id) do
       nil ->
         Logger.error("Movie with TMDb ID #{tmdb_id} not found for Oscar nomination")
+        {:error, :movie_not_found}
         
       movie ->
+        Logger.info("Found movie: #{movie.title} (ID: #{movie.id})")
+        
         # Find the ceremony and category
         ceremony_year = metadata["ceremony_year"]
         category_name = metadata["category"]
         
+        Logger.info("Looking up ceremony year #{ceremony_year} and category '#{category_name}'")
+        
         ceremony = Repo.get_by(Cinegraph.Cultural.OscarCeremony, year: ceremony_year)
         category = Repo.get_by(Cinegraph.Cultural.OscarCategory, name: category_name)
         
+        Logger.info("Ceremony lookup result: #{inspect(ceremony)}")
+        Logger.info("Category lookup result: #{inspect(category)}")
+        
         if ceremony && category do
+          Logger.info("Both ceremony and category found, creating nomination...")
+          
           # Use insert with on_conflict option for idempotent operation
           attrs = %{
             ceremony_id: ceremony.id,
@@ -242,6 +260,8 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
               "person_imdb_ids" => []
             }
           }
+          
+          Logger.info("Nomination attributes: #{inspect(attrs)}")
 
           %Cinegraph.Cultural.OscarNomination{}
           |> Cinegraph.Cultural.OscarNomination.changeset(attrs)
@@ -250,13 +270,19 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
             conflict_target: [:ceremony_id, :category_id, :movie_id]
           )
           |> case do
-            {:ok, _} ->
-              Logger.info("Created Oscar nomination for #{movie.title} in #{category_name}")
+            {:ok, nomination} ->
+              Logger.info("Successfully created Oscar nomination for #{movie.title} in #{category_name} (ID: #{nomination.id})")
+              {:ok, nomination}
             {:error, changeset} ->
               Logger.error("Failed to create Oscar nomination: #{inspect(changeset.errors)}")
+              {:error, changeset}
           end
         else
-          Logger.error("Ceremony (#{ceremony_year}) or category (#{category_name}) not found")
+          ceremony_status = if ceremony, do: "found (ID: #{ceremony.id})", else: "NOT FOUND"
+          category_status = if category, do: "found (ID: #{category.id})", else: "NOT FOUND"
+          
+          Logger.error("Lookup failed - Ceremony (#{ceremony_year}): #{ceremony_status}, Category (#{category_name}): #{category_status}")
+          {:error, :lookup_failed}
         end
     end
   end

--- a/lib/cinegraph_web/live/import_dashboard_live.html.heex
+++ b/lib/cinegraph_web/live/import_dashboard_live.html.heex
@@ -188,6 +188,19 @@
         </div>
       </div>
     <% end %>
+    
+    <!-- Academy Awards Statistics -->
+    <div class="mt-6 p-4 bg-gray-50 rounded">
+      <h3 class="text-lg font-medium text-gray-900 mb-3">Academy Awards Statistics</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <%= for oscar_stat <- @oscar_stats do %>
+          <div class="flex justify-between items-center">
+            <span class="text-sm text-gray-600"><%= oscar_stat.label %></span>
+            <span class="text-sm font-semibold text-gray-900"><%= oscar_stat.value %></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <!-- Database Stats -->


### PR DESCRIPTION
### TL;DR

Added Cannes Film Festival winners to canonical lists and improved Oscar award tracking with dynamic category creation and enhanced logging.

### What changed?

- Added Cannes Film Festival Award Winners (1939-2023) to the canonical lists with metadata about included awards
- Enhanced the Oscar discovery worker with dynamic category creation functionality
  - Added helper functions to classify categories by type, importance, and whether they track people
  - Improved person handling logic to defer creation until TMDb data is available
- Added detailed logging throughout the TMDb details worker's Oscar nomination creation process
  - Improved error handling with specific error returns
  - Enhanced logging for better debugging of nomination creation issues
- Updated the Import Dashboard to display Oscar statistics
  - Added a new section showing ceremony counts, nominations, wins, and categories
  - Included year-by-year breakdown of Oscar wins

### How to test?

1. Run an import of the new Cannes winners list to verify it's properly recognized
2. Test the Oscar discovery worker with new categories to ensure they're automatically created
3. Check the Import Dashboard to verify the new Oscar statistics section displays correctly
4. Review logs during Oscar nomination creation to confirm enhanced logging is working

### Why make this change?

This change expands the application's film award coverage beyond just Oscars to include Cannes Film Festival, one of the most prestigious film festivals globally. The dynamic category creation for Oscars makes the system more flexible when encountering new or renamed award categories. Enhanced logging improves troubleshooting capabilities for the Oscar nomination creation process, which was previously difficult to debug. The new dashboard statistics provide better visibility into the Oscar data that has been imported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Academy Awards Statistics" section to the import dashboard, displaying aggregated Oscar ceremony, nomination, and win data.
  * Introduced a new canonical list for Cannes Film Festival Award Winners (1939–2023).

* **Improvements**
  * Enhanced error handling and logging for Oscar nomination imports, providing clearer status and traceability.
  * Improved Oscar category processing to dynamically create categories as needed and defer person creation until more data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->