### PR TITLE
fix lists

### DIFF
--- a/CANONICAL_IMPORT_FIX_SUMMARY.md
+++ b/CANONICAL_IMPORT_FIX_SUMMARY.md
@@ -1,0 +1,44 @@
+# Canonical Import Fix Summary
+
+## Problem
+Movies appearing in multiple canonical lists were only getting tagged with ONE list because:
+- Oban's unique constraint prevented multiple jobs for the same movie
+- Each list tried to create a separate job, but only the first succeeded
+
+## Solution Implemented
+
+### 1. Updated TMDbDetailsWorker Unique Constraint
+Changed from:
+```elixir
+unique: [fields: [:args], keys: [:tmdb_id, :imdb_id], period: 300]
+```
+
+To:
+```elixir
+unique: [fields: [:args], keys: [:tmdb_id, :imdb_id, :source_key], period: 300]
+```
+
+This allows one job per movie per canonical list.
+
+### 2. Updated CanonicalPageWorker
+- Removed direct movie updates when movie exists
+- Now always creates a TMDbDetailsWorker job (for both new and existing movies)
+- Added `source_key` to job args for the unique constraint
+- This ensures all canonical sources go through the same update path
+
+### 3. Preserved mark_movie_canonical Logic
+- Already uses `Map.put` which replaces the value for a specific key
+- When re-running imports, it will replace the data for that list only
+- Other canonical sources remain untouched
+
+## How It Works Now
+
+1. **First Import**: List A imports movie → creates job with source_key "list_a" → movie gets `{"list_a": {...}}`
+2. **Second Import**: List B imports same movie → creates job with source_key "list_b" → movie gets `{"list_a": {...}, "list_b": {...}}`
+3. **Re-run Import**: List A imports again → creates job with source_key "list_a" → replaces only "list_a" data
+
+## Benefits
+- Movies can belong to multiple canonical lists
+- Re-running imports updates only that list's data
+- No more silent job drops
+- Consistent handling for new and existing movies

--- a/lib/cinegraph/workers/tmdb_details_worker.ex
+++ b/lib/cinegraph/workers/tmdb_details_worker.ex
@@ -6,7 +6,7 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
   use Oban.Worker, 
     queue: :tmdb_details,
     max_attempts: 5,
-    unique: [fields: [:args], keys: [:tmdb_id, :imdb_id], period: 300]
+    unique: [fields: [:args], keys: [:tmdb_id, :imdb_id, :source_key], period: 300]
     
   alias Cinegraph.{Repo, Movies}
   alias Cinegraph.Workers.{OMDbEnrichmentWorker, CollaborationWorker}


### PR DESCRIPTION
### TL;DR

Fixed an issue where movies appearing in multiple canonical lists were only getting tagged with one list.

### What changed?

- Updated `TMDbDetailsWorker` unique constraint to include `source_key` alongside `tmdb_id` and `imdb_id`
- Modified `CanonicalPageWorker` to always create a `TMDbDetailsWorker` job for both new and existing movies
- Added `source_key` to job args to ensure the unique constraint works properly
- Removed direct movie updates in `CanonicalPageWorker` to ensure consistent processing path

### How to test?

1. Import a movie that appears in multiple canonical lists (e.g., appears in both "Top 250" and "Oscar Winners")
2. Verify the movie is tagged with both lists in its `canonical_sources` field
3. Re-run an import for one list and confirm it only updates that list's data without affecting other lists

### Why make this change?

Previously, Oban's unique constraint prevented multiple jobs for the same movie, causing only the first canonical list to be recorded. This change allows one job per movie per canonical list, ensuring movies can properly belong to multiple canonical lists while maintaining data integrity when re-running imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where movies appearing in multiple canonical lists were only tagged with one list. Now, movies can be correctly associated with all relevant canonical lists.

* **Refactor**
  * Updated job handling to ensure all updates for canonical sources are processed through a unified workflow, improving reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->