### PR TITLE
fixes

### DIFF
--- a/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
+++ b/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
@@ -550,10 +550,17 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
       
       Logger.info("Found #{length(list_items)} potential movie items")
       
+      # Calculate base position based on page number
+      # Page 1: positions 1-250, Page 2: positions 251-500, etc.
+      base_position = (page - 1) * 250
+      
       movies = 
         list_items
         |> Enum.with_index(1)
-        |> Enum.map(fn {item, position} -> parse_movie_from_list_item(item, position) end)
+        |> Enum.map(fn {item, index} -> 
+          position = base_position + index
+          parse_movie_from_list_item(item, position) 
+        end)
         |> Enum.reject(&is_nil/1)
         |> Enum.uniq_by(& &1.imdb_id)  # Remove duplicates
       

--- a/lib/cinegraph/workers/canonical_import_orchestrator.ex
+++ b/lib/cinegraph/workers/canonical_import_orchestrator.ex
@@ -6,7 +6,12 @@ defmodule Cinegraph.Workers.CanonicalImportOrchestrator do
   
   use Oban.Worker, 
     queue: :imdb_scraping,
-    max_attempts: 3
+    max_attempts: 3,
+    unique: [
+      keys: [:list_key],
+      period: 300,  # 5 minutes
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
   
   alias Cinegraph.Workers.CanonicalPageWorker
   alias Cinegraph.Scrapers.ImdbCanonicalScraper

--- a/lib/cinegraph/workers/oscar_import_worker.ex
+++ b/lib/cinegraph/workers/oscar_import_worker.ex
@@ -34,6 +34,7 @@ defmodule Cinegraph.Workers.OscarImportWorker do
               year: year,
               job_id: result.job_id,
               ceremony_id: result.ceremony_id,
+              jobs_queued: 1,
               status: "Queued Oscar discovery job for #{year}"
             })
             
@@ -89,6 +90,7 @@ defmodule Cinegraph.Workers.OscarImportWorker do
               year: year,
               job_id: result.job_id,
               ceremony_id: result.ceremony_id,
+              jobs_queued: 1,
               status: "Queued Oscar discovery job for #{year}"
             })
             

--- a/lib/cinegraph_web/live/import_dashboard_live.html.heex
+++ b/lib/cinegraph_web/live/import_dashboard_live.html.heex
@@ -116,6 +116,8 @@
         <select name="list_key" required
                 class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500">
           <option value="">Select a list...</option>
+          <option value="all" class="font-semibold">Import All Lists</option>
+          <option value="" disabled>──────────────</option>
           <%= for {key, config} <- @canonical_lists do %>
             <option value={key}><%= config.name %></option>
           <% end %>

--- a/scripts/cleanup_canonical_duplicates.exs
+++ b/scripts/cleanup_canonical_duplicates.exs
@@ -1,0 +1,91 @@
+#!/usr/bin/env elixir
+# Script to clean up duplicate canonical entries
+
+alias Cinegraph.Repo
+alias Cinegraph.Movies.Movie
+import Ecto.Query
+
+IO.puts("=== Cleaning Up Canonical Duplicates ===\n")
+
+# For each canonical source, find and fix duplicates
+canonical_sources = ["1001_movies", "criterion", "national_film_registry", "cannes_winners", "sight_sound_critics_2022"]
+
+Enum.each(canonical_sources, fn source_key ->
+  IO.puts("\nProcessing #{source_key}...")
+  
+  # Find all positions that have duplicates
+  duplicate_positions_query = """
+  SELECT 
+    canonical_sources->'#{source_key}'->>'list_position' as position,
+    COUNT(*) as count,
+    array_agg(id) as movie_ids
+  FROM movies 
+  WHERE canonical_sources ? '#{source_key}'
+  GROUP BY canonical_sources->'#{source_key}'->>'list_position'
+  HAVING COUNT(*) > 1
+  ORDER BY (canonical_sources->'#{source_key}'->>'list_position')::int
+  """
+  
+  case Repo.query(duplicate_positions_query) do
+    {:ok, %{rows: rows}} when length(rows) > 0 ->
+      IO.puts("Found #{length(rows)} positions with duplicates")
+      
+      Enum.each(rows, fn [position, count, movie_ids] ->
+        IO.puts("\n  Position #{position}: #{count} duplicates")
+        
+        # Get the movies
+        movies = Repo.all(from m in Movie, where: m.id in ^movie_ids)
+        
+        # Sort by various criteria to pick the best one
+        # Prefer: has more data, was created first, has higher vote count
+        sorted_movies = movies
+        |> Enum.sort_by(fn movie ->
+          {
+            # Prefer movies with more complete data
+            -(if movie.runtime, do: 1, else: 0),
+            -(if movie.budget && movie.budget > 0, do: 1, else: 0),
+            -(movie.vote_count || 0),
+            # Earlier creation date
+            movie.inserted_at
+          }
+        end)
+        
+        [keep_movie | remove_movies] = sorted_movies
+        
+        IO.puts("  Keeping: #{keep_movie.title} (ID: #{keep_movie.id}, votes: #{keep_movie.vote_count})")
+        
+        # Remove the canonical source from the duplicate movies
+        Enum.each(remove_movies, fn movie ->
+          IO.puts("  Removing from: #{movie.title} (ID: #{movie.id})")
+          
+          updated_sources = Map.delete(movie.canonical_sources || %{}, source_key)
+          
+          movie
+          |> Movie.changeset(%{canonical_sources: updated_sources})
+          |> Repo.update!()
+        end)
+      end)
+      
+      IO.puts("\nCleaned up #{length(rows)} duplicate positions for #{source_key}")
+      
+    {:ok, %{rows: []}} ->
+      IO.puts("No duplicates found for #{source_key}")
+      
+    {:error, error} ->
+      IO.puts("Error checking duplicates for #{source_key}: #{inspect(error)}")
+  end
+end)
+
+# Final statistics
+IO.puts("\n\n=== Final Statistics ===")
+
+Enum.each(canonical_sources, fn source_key ->
+  {:ok, %{rows: [[count]]}} = Repo.query(
+    "SELECT COUNT(*) FROM movies WHERE canonical_sources ? $1",
+    [source_key]
+  )
+  
+  IO.puts("#{source_key}: #{count} movies")
+end)
+
+IO.puts("\nCleanup complete!")


### PR DESCRIPTION
### TL;DR

Added Oban job metadata tracking for better monitoring of import processes and fixed canonical list position calculation.

### What changed?

- Added a new `OBAN_METADATA_AUDIT.md` document that audits which workers track metadata and which don't
- Added metadata tracking to `OscarDiscoveryWorker` to record ceremony details and processing statistics
- Enhanced `CanonicalPageWorker` to save comprehensive metadata about processed pages
- Fixed position calculation in `ImdbCanonicalScraper` to properly handle pagination (positions now correctly increment across pages)
- Added uniqueness constraints to prevent duplicate job processing in `CanonicalImportOrchestrator` and `CanonicalPageWorker`
- Improved `OMDb.Transformer` to handle race conditions when creating the OMDb source
- Added "Import All Lists" option to the import dashboard
- Created a script to clean up duplicate canonical entries (`cleanup_canonical_duplicates.exs`)
- Enhanced movie update logic to avoid unnecessary updates when canonical data hasn't changed

### How to test?

1. Run a canonical import and check the Oban job metadata in the database:
```sql
SELECT args->>'page' as page, meta FROM oban_jobs 
WHERE worker = 'Cinegraph.Workers.CanonicalPageWorker' 
ORDER BY CAST(args->>'page' AS INTEGER);
```

2. Run an Oscar import and verify metadata is being saved:
```sql
SELECT args->>'ceremony_id' as ceremony_id, meta FROM oban_jobs 
WHERE worker = 'Cinegraph.Workers.OscarDiscoveryWorker';
```

3. Test the "Import All Lists" option on the import dashboard

### Why make this change?

Tracking metadata in Oban jobs provides better visibility into import processes, making it easier to monitor progress and diagnose issues. The position calculation fix ensures movies are assigned the correct positions in canonical lists across multiple pages. The uniqueness constraints prevent duplicate processing, improving efficiency and data consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to import all canonical movie lists at once from the dashboard.
  * Enhanced the dropdown menu with an "Import All Lists" option for bulk actions.
  * Introduced a script to clean up duplicate canonical movie entries for improved data quality.

* **Improvements**
  * Job progress and summary metadata are now stored and updated for import and discovery tasks, providing more detailed tracking.
  * Enhanced uniqueness constraints for background jobs to prevent duplicate processing.
  * Improved handling and logging of movie source updates during imports.
  * Increased robustness in concurrent source creation to avoid errors.

* **Bug Fixes**
  * Ensured consistent movie position indexing across paginated IMDb list imports.
  * Fixed handling of canonical source data structures in TMDb detail imports.

* **Chores**
  * Added a maintenance script for database cleanup of duplicate canonical sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->