### PR TITLE
new dropdowns

### DIFF
--- a/lib/cinegraph/movies/discovery_scoring.ex
+++ b/lib/cinegraph/movies/discovery_scoring.ex
@@ -1,0 +1,396 @@
+defmodule Cinegraph.Movies.DiscoveryScoring do
+  @moduledoc """
+  Tunable Movie Discovery System
+  
+  Allows users to adjust how different scoring criteria are weighted 
+  in their movie search and browsing experience.
+  
+  Scoring Dimensions:
+  - Popular Opinion (TMDb/IMDb ratings and votes)
+  - Critical Acclaim (Metacritic, Rotten Tomatoes)
+  - Industry Recognition (Festival awards, Oscar nominations)
+  - Cultural Impact (Canonical lists, popularity metrics)
+  """
+
+  import Ecto.Query, warn: false
+  alias Cinegraph.Repo
+  alias Cinegraph.Movies.Movie
+
+  @default_weights %{
+    popular_opinion: 0.25,
+    critical_acclaim: 0.25,
+    industry_recognition: 0.25,
+    cultural_impact: 0.25
+  }
+
+  @doc """
+  Applies discovery scoring to a movie query with user-defined weights.
+  
+  ## Parameters
+    - query: Base Ecto query for movies
+    - weights: Map of scoring dimension weights (0.0 to 1.0)
+    - options: Additional options like min_score threshold
+  
+  ## Example
+      iex> weights = %{popular_opinion: 0.4, critical_acclaim: 0.3, industry_recognition: 0.2, cultural_impact: 0.1}
+      iex> DiscoveryScoring.apply_scoring(Movie, weights)
+  """
+  def apply_scoring(query, weights \\ @default_weights, options \\ %{}) do
+    normalized_weights = normalize_weights(weights)
+    min_score = Map.get(options, :min_score, 0.0)
+    
+    query
+    |> add_scoring_subqueries(normalized_weights)
+    |> filter_by_min_score(min_score)
+    |> order_by_discovery_score()
+  end
+
+  @doc """
+  Calculates individual scoring components for a movie.
+  Useful for displaying score breakdown in UI.
+  """
+  def calculate_movie_scores(movie_id) do
+    movie = Repo.get!(Movie, movie_id)
+    
+    %{
+      popular_opinion: calculate_popular_opinion(movie_id),
+      critical_acclaim: calculate_critical_acclaim(movie_id),
+      industry_recognition: calculate_industry_recognition(movie_id),
+      cultural_impact: calculate_cultural_impact(movie_id)
+    }
+  end
+
+  @doc """
+  Returns scoring presets for common use cases.
+  """
+  def get_presets do
+    %{
+      balanced: @default_weights,
+      crowd_pleaser: %{
+        popular_opinion: 0.5,
+        critical_acclaim: 0.15,
+        industry_recognition: 0.15,
+        cultural_impact: 0.2
+      },
+      critics_choice: %{
+        popular_opinion: 0.15,
+        critical_acclaim: 0.5,
+        industry_recognition: 0.25,
+        cultural_impact: 0.1
+      },
+      award_winner: %{
+        popular_opinion: 0.1,
+        critical_acclaim: 0.2,
+        industry_recognition: 0.6,
+        cultural_impact: 0.1
+      },
+      cult_classic: %{
+        popular_opinion: 0.2,
+        critical_acclaim: 0.1,
+        industry_recognition: 0.1,
+        cultural_impact: 0.6
+      }
+    }
+  end
+
+  # Private functions
+
+  defp normalize_weights(weights) do
+    weights = Map.merge(@default_weights, weights)
+    total = Enum.sum(Map.values(weights))
+    
+    if total == 0 do
+      @default_weights
+    else
+      Map.new(weights, fn {k, v} -> {k, v / total} end)
+    end
+  end
+
+  defp add_scoring_subqueries(query, weights) do
+    from(m in query,
+      left_lateral_join: scores in fragment("""
+        SELECT 
+          -- Popular Opinion Score (TMDb + IMDb ratings)
+          COALESCE(
+            (
+              SELECT 
+                (COALESCE(tmdb.value, 0) / 10.0 * 0.5) +
+                (COALESCE(imdb.value, 0) / 10.0 * 0.5)
+              FROM movies m2
+              LEFT JOIN LATERAL (
+                SELECT value FROM external_metrics 
+                WHERE movie_id = m2.id AND source = 'tmdb' AND metric_type = 'rating_average'
+                ORDER BY fetched_at DESC LIMIT 1
+              ) tmdb ON true
+              LEFT JOIN LATERAL (
+                SELECT value FROM external_metrics 
+                WHERE movie_id = m2.id AND source = 'imdb' AND metric_type = 'rating_average'
+                ORDER BY fetched_at DESC LIMIT 1
+              ) imdb ON true
+              WHERE m2.id = ?
+            ), 0
+          ) * ? AS popular_opinion,
+          
+          -- Critical Acclaim Score (Metacritic + Rotten Tomatoes)
+          COALESCE(
+            (
+              SELECT 
+                (COALESCE(mc.value, 0) / 100.0 * 0.5) +
+                (COALESCE(rt.value, 0) / 100.0 * 0.5)
+              FROM movies m2
+              LEFT JOIN LATERAL (
+                SELECT value FROM external_metrics 
+                WHERE movie_id = m2.id AND source = 'metacritic' AND metric_type = 'metascore'
+                ORDER BY fetched_at DESC LIMIT 1
+              ) mc ON true
+              LEFT JOIN LATERAL (
+                SELECT value FROM external_metrics 
+                WHERE movie_id = m2.id AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer'
+                ORDER BY fetched_at DESC LIMIT 1
+              ) rt ON true
+              WHERE m2.id = ?
+            ), 0
+          ) * ? AS critical_acclaim,
+          
+          -- Industry Recognition Score (Festival awards + nominations)
+          COALESCE(
+            (
+              SELECT 
+                LEAST(1.0, 
+                  (COUNT(CASE WHEN fn.won = true THEN 1 END) * 0.2) +
+                  (COUNT(fn.id) * 0.05)
+                )
+              FROM festival_nominations fn
+              WHERE fn.movie_id = ?
+            ), 0
+          ) * ? AS industry_recognition,
+          
+          -- Cultural Impact Score (Canonical lists + popularity)
+          COALESCE(
+            (
+              SELECT 
+                LEAST(1.0,
+                  -- Canonical lists presence
+                  (CASE 
+                    WHEN m2.canonical_sources IS NOT NULL AND m2.canonical_sources != '{}' 
+                    THEN jsonb_array_length(jsonb_object_keys(m2.canonical_sources)::jsonb) * 0.1
+                    ELSE 0
+                  END) +
+                  -- Popularity score normalized
+                  (COALESCE(pop.value, 0) / 1000.0)
+                )
+              FROM movies m2
+              LEFT JOIN LATERAL (
+                SELECT value FROM external_metrics 
+                WHERE movie_id = m2.id AND source = 'tmdb' AND metric_type = 'popularity_score'
+                ORDER BY fetched_at DESC LIMIT 1
+              ) pop ON true
+              WHERE m2.id = ?
+            ), 0
+          ) * ? AS cultural_impact,
+          
+          -- Total weighted score
+          (
+            COALESCE(
+              (
+                SELECT 
+                  (COALESCE(tmdb.value, 0) / 10.0 * 0.5) +
+                  (COALESCE(imdb.value, 0) / 10.0 * 0.5)
+                FROM movies m2
+                LEFT JOIN LATERAL (
+                  SELECT value FROM external_metrics 
+                  WHERE movie_id = m2.id AND source = 'tmdb' AND metric_type = 'rating_average'
+                  ORDER BY fetched_at DESC LIMIT 1
+                ) tmdb ON true
+                LEFT JOIN LATERAL (
+                  SELECT value FROM external_metrics 
+                  WHERE movie_id = m2.id AND source = 'imdb' AND metric_type = 'rating_average'
+                  ORDER BY fetched_at DESC LIMIT 1
+                ) imdb ON true
+                WHERE m2.id = ?
+              ), 0
+            ) * ?
+          ) +
+          (
+            COALESCE(
+              (
+                SELECT 
+                  (COALESCE(mc.value, 0) / 100.0 * 0.5) +
+                  (COALESCE(rt.value, 0) / 100.0 * 0.5)
+                FROM movies m2
+                LEFT JOIN LATERAL (
+                  SELECT value FROM external_metrics 
+                  WHERE movie_id = m2.id AND source = 'metacritic' AND metric_type = 'metascore'
+                  ORDER BY fetched_at DESC LIMIT 1
+                ) mc ON true
+                LEFT JOIN LATERAL (
+                  SELECT value FROM external_metrics 
+                  WHERE movie_id = m2.id AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer'
+                  ORDER BY fetched_at DESC LIMIT 1
+                ) rt ON true
+                WHERE m2.id = ?
+              ), 0
+            ) * ?
+          ) +
+          (
+            COALESCE(
+              (
+                SELECT 
+                  LEAST(1.0, 
+                    (COUNT(CASE WHEN fn.won = true THEN 1 END) * 0.2) +
+                    (COUNT(fn.id) * 0.05)
+                  )
+                FROM festival_nominations fn
+                WHERE fn.movie_id = ?
+              ), 0
+            ) * ?
+          ) +
+          (
+            COALESCE(
+              (
+                SELECT 
+                  LEAST(1.0,
+                    (CASE 
+                      WHEN m2.canonical_sources IS NOT NULL AND m2.canonical_sources != '{}' 
+                      THEN jsonb_array_length(jsonb_object_keys(m2.canonical_sources)::jsonb) * 0.1
+                      ELSE 0
+                    END) +
+                    (COALESCE(pop.value, 0) / 1000.0)
+                  )
+                FROM movies m2
+                LEFT JOIN LATERAL (
+                  SELECT value FROM external_metrics 
+                  WHERE movie_id = m2.id AND source = 'tmdb' AND metric_type = 'popularity_score'
+                  ORDER BY fetched_at DESC LIMIT 1
+                ) pop ON true
+                WHERE m2.id = ?
+              ), 0
+            ) * ?
+          ) AS total_score
+      """, m.id, ^weights.popular_opinion, 
+           m.id, ^weights.critical_acclaim,
+           m.id, ^weights.industry_recognition,
+           m.id, ^weights.cultural_impact,
+           m.id, ^weights.popular_opinion,
+           m.id, ^weights.critical_acclaim,
+           m.id, ^weights.industry_recognition,
+           m.id, ^weights.cultural_impact),
+      on: true,
+      select_merge: %{
+        discovery_score: scores.total_score,
+        score_components: %{
+          popular_opinion: scores.popular_opinion,
+          critical_acclaim: scores.critical_acclaim,
+          industry_recognition: scores.industry_recognition,
+          cultural_impact: scores.cultural_impact
+        }
+      }
+    )
+  end
+
+  defp filter_by_min_score(query, 0.0), do: query
+  defp filter_by_min_score(query, min_score) do
+    from([m, scores] in query,
+      where: scores.total_score >= ^min_score
+    )
+  end
+
+  defp order_by_discovery_score(query) do
+    from([m, scores] in query,
+      order_by: [desc: scores.total_score]
+    )
+  end
+
+  defp calculate_popular_opinion(movie_id) do
+    query = """
+    SELECT 
+      (COALESCE(tmdb.value, 0) / 10.0 * 0.5) +
+      (COALESCE(imdb.value, 0) / 10.0 * 0.5) as score
+    FROM movies m
+    LEFT JOIN LATERAL (
+      SELECT value FROM external_metrics 
+      WHERE movie_id = m.id AND source = 'tmdb' AND metric_type = 'rating_average'
+      ORDER BY fetched_at DESC LIMIT 1
+    ) tmdb ON true
+    LEFT JOIN LATERAL (
+      SELECT value FROM external_metrics 
+      WHERE movie_id = m.id AND source = 'imdb' AND metric_type = 'rating_average'
+      ORDER BY fetched_at DESC LIMIT 1
+    ) imdb ON true
+    WHERE m.id = $1
+    """
+    
+    case Repo.query(query, [movie_id]) do
+      {:ok, %{rows: [[score]]}} when not is_nil(score) -> score
+      _ -> 0.0
+    end
+  end
+
+  defp calculate_critical_acclaim(movie_id) do
+    query = """
+    SELECT 
+      (COALESCE(mc.value, 0) / 100.0 * 0.5) +
+      (COALESCE(rt.value, 0) / 100.0 * 0.5) as score
+    FROM movies m
+    LEFT JOIN LATERAL (
+      SELECT value FROM external_metrics 
+      WHERE movie_id = m.id AND source = 'metacritic' AND metric_type = 'metascore'
+      ORDER BY fetched_at DESC LIMIT 1
+    ) mc ON true
+    LEFT JOIN LATERAL (
+      SELECT value FROM external_metrics 
+      WHERE movie_id = m.id AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer'
+      ORDER BY fetched_at DESC LIMIT 1
+    ) rt ON true
+    WHERE m.id = $1
+    """
+    
+    case Repo.query(query, [movie_id]) do
+      {:ok, %{rows: [[score]]}} when not is_nil(score) -> score
+      _ -> 0.0
+    end
+  end
+
+  defp calculate_industry_recognition(movie_id) do
+    query = """
+    SELECT 
+      LEAST(1.0, 
+        (COUNT(CASE WHEN fn.won = true THEN 1 END) * 0.2) +
+        (COUNT(fn.id) * 0.05)
+      ) as score
+    FROM festival_nominations fn
+    WHERE fn.movie_id = $1
+    """
+    
+    case Repo.query(query, [movie_id]) do
+      {:ok, %{rows: [[score]]}} when not is_nil(score) -> score
+      _ -> 0.0
+    end
+  end
+
+  defp calculate_cultural_impact(movie_id) do
+    query = """
+    SELECT 
+      LEAST(1.0,
+        (CASE 
+          WHEN m.canonical_sources IS NOT NULL AND m.canonical_sources != '{}' 
+          THEN jsonb_array_length(jsonb_object_keys(m.canonical_sources)::jsonb) * 0.1
+          ELSE 0
+        END) +
+        (COALESCE(pop.value, 0) / 1000.0)
+      ) as score
+    FROM movies m
+    LEFT JOIN LATERAL (
+      SELECT value FROM external_metrics 
+      WHERE movie_id = m.id AND source = 'tmdb' AND metric_type = 'popularity_score'
+      ORDER BY fetched_at DESC LIMIT 1
+    ) pop ON true
+    WHERE m.id = $1
+    """
+    
+    case Repo.query(query, [movie_id]) do
+      {:ok, %{rows: [[score]]}} when not is_nil(score) -> score
+      _ -> 0.0
+    end
+  end
+end

--- a/lib/cinegraph/movies/discovery_scoring_simple.ex
+++ b/lib/cinegraph/movies/discovery_scoring_simple.ex
@@ -1,0 +1,178 @@
+defmodule Cinegraph.Movies.DiscoveryScoringSimple do
+  @moduledoc """
+  Simplified Tunable Movie Discovery System using materialized scores.
+  
+  This version pre-calculates component scores for better performance.
+  """
+
+  import Ecto.Query, warn: false
+  alias Cinegraph.Repo
+  alias Cinegraph.Movies.Movie
+
+  @default_weights %{
+    popular_opinion: 0.25,
+    critical_acclaim: 0.25,
+    industry_recognition: 0.25,
+    cultural_impact: 0.25
+  }
+
+  @doc """
+  Applies discovery scoring to a movie query with user-defined weights.
+  This simplified version uses pre-calculated scores for better performance.
+  """
+  def apply_scoring(query, weights \\ @default_weights, options \\ %{}) do
+    normalized_weights = normalize_weights(weights)
+    min_score = Map.get(options, :min_score, 0.0)
+    
+    query
+    |> join(:left, [m], em_tmdb in "external_metrics", 
+        on: em_tmdb.movie_id == m.id and 
+            em_tmdb.source == "tmdb" and 
+            em_tmdb.metric_type == "rating_average",
+        as: :tmdb_rating)
+    |> join(:left, [m], em_imdb in "external_metrics",
+        on: em_imdb.movie_id == m.id and
+            em_imdb.source == "imdb" and
+            em_imdb.metric_type == "rating_average",
+        as: :imdb_rating)
+    |> join(:left, [m], em_meta in "external_metrics",
+        on: em_meta.movie_id == m.id and
+            em_meta.source == "metacritic" and
+            em_meta.metric_type == "metascore",
+        as: :metacritic)
+    |> join(:left, [m], em_rt in "external_metrics",
+        on: em_rt.movie_id == m.id and
+            em_rt.source == "rotten_tomatoes" and
+            em_rt.metric_type == "tomatometer",
+        as: :rotten_tomatoes)
+    |> join(:left, [m], em_pop in "external_metrics",
+        on: em_pop.movie_id == m.id and
+            em_pop.source == "tmdb" and
+            em_pop.metric_type == "popularity_score",
+        as: :popularity)
+    |> join(:left, [m], f in subquery(festival_nominations_summary()), 
+        on: f.movie_id == m.id,
+        as: :festivals)
+    |> select_merge([m, tmdb_rating: tr, imdb_rating: ir, metacritic: mc, 
+                     rotten_tomatoes: rt, popularity: pop, festivals: f], %{
+      discovery_score: fragment(
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + 
+         ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) +
+         ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
+         ? * COALESCE(LEAST(1.0, 
+           COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+         ^normalized_weights.popular_opinion, tr.value, ir.value,
+         ^normalized_weights.critical_acclaim, mc.value, rt.value,
+         ^normalized_weights.industry_recognition, f.wins, f.nominations,
+         ^normalized_weights.cultural_impact, 
+         m.canonical_sources, pop.value
+      ),
+      score_components: %{
+        popular_opinion: fragment(
+          "COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0)",
+          tr.value, ir.value
+        ),
+        critical_acclaim: fragment(
+          "COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0)",
+          mc.value, rt.value
+        ),
+        industry_recognition: fragment(
+          "COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0)",
+          f.wins, f.nominations
+        ),
+        cultural_impact: fragment(
+          "COALESCE(LEAST(1.0, 
+           COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + 
+           COALESCE(?, 0) / 1000.0), 0)",
+          m.canonical_sources, pop.value
+        )
+      }
+    })
+    |> where([m, tmdb_rating: tr, imdb_rating: ir, metacritic: mc, 
+              rotten_tomatoes: rt, popularity: pop, festivals: f], 
+      fragment(
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + 
+         ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) +
+         ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
+         ? * COALESCE(LEAST(1.0, 
+           COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0) >= ?",
+         ^normalized_weights.popular_opinion, tr.value, ir.value,
+         ^normalized_weights.critical_acclaim, mc.value, rt.value,
+         ^normalized_weights.industry_recognition, f.wins, f.nominations,
+         ^normalized_weights.cultural_impact, 
+         m.canonical_sources, pop.value,
+         ^min_score
+      ))
+    |> order_by([m, tmdb_rating: tr, imdb_rating: ir, metacritic: mc, 
+                 rotten_tomatoes: rt, popularity: pop, festivals: f], 
+      desc: fragment(
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + 
+         ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) +
+         ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
+         ? * COALESCE(LEAST(1.0, 
+           COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+         ^normalized_weights.popular_opinion, tr.value, ir.value,
+         ^normalized_weights.critical_acclaim, mc.value, rt.value,
+         ^normalized_weights.industry_recognition, f.wins, f.nominations,
+         ^normalized_weights.cultural_impact, 
+         m.canonical_sources, pop.value
+      ))
+  end
+
+  @doc """
+  Returns scoring presets for common use cases.
+  """
+  def get_presets do
+    %{
+      balanced: @default_weights,
+      crowd_pleaser: %{
+        popular_opinion: 0.5,
+        critical_acclaim: 0.15,
+        industry_recognition: 0.15,
+        cultural_impact: 0.2
+      },
+      critics_choice: %{
+        popular_opinion: 0.15,
+        critical_acclaim: 0.5,
+        industry_recognition: 0.25,
+        cultural_impact: 0.1
+      },
+      award_winner: %{
+        popular_opinion: 0.1,
+        critical_acclaim: 0.2,
+        industry_recognition: 0.6,
+        cultural_impact: 0.1
+      },
+      cult_classic: %{
+        popular_opinion: 0.2,
+        critical_acclaim: 0.1,
+        industry_recognition: 0.1,
+        cultural_impact: 0.6
+      }
+    }
+  end
+
+  # Private functions
+
+  defp normalize_weights(weights) do
+    weights = Map.merge(@default_weights, weights)
+    total = Enum.sum(Map.values(weights))
+    
+    if total == 0 do
+      @default_weights
+    else
+      Map.new(weights, fn {k, v} -> {k, v / total} end)
+    end
+  end
+
+  defp festival_nominations_summary do
+    from(f in "festival_nominations",
+      group_by: f.movie_id,
+      select: %{
+        movie_id: f.movie_id,
+        wins: count(fragment("CASE WHEN ? = true THEN 1 END", f.won)),
+        nominations: count(f.id)
+      }
+    )
+  end
+end

--- a/lib/cinegraph/movies/movie.ex
+++ b/lib/cinegraph/movies/movie.ex
@@ -69,6 +69,10 @@ defmodule Cinegraph.Movies.Movie do
     has_many :external_recommendations, Cinegraph.Movies.MovieRecommendation,
       foreign_key: :source_movie_id
 
+    # Virtual fields for discovery scoring
+    field :discovery_score, :float, virtual: true
+    field :score_components, :map, virtual: true
+
     timestamps()
   end
 

--- a/lib/cinegraph_web/components/layouts/root.html.heex
+++ b/lib/cinegraph_web/components/layouts/root.html.heex
@@ -8,6 +8,7 @@
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>

--- a/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
+++ b/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
@@ -1,0 +1,331 @@
+defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
+  @moduledoc """
+  LiveView component for the Tunable Movie Discovery System.
+  Allows users to adjust scoring weights and see results in real-time.
+  """
+  use CinegraphWeb, :live_view
+  import Ecto.Query
+  
+  alias Cinegraph.Movies
+  alias Cinegraph.Movies.DiscoveryScoringSimple, as: DiscoveryScoring
+  
+  @impl true
+  def mount(_params, _session, socket) do
+    weights = DiscoveryScoring.get_presets().balanced
+    
+    socket = 
+      socket
+      |> assign(:weights, weights)
+      |> assign(:preset, "balanced")
+      |> assign(:movies, [])
+      |> assign(:page, 1)
+      |> assign(:per_page, 20)
+      |> assign(:min_score, 0.0)
+      |> assign(:show_scores, false)
+      |> load_movies()
+    
+    {:ok, socket}
+  end
+  
+  @impl true
+  def handle_event("update_weight", %{"dimension" => dimension, "value" => value}, socket) do
+    dimension = String.to_atom(dimension)
+    value = String.to_float(value) / 100
+    
+    weights = Map.put(socket.assigns.weights, dimension, value)
+    
+    socket =
+      socket
+      |> assign(:weights, weights)
+      |> assign(:preset, "custom")
+      |> load_movies()
+    
+    {:noreply, socket}
+  end
+  
+  @impl true
+  def handle_event("select_preset", %{"preset" => preset}, socket) do
+    weights = 
+      case preset do
+        "custom" -> socket.assigns.weights
+        preset_name -> 
+          DiscoveryScoring.get_presets()
+          |> Map.get(String.to_atom(preset_name))
+      end
+    
+    socket =
+      socket
+      |> assign(:weights, weights)
+      |> assign(:preset, preset)
+      |> load_movies()
+    
+    {:noreply, socket}
+  end
+  
+  @impl true
+  def handle_event("update_min_score", %{"value" => value}, socket) do
+    min_score = String.to_float(value) / 100
+    
+    socket =
+      socket
+      |> assign(:min_score, min_score)
+      |> load_movies()
+    
+    {:noreply, socket}
+  end
+  
+  @impl true
+  def handle_event("toggle_scores", _params, socket) do
+    {:noreply, assign(socket, :show_scores, !socket.assigns.show_scores)}
+  end
+  
+  @impl true
+  def handle_event("load_more", _params, socket) do
+    socket =
+      socket
+      |> assign(:page, socket.assigns.page + 1)
+      |> load_movies(append: true)
+    
+    {:noreply, socket}
+  end
+  
+  defp load_movies(socket, opts \\ []) do
+    query = Movies.Movie
+    
+    movies = 
+      DiscoveryScoring.apply_scoring(
+        query, 
+        socket.assigns.weights,
+        %{min_score: socket.assigns.min_score}
+      )
+      |> limit(^socket.assigns.per_page)
+      |> offset(^((socket.assigns.page - 1) * socket.assigns.per_page))
+      |> Cinegraph.Repo.all()
+      |> Cinegraph.Repo.preload([:genres])
+    
+    if opts[:append] do
+      assign(socket, :movies, socket.assigns.movies ++ movies)
+    else
+      assign(socket, :movies, movies)
+    end
+  end
+  
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <.header>
+        Tunable Movie Discovery
+        <:subtitle>
+          Adjust the importance of different scoring factors to discover movies that match your preferences
+        </:subtitle>
+      </.header>
+      
+      <div class="tuner-controls space-y-6 bg-white p-6 rounded-lg shadow mb-8">
+        <!-- Preset Selector -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2">
+            Presets
+          </label>
+          <div class="flex flex-wrap gap-2">
+            <button
+              :for={{key, _weights} <- DiscoveryScoring.get_presets()}
+              phx-click="select_preset"
+              phx-value-preset={key}
+              class={[
+                "px-4 py-2 rounded-md text-sm font-medium transition-colors",
+                if(@preset == to_string(key),
+                  do: "bg-blue-600 text-white",
+                  else: "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                )
+              ]}
+            >
+              <%= humanize_preset(key) %>
+            </button>
+            <button
+              phx-click="select_preset"
+              phx-value-preset="custom"
+              class={[
+                "px-4 py-2 rounded-md text-sm font-medium transition-colors",
+                if(@preset == "custom",
+                  do: "bg-blue-600 text-white",
+                  else: "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                )
+              ]}
+            >
+              Custom
+            </button>
+          </div>
+        </div>
+        
+        <!-- Weight Sliders -->
+        <div class="space-y-4">
+          <h3 class="text-lg font-semibold text-gray-900">Scoring Weights</h3>
+          
+          <div :for={{dimension, weight} <- @weights} class="space-y-1">
+            <div class="flex justify-between items-center">
+              <label class="text-sm font-medium text-gray-700">
+                <%= humanize_dimension(dimension) %>
+              </label>
+              <span class="text-sm text-gray-600">
+                <%= round(weight * 100) %>%
+              </span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value={round(weight * 100)}
+              phx-change="update_weight"
+              phx-value-dimension={dimension}
+              class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+            />
+            <p class="text-xs text-gray-500">
+              <%= dimension_description(dimension) %>
+            </p>
+          </div>
+        </div>
+        
+        <!-- Minimum Score Filter -->
+        <div class="space-y-1">
+          <div class="flex justify-between items-center">
+            <label class="text-sm font-medium text-gray-700">
+              Minimum Score Threshold
+            </label>
+            <span class="text-sm text-gray-600">
+              <%= round(@min_score * 100) %>%
+            </span>
+          </div>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={round(@min_score * 100)}
+            phx-change="update_min_score"
+            class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+          />
+        </div>
+        
+        <!-- Toggle Score Display -->
+        <div>
+          <button
+            phx-click="toggle_scores"
+            class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors"
+          >
+            <%= if @show_scores, do: "Hide", else: "Show" %> Score Breakdown
+          </button>
+        </div>
+      </div>
+      
+      <!-- Results Grid -->
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <%= for movie <- @movies do %>
+          <.link navigate={~p"/movies/#{movie.id}"} class="group block">
+            <div class="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 overflow-hidden">
+              <!-- Movie Poster -->
+              <div class="aspect-[2/3] bg-gray-200 relative">
+                <%= if movie.poster_path do %>
+                  <img
+                    src={Cinegraph.Movies.Movie.poster_url(movie, "w500")}
+                    alt={movie.title}
+                    class="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                <% else %>
+                  <div class="w-full h-full flex items-center justify-center">
+                    <span class="text-gray-400 text-lg">No Image</span>
+                  </div>
+                <% end %>
+
+                <!-- Rating Badge (if available) -->
+                <% vote_avg = Cinegraph.Movies.Movie.vote_average(movie) %>
+                <%= if vote_avg && vote_avg > 0 do %>
+                  <div class="absolute top-2 left-2 bg-black bg-opacity-75 text-white text-sm px-2 py-1 rounded">
+                    ⭐ <%= Float.round(vote_avg, 1) %>
+                  </div>
+                <% end %>
+              </div>
+
+              <!-- Movie Info -->
+              <div class="p-4">
+                <h3 class="font-semibold text-lg text-gray-900 group-hover:text-blue-600 transition-colors line-clamp-2">
+                  <%= movie.title %>
+                </h3>
+
+                <%= if movie.release_date do %>
+                  <p class="text-gray-500 text-sm mt-1">
+                    <%= Calendar.strftime(movie.release_date, "%Y") %>
+                  </p>
+                <% end %>
+
+                <!-- Quick Stats -->
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <%= if movie.runtime do %>
+                    <span class="text-xs text-gray-500">
+                      <%= movie.runtime %> min
+                    </span>
+                  <% end %>
+
+                  <%= if movie.original_language do %>
+                    <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      <%= String.upcase(movie.original_language) %>
+                    </span>
+                  <% end %>
+                </div>
+
+                <!-- Score Breakdown -->
+                <%= if @show_scores and movie.score_components do %>
+                  <div class="mt-4 space-y-1 text-xs text-gray-600">
+                    <div class="font-semibold text-gray-700">
+                      Total Score: <%= format_score(movie.discovery_score) %>
+                    </div>
+                    <div :for={{dimension, score} <- movie.score_components} class="flex justify-between">
+                      <span><%= humanize_dimension(dimension) %>:</span>
+                      <span><%= format_score(score) %></span>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </.link>
+        <% end %>
+      </div>
+      
+      <!-- Load More Button -->
+      <%= if length(@movies) >= @page * @per_page do %>
+        <div class="mt-8 text-center">
+          <button
+            phx-click="load_more"
+            class="px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          >
+            Load More Movies
+          </button>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+  
+  defp humanize_preset(:balanced), do: "Balanced"
+  defp humanize_preset(:crowd_pleaser), do: "Crowd Pleaser"
+  defp humanize_preset(:critics_choice), do: "Critics' Choice"
+  defp humanize_preset(:award_winner), do: "Award Winner"
+  defp humanize_preset(:cult_classic), do: "Cult Classic"
+  defp humanize_preset(preset), do: Phoenix.Naming.humanize(preset)
+  
+  defp humanize_dimension(:popular_opinion), do: "Popular Opinion"
+  defp humanize_dimension(:critical_acclaim), do: "Critical Acclaim"
+  defp humanize_dimension(:industry_recognition), do: "Industry Recognition"
+  defp humanize_dimension(:cultural_impact), do: "Cultural Impact"
+  defp humanize_dimension(dimension), do: Phoenix.Naming.humanize(dimension)
+  
+  defp dimension_description(:popular_opinion), do: "TMDb and IMDb user ratings"
+  defp dimension_description(:critical_acclaim), do: "Metacritic and Rotten Tomatoes scores"
+  defp dimension_description(:industry_recognition), do: "Festival awards and nominations"
+  defp dimension_description(:cultural_impact), do: "Canonical lists and popularity metrics"
+  defp dimension_description(_), do: ""
+  
+  defp format_score(nil), do: "N/A"
+  defp format_score(score) when is_float(score), do: "#{round(score * 100)}%"
+  defp format_score(score), do: to_string(score)
+end

--- a/lib/cinegraph_web/live/movie_live/index.html.heex
+++ b/lib/cinegraph_web/live/movie_live/index.html.heex
@@ -23,6 +23,14 @@
             No movies found
           <% end %>
         </p>
+        <div class="mt-2">
+          <.link navigate={~p"/movies/discover"} class="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+            </svg>
+            Discover Movies with Tunable Scoring
+          </.link>
+        </div>
       </div>
       
       <!-- Search Bar -->
@@ -122,19 +130,15 @@
               <label class="block text-sm font-medium text-gray-700 mb-1">
                 Genres
               </label>
-              <select
+              <.multi_select_dropdown
+                id="genres-select"
                 name="filters[genres][]"
-                multiple
-                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                size="3"
-              >
-                <%= for genre <- @available_genres do %>
-                  <option value={genre.id} selected={to_string(genre.id) in (@filters.genres || [])}>
-                    <%= genre.name %>
-                  </option>
-                <% end %>
-              </select>
-              <p class="mt-1 text-xs text-gray-500">Hold Ctrl/Cmd to select multiple</p>
+                options={@available_genres}
+                selected={@filters.genres || []}
+                placeholder="Select genres..."
+                label_field={:name}
+                value_field={:id}
+              />
             </div>
             
             <!-- Country Filter -->
@@ -142,19 +146,15 @@
               <label class="block text-sm font-medium text-gray-700 mb-1">
                 Production Countries
               </label>
-              <select
+              <.multi_select_dropdown
+                id="countries-select"
                 name="filters[countries][]"
-                multiple
-                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                size="3"
-              >
-                <%= for country <- @available_countries do %>
-                  <option value={country.id} selected={to_string(country.id) in (@filters.countries || [])}>
-                    <%= country.name %>
-                  </option>
-                <% end %>
-              </select>
-              <p class="mt-1 text-xs text-gray-500">Hold Ctrl/Cmd to select multiple</p>
+                options={@available_countries}
+                selected={@filters.countries || []}
+                placeholder="Select countries..."
+                label_field={:name}
+                value_field={:id}
+              />
             </div>
             
             <!-- Language Filter -->
@@ -162,19 +162,15 @@
               <label class="block text-sm font-medium text-gray-700 mb-1">
                 Languages
               </label>
-              <select
+              <.multi_select_dropdown
+                id="languages-select"
                 name="filters[languages][]"
-                multiple
-                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                size="3"
-              >
-                <%= for language <- @available_languages do %>
-                  <option value={language.iso_639_1} selected={language.iso_639_1 in (@filters.languages || [])}>
-                    <%= language.english_name %>
-                  </option>
-                <% end %>
-              </select>
-              <p class="mt-1 text-xs text-gray-500">Hold Ctrl/Cmd to select multiple</p>
+                options={@available_languages}
+                selected={@filters.languages || []}
+                placeholder="Select languages..."
+                label_field={:english_name}
+                value_field={:iso_639_1}
+              />
             </div>
             
             <!-- Canonical Lists Filter -->
@@ -182,19 +178,15 @@
               <label class="block text-sm font-medium text-gray-700 mb-1">
                 Lists
               </label>
-              <select
+              <.multi_select_dropdown
+                id="lists-select"
                 name="filters[lists][]"
-                multiple
-                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                size="3"
-              >
-                <%= for list <- @available_lists do %>
-                  <option value={list.key} selected={list.key in (@filters.lists || [])}>
-                    <%= list.name %>
-                  </option>
-                <% end %>
-              </select>
-              <p class="mt-1 text-xs text-gray-500">Hold Ctrl/Cmd to select multiple</p>
+                options={@available_lists}
+                selected={@filters.lists || []}
+                placeholder="Select lists..."
+                label_field={:name}
+                value_field={:key}
+              />
             </div>
             
             <!-- Year Range -->

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -21,6 +21,7 @@ defmodule CinegraphWeb.Router do
 
     # Movie routes
     live "/movies", MovieLive.Index, :index
+    live "/movies/discover", MovieLive.DiscoveryTuner, :index
     live "/movies/:id", MovieLive.Show, :show
 
     # People routes

--- a/scripts/test_discovery_scoring.exs
+++ b/scripts/test_discovery_scoring.exs
@@ -1,0 +1,85 @@
+# Test script for the Tunable Movie Discovery System
+
+import Ecto.Query
+
+alias Cinegraph.Movies
+alias Cinegraph.Movies.DiscoveryScoringSimple, as: DiscoveryScoring
+alias Cinegraph.Repo
+
+IO.puts("Testing Tunable Movie Discovery System")
+IO.puts("=" |> String.duplicate(50))
+
+# Test with different presets
+presets = DiscoveryScoring.get_presets()
+
+Enum.each(presets, fn {preset_name, weights} ->
+  IO.puts("\n#{preset_name |> to_string() |> String.upcase()} PRESET")
+  IO.puts("-" |> String.duplicate(30))
+  
+  IO.puts("Weights:")
+  Enum.each(weights, fn {dimension, weight} ->
+    IO.puts("  #{dimension}: #{Float.round(weight * 100, 1)}%")
+  end)
+  
+  # Get top 5 movies with this preset
+  movies = 
+    Movies.Movie
+    |> DiscoveryScoring.apply_scoring(weights, %{min_score: 0.2})
+    |> limit(5)
+    |> Repo.all()
+    |> Repo.preload([:genres])
+  
+  IO.puts("\nTop 5 Movies:")
+  Enum.with_index(movies, 1) |> Enum.each(fn {movie, index} ->
+    IO.puts("#{index}. #{movie.title} (#{movie.release_date && movie.release_date.year})")
+    
+    if movie[:discovery_score] do
+      IO.puts("   Total Score: #{Float.round(movie.discovery_score * 100, 1)}%")
+    end
+    
+    if movie[:score_components] do
+      IO.puts("   Components:")
+      Enum.each(movie.score_components, fn {dimension, score} ->
+        if is_float(score) do
+          IO.puts("     #{dimension}: #{Float.round(score * 100, 1)}%")
+        end
+      end)
+    end
+  end)
+end)
+
+# Test custom weights
+IO.puts("\n" <> "=" |> String.duplicate(50))
+IO.puts("CUSTOM WEIGHTS TEST")
+IO.puts("-" |> String.duplicate(30))
+
+custom_weights = %{
+  popular_opinion: 0.1,
+  critical_acclaim: 0.1,
+  industry_recognition: 0.7,  # Heavy emphasis on awards
+  cultural_impact: 0.1
+}
+
+IO.puts("Custom weights (awards-focused):")
+Enum.each(custom_weights, fn {dimension, weight} ->
+  IO.puts("  #{dimension}: #{Float.round(weight * 100, 1)}%")
+end)
+
+movies = 
+  Movies.Movie
+  |> DiscoveryScoring.apply_scoring(custom_weights, %{min_score: 0.1})
+  |> limit(10)
+  |> Repo.all()
+  |> Repo.preload([:genres])
+
+IO.puts("\nTop 10 Movies with Awards Focus:")
+Enum.with_index(movies, 1) |> Enum.each(fn {movie, index} ->
+  IO.puts("#{index}. #{movie.title} (#{movie.release_date && movie.release_date.year})")
+  
+  if movie[:discovery_score] do
+    IO.puts("   Total Score: #{Float.round(movie.discovery_score * 100, 1)}%")
+  end
+end)
+
+IO.puts("\n" <> "=" |> String.duplicate(50))
+IO.puts("Discovery Scoring System Test Complete!")


### PR DESCRIPTION
### TL;DR

Added a tunable movie discovery system that allows users to customize how movies are scored and ranked based on different criteria.

### What changed?

- Created `DiscoveryScoring` module with weighted scoring across four dimensions: popular opinion, critical acclaim, industry recognition, and cultural impact
- Added `DiscoveryScoringSimple` module with a more performant implementation using pre-calculated scores
- Implemented virtual fields in the `Movie` schema to support discovery scoring
- Created a new LiveView component `DiscoveryTuner` with an interactive UI for adjusting scoring weights
- Added a multi-select dropdown component to improve the filter UI in movie search
- Updated the movie index page to include a link to the new discovery feature
- Added a new route `/movies/discover` for the discovery tuner page
- Created a test script to validate the scoring system

### How to test?

1. Visit `/movies/discover` to access the new discovery tuner interface
2. Try different presets (Balanced, Crowd Pleaser, Critics' Choice, etc.)
3. Adjust individual scoring weights using the sliders
4. Set a minimum score threshold to filter results
5. Toggle the "Show Score Breakdown" button to see detailed scoring for each movie
6. Run the test script with `mix run scripts/test_discovery_scoring.exs` to see how different presets affect movie rankings

### Why make this change?

This feature enhances the user experience by providing personalized movie recommendations based on individual preferences. Users can now discover movies that match their specific interests, whether they value popular ratings, critical reviews, awards recognition, or cultural significance. The tunable system gives users more control over their browsing experience while making movie discovery more engaging and tailored to individual tastes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced tunable movie discovery with adjustable weights and presets (popular opinion, critical acclaim, industry recognition, cultural impact), min-score filtering, pagination, and optional per-movie score breakdown.
  * Added a Discover Movies page at /movies/discover and a header link to access it.

* UI/UX
  * Replaced manual multi-selects with a reusable, searchable multi-select dropdown for Genres, Countries, Languages, and Lists, featuring removable chips and improved usability.
  * Enabled richer client-side interactions powered by Alpine.js.

* Chores
  * Added a script to demo and validate discovery scoring outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->