### PR TITLE
small

### DIFF
--- a/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
+++ b/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
@@ -1498,9 +1498,8 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
     job_args = %{
       "imdb_id" => movie_data.imdb_id,
       "source" => "canonical_import",
-      "canonical_source" => %{
-        "source_key" => source_key,
-        "metadata" => metadata
+      "canonical_sources" => %{
+        source_key => metadata
       }
     }
     

--- a/lib/cinegraph/workers/canonical_import_orchestrator.ex
+++ b/lib/cinegraph/workers/canonical_import_orchestrator.ex
@@ -63,6 +63,7 @@ defmodule Cinegraph.Workers.CanonicalImportOrchestrator do
       broadcast_progress(list_key, :orchestrating, %{
         list_name: list_config.name,
         total_pages: total_pages,
+        expected_count: expected_count,
         status: "Queueing page jobs..."
       })
       
@@ -90,6 +91,8 @@ defmodule Cinegraph.Workers.CanonicalImportOrchestrator do
         broadcast_progress(list_key, :queued, %{
           list_name: list_config.name,
           pages_queued: length(jobs_list),
+          total_pages: total_pages,
+          expected_count: expected_count,
           status: "#{length(jobs_list)} page jobs queued"
         })
         


### PR DESCRIPTION
### TL;DR

Improved canonical import progress tracking and messaging in the import dashboard.

### What changed?

- Modified the data structure in `imdb_canonical_scraper.ex` to use a map of source keys to metadata instead of a nested structure
- Enhanced the `canonical_import_orchestrator.ex` to include additional progress information (expected count and total pages) in broadcast messages
- Updated the import dashboard to display more accurate and detailed progress messages:
  - Added conditional logic to show different completion messages based on available data
  - Improved progress status formatting to show more detailed information about queued jobs and expected counts

### How to test?

1. Run a canonical import from the import dashboard
2. Observe the progress messages during the import process
3. Verify that the completion message shows accurate information about the number of movies imported vs. expected

### Why make this change?

This change provides users with more detailed and accurate information about the progress of canonical imports. By including expected counts and more detailed status messages, users can better understand the scope and progress of import operations, making the system more transparent and user-friendly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress messages during canonical imports now display more detailed information, including the number of movies imported out of the expected total, and clearer status updates for queued pages and named lists.

* **Enhancements**
  * Progress updates now include the expected movie count, providing more informative feedback during import operations.
  * Improved clarity and specificity in progress and completion messages shown on the import dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->