### PR TITLE
fix stats

### DIFF
--- a/lib/cinegraph/workers/tmdb_details_worker.ex
+++ b/lib/cinegraph/workers/tmdb_details_worker.ex
@@ -206,13 +206,17 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
         end
       
       # Canonical import - mark as canonical source  
-      args["source"] == "canonical_import" && args["canonical_source"] ->
-        canonical_source = args["canonical_source"]
-        source_key = canonical_source["source_key"]
-        metadata = canonical_source["metadata"]
+      args["source"] == "canonical_import" && args["canonical_sources"] ->
+        # canonical_sources is a map with source_key => canonical_data
+        canonical_sources = args["canonical_sources"]
         
-        Logger.info("Marking movie with TMDb ID #{tmdb_id} as canonical in #{source_key}")
-        mark_movie_canonical(tmdb_id, source_key, metadata)
+        # Process each canonical source (usually just one)
+        Enum.each(canonical_sources, fn {source_key, canonical_data} ->
+          Logger.info("Marking movie with TMDb ID #{tmdb_id} as canonical in #{source_key}")
+          mark_movie_canonical(tmdb_id, source_key, canonical_data)
+        end)
+        
+        :ok
       
       true ->
         # No special post-processing needed

--- a/lib/cinegraph_web/live/import_dashboard_live.ex
+++ b/lib/cinegraph_web/live/import_dashboard_live.ex
@@ -347,10 +347,10 @@ defmodule CinegraphWeb.ImportDashboardLive do
     # Get all canonical lists and their counts
     CanonicalLists.all()
     |> Enum.map(fn {list_key, config} ->
-      count = Repo.one(
-        from m in Movie,
-        where: fragment("? \\? ?", m.canonical_sources, ^list_key),
-        select: count(m.id)
+      # Use raw SQL to avoid Ecto escaping issues with the ? operator
+      {:ok, %{rows: [[count]]}} = Repo.query(
+        "SELECT COUNT(*) FROM movies WHERE canonical_sources ? $1",
+        [list_key]
       )
       
       %{


### PR DESCRIPTION
### TL;DR

Updated canonical source handling in TMDb details worker to support multiple sources and fixed a PostgreSQL query issue in the import dashboard.

### What changed?

- Modified `TMDbDetailsWorker` to handle multiple canonical sources through a map structure instead of a single source
- Changed the parameter from `canonical_source` to `canonical_sources` which is now a map with `source_key => canonical_data`
- Added iteration over each canonical source to process them individually
- Fixed a PostgreSQL query in `ImportDashboardLive` by replacing the Ecto query with raw SQL to avoid escaping issues with the PostgreSQL `?` operator

### How to test?

1. Import a movie and mark it as canonical in multiple sources
2. Verify that all canonical sources are properly processed
3. Check the import dashboard to confirm canonical list counts are displayed correctly

### Why make this change?

The previous implementation only supported a single canonical source per import operation. This change allows for marking a movie as canonical in multiple sources simultaneously, improving flexibility. Additionally, the dashboard query was fixed to properly count movies in canonical lists, as the Ecto query was having issues with the PostgreSQL containment operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for handling multiple canonical sources for movies, allowing batch processing and improved tracking.

* **Bug Fixes**
  * Improved reliability of movie count retrieval for canonical lists, addressing issues with database queries to ensure accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->