### PR TITLE
small

### DIFF
--- a/lib/cinegraph_web/live/import_dashboard_live.ex
+++ b/lib/cinegraph_web/live/import_dashboard_live.ex
@@ -399,8 +399,15 @@ defmodule CinegraphWeb.ImportDashboardLive do
       ) do
     # Special handling for Academy Awards/Oscars - use the Oscar-specific scraper
     if festival == "oscars" do
-      # Route to Oscar import handler
-      handle_event("import_oscars", %{"year_range" => year_range}, socket)
+      # Validate Oscar configuration exists for consistency
+      case Events.get_active_by_source_key("oscars") do
+        nil ->
+          socket = put_flash(socket, :error, "Oscar configuration not found in database")
+          {:noreply, socket}
+        _event ->
+          # Route to Oscar import handler
+          handle_event("import_oscars", %{"year_range" => year_range}, socket)
+      end
     else
       # Validate festival exists in database before proceeding
       festival_event = Events.get_active_by_source_key(festival)


### PR DESCRIPTION
### TL;DR

Added validation to check if Oscar configuration exists before proceeding with Oscar imports.

### What changed?

Enhanced the festival import handler to validate that an Oscar configuration exists in the database before attempting to import Oscar data. If the configuration is not found, the system now displays an error flash message instead of proceeding with the import.

### How to test?

1. Navigate to the import dashboard
2. Try to import Oscar data when:
   - Oscar configuration exists in the database (should proceed normally)
   - Oscar configuration is missing (should show an error message)

### Why make this change?

This change prevents potential errors that could occur when trying to import Oscar data without having the necessary configuration in place. It improves error handling and provides clearer feedback to users when the required configuration is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling to prevent importing Oscars festival data when the required configuration is missing, with a clear error message displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->