### PR TITLE
cri started

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -87,7 +87,9 @@ config :cinegraph, Oban,
     # IMDb website scraping (canonical lists, user lists, etc.)
     imdb_scraping: 5,
     # Retry failed canonical source updates
-    canonical_retry: 3
+    canonical_retry: 3,
+    # CRI calculation jobs
+    cri_calculation: 5
   ],
   plugins: [
     # Keep jobs for 7 days

--- a/lib/cinegraph/metrics/metric_definition.ex
+++ b/lib/cinegraph/metrics/metric_definition.ex
@@ -1,0 +1,61 @@
+defmodule Cinegraph.Metrics.MetricDefinition do
+  @moduledoc """
+  Schema for metric definitions that describe how to interpret and normalize different metrics.
+  
+  This schema defines metadata about metrics from various sources (external APIs, festival 
+  nominations, canonical lists) and maps them to categories with proper normalization.
+  """
+  
+  use Ecto.Schema
+  import Ecto.Changeset
+  
+  @primary_key {:id, :id, autogenerate: true}
+  @foreign_key_type :id
+  
+  schema "metric_definitions" do
+    field :code, :string
+    field :name, :string
+    field :description, :string
+    
+    # Source information
+    field :source_table, :string
+    field :source_type, :string
+    field :source_field, :string
+    
+    # Category mapping
+    field :category, :string  # 'ratings', 'awards', 'financial', 'cultural'
+    field :subcategory, :string  # e.g., 'critic_rating', 'audience_rating', 'major_award'
+    
+    # Normalization
+    field :normalization_type, :string  # 'linear', 'logarithmic', 'sigmoid', 'boolean', 'custom'
+    field :normalization_params, :map
+    field :raw_scale_min, :float
+    field :raw_scale_max, :float
+    
+    # Display information
+    field :display_format, :string  # 'percentage', 'score', 'money', 'count', 'boolean'
+    field :display_unit, :string  # '%', '/10', '/100', '$', null
+    
+    # Metadata
+    field :source_reliability, :float, default: 1.0
+    field :active, :boolean, default: true
+    
+    timestamps()
+  end
+  
+  @required_fields [:code, :name, :source_table, :category, :normalization_type]
+  @optional_fields [:description, :source_type, :source_field, :subcategory, :normalization_params, 
+                    :raw_scale_min, :raw_scale_max, :display_format, :display_unit,
+                    :source_reliability, :active]
+  
+  @doc false
+  def changeset(metric_definition, attrs) do
+    metric_definition
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> unique_constraint(:code)
+    |> validate_inclusion(:category, ["ratings", "awards", "financial", "cultural"])
+    |> validate_inclusion(:normalization_type, ["linear", "logarithmic", "sigmoid", "boolean", "custom"])
+    |> validate_inclusion(:display_format, ["percentage", "score", "money", "count", "boolean"], allow_nil: true)
+  end
+end

--- a/lib/cinegraph/metrics/metric_score.ex
+++ b/lib/cinegraph/metrics/metric_score.ex
@@ -1,0 +1,65 @@
+defmodule Cinegraph.Metrics.MetricScore do
+  @moduledoc """
+  Schema for calculated metric scores that are cached for performance.
+  
+  Stores the computed scores for each movie using different weight profiles, 
+  including category breakdowns and calculation metadata.
+  """
+  
+  use Ecto.Schema
+  import Ecto.Changeset
+  
+  @primary_key {:id, :id, autogenerate: true}
+  @foreign_key_type :id
+  
+  schema "metric_scores" do
+    # Foreign keys
+    belongs_to :movie, Cinegraph.Movies.Movie
+    belongs_to :profile, Cinegraph.Metrics.MetricWeightProfile
+    
+    # Category scores
+    field :ratings_score, :float  # Normalized aggregate of all ratings
+    field :awards_score, :float   # Normalized aggregate of all awards
+    field :financial_score, :float # Normalized aggregate of financial metrics
+    field :cultural_score, :float  # Normalized aggregate of cultural list inclusions
+    
+    # Total weighted score
+    field :total_score, :float
+    
+    # Raw metric values used (for transparency)
+    field :metric_values, :map  # {"imdb_rating": 8.3, "oscar_wins": 7, ...}
+    
+    # Metadata
+    field :percentile_rank, :float  # Where this movie ranks in the distribution
+    field :calculated_at, :utc_datetime
+    field :metrics_available, :integer  # Number of metrics available for this movie
+    field :metrics_missing, {:array, :string}  # List of missing metric codes
+    
+    timestamps()
+  end
+  
+  @required_fields [:movie_id, :profile_id, :total_score, :calculated_at]
+  @optional_fields [:ratings_score, :awards_score, :financial_score, :cultural_score,
+                    :metric_values, :percentile_rank, :metrics_available, :metrics_missing]
+  
+  @doc false
+  def changeset(metric_score, attrs) do
+    metric_score
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:movie_id)
+    |> foreign_key_constraint(:profile_id)
+    |> unique_constraint([:movie_id, :profile_id])
+    |> validate_number(:total_score, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0)
+    |> validate_category_scores()
+  end
+  
+  defp validate_category_scores(changeset) do
+    changeset
+    |> validate_number(:ratings_score, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0, allow_nil: true)
+    |> validate_number(:awards_score, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0, allow_nil: true)
+    |> validate_number(:financial_score, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0, allow_nil: true)
+    |> validate_number(:cultural_score, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0, allow_nil: true)
+    |> validate_number(:percentile_rank, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 100.0, allow_nil: true)
+  end
+end

--- a/lib/cinegraph/metrics/metric_weight_profile.ex
+++ b/lib/cinegraph/metrics/metric_weight_profile.ex
@@ -1,0 +1,79 @@
+defmodule Cinegraph.Metrics.MetricWeightProfile do
+  @moduledoc """
+  Schema for weight profiles that define different scoring strategies for movie metrics.
+  
+  Weight profiles allow different approaches to scoring movies (critics choice, crowd pleaser, etc.)
+  by adjusting the relative importance of different categories and individual metrics.
+  """
+  
+  use Ecto.Schema
+  import Ecto.Changeset
+  
+  @primary_key {:id, :id, autogenerate: true}
+  @foreign_key_type :id
+  
+  schema "metric_weight_profiles" do
+    field :name, :string
+    field :description, :string
+    
+    # Individual metric weights by metric code
+    field :weights, :map, default: %{}
+    # Example: {"imdb_rating" => 1.0, "oscar_wins" => 2.0, "revenue_worldwide" => 0.8}
+    
+    # Category multipliers (applied after individual weights)
+    field :category_weights, :map, default: %{"ratings" => 1.0, "awards" => 1.0, "financial" => 1.0, "cultural" => 1.0}
+    
+    # Usage tracking
+    field :usage_count, :integer, default: 0
+    field :last_used_at, :utc_datetime
+    
+    # Status
+    field :active, :boolean, default: true
+    field :is_default, :boolean, default: false
+    field :is_system, :boolean, default: false
+    
+    # Associations
+    has_many :metric_scores, Cinegraph.Metrics.MetricScore, foreign_key: :profile_id
+    
+    timestamps()
+  end
+  
+  @doc false
+  def changeset(weight_profile, attrs) do
+    weight_profile
+    |> cast(attrs, [:name, :description, :weights, :category_weights, :active, :is_default, :is_system])
+    |> validate_required([:name, :weights])
+    |> unique_constraint(:name)
+    |> validate_category_weights()
+    |> validate_only_one_default()
+  end
+  
+  defp validate_category_weights(changeset) do
+    case get_change(changeset, :category_weights) do
+      nil -> changeset
+      weights ->
+        valid_categories = ["ratings", "awards", "financial", "cultural"]
+        
+        if Enum.all?(Map.keys(weights), &(&1 in valid_categories)) do
+          changeset
+        else
+          add_error(changeset, :category_weights, "contains invalid categories")
+        end
+    end
+  end
+  
+  defp validate_only_one_default(changeset) do
+    if get_change(changeset, :is_default) == true do
+      # Check if another default exists
+      import Ecto.Query
+      current_id = changeset.data.id
+      
+      case Cinegraph.Repo.one(from p in __MODULE__, where: p.is_default == true and p.id != ^current_id) do
+        nil -> changeset
+        _ -> add_error(changeset, :is_default, "only one profile can be default")
+      end
+    else
+      changeset
+    end
+  end
+end

--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -1,0 +1,279 @@
+defmodule Cinegraph.Metrics.ScoringService do
+  @moduledoc """
+  Service module for calculating movie scores using database-driven weight profiles.
+  Replaces the hard-coded discovery scoring system with a flexible, database-backed approach.
+  """
+  
+  import Ecto.Query, warn: false
+  alias Cinegraph.Repo
+  alias Cinegraph.Metrics.MetricWeightProfile
+  
+  @doc """
+  Gets a weight profile by name from the database.
+  Returns the profile or nil if not found.
+  """
+  def get_profile(name) when is_binary(name) do
+    Repo.get_by(MetricWeightProfile, name: name, active: true)
+  end
+  
+  def get_profile(name) when is_atom(name) do
+    get_profile(Atom.to_string(name) |> String.replace("_", " ") |> String.split() |> Enum.map(&String.capitalize/1) |> Enum.join(" "))
+  end
+  
+  @doc """
+  Gets all active weight profiles from the database.
+  """
+  def get_all_profiles do
+    from(p in MetricWeightProfile, where: p.active == true, order_by: [asc: p.name])
+    |> Repo.all()
+  end
+  
+  @doc """
+  Gets the default weight profile from the database.
+  """
+  def get_default_profile do
+    Repo.get_by(MetricWeightProfile, is_default: true, active: true) ||
+      get_profile("Balanced")
+  end
+  
+  @doc """
+  Converts a database weight profile to the format expected by the discovery UI.
+  Maps category_weights to the four main dimensions.
+  """
+  def profile_to_discovery_weights(%MetricWeightProfile{} = profile) do
+    %{
+      popular_opinion: get_category_weight(profile, "ratings", 0.25),
+      critical_acclaim: get_critical_weight(profile, 0.25),
+      industry_recognition: get_category_weight(profile, "awards", 0.25),
+      cultural_impact: get_category_weight(profile, "cultural", 0.25)
+    }
+  end
+  
+  @doc """
+  Converts discovery UI weights back to database format for custom profiles.
+  """
+  def discovery_weights_to_profile(weights, name \\ "Custom") do
+    %{
+      name: name,
+      description: "Custom weight profile created from discovery UI",
+      category_weights: %{
+        "ratings" => Map.get(weights, :popular_opinion, 0.25),
+        "awards" => Map.get(weights, :industry_recognition, 0.25),
+        "financial" => Map.get(weights, :popular_opinion, 0.25) * 0.3, # Financial correlates with popular
+        "cultural" => Map.get(weights, :cultural_impact, 0.25)
+      },
+      weights: build_metric_weights_from_discovery(weights),
+      active: true,
+      is_system: false
+    }
+  end
+  
+  @doc """
+  Applies database-driven scoring to a movie query.
+  This replaces the hard-coded scoring in DiscoveryScoringSimple.
+  """
+  def apply_scoring(query, profile_or_name, options \\ %{})
+  
+  def apply_scoring(query, %MetricWeightProfile{} = profile, options) do
+    discovery_weights = profile_to_discovery_weights(profile)
+    normalized_weights = normalize_weights(discovery_weights)
+    min_score = Map.get(options, :min_score, 0.0)
+    
+    # Use the same query structure as DiscoveryScoringSimple but with database weights
+    query
+    |> join_external_metrics()
+    |> join_festival_data()
+    |> select_with_scores(normalized_weights)
+    |> filter_by_min_score(normalized_weights, min_score)
+    |> order_by_score(normalized_weights)
+  end
+  
+  def apply_scoring(query, profile_name, options) when is_binary(profile_name) do
+    case get_profile(profile_name) do
+      nil -> apply_scoring(query, get_default_profile(), options)
+      profile -> apply_scoring(query, profile, options)
+    end
+  end
+  
+  # Private functions
+  
+  defp get_category_weight(%MetricWeightProfile{category_weights: weights}, category, default) do
+    Map.get(weights || %{}, category, default)
+  end
+  
+  defp get_critical_weight(%MetricWeightProfile{} = profile, default) do
+    # Critical acclaim is a special case - it's ratings but only for critic scores
+    # We need to look at individual metric weights to determine this
+    ratings_weight = get_category_weight(profile, "ratings", default)
+    
+    # Check if profile emphasizes critic scores specifically
+    weights = profile.weights || %{}
+    critic_weight = (Map.get(weights, "metacritic_metascore", 1.0) + 
+                    Map.get(weights, "rotten_tomatoes_tomatometer", 1.0)) / 2
+    audience_weight = (Map.get(weights, "imdb_rating", 1.0) + 
+                      Map.get(weights, "tmdb_rating", 1.0)) / 2
+    
+    if critic_weight > audience_weight do
+      ratings_weight * (critic_weight / (critic_weight + audience_weight))
+    else
+      ratings_weight * 0.5  # Default to half of ratings weight for critics
+    end
+  end
+  
+  defp build_metric_weights_from_discovery(weights) do
+    pop_weight = Map.get(weights, :popular_opinion, 0.25)
+    crit_weight = Map.get(weights, :critical_acclaim, 0.25)
+    award_weight = Map.get(weights, :industry_recognition, 0.25)
+    cultural_weight = Map.get(weights, :cultural_impact, 0.25)
+    
+    %{
+      # Popular Opinion metrics
+      "imdb_rating" => pop_weight * 2,
+      "tmdb_rating" => pop_weight * 2,
+      "rotten_tomatoes_audience_score" => pop_weight * 1.5,
+      "imdb_rating_votes" => pop_weight * 0.5,
+      
+      # Critical Acclaim metrics
+      "metacritic_metascore" => crit_weight * 2,
+      "rotten_tomatoes_tomatometer" => crit_weight * 2,
+      
+      # Industry Recognition metrics
+      "oscar_wins" => award_weight * 3,
+      "oscar_nominations" => award_weight * 2,
+      "cannes_palme_dor" => award_weight * 2,
+      "venice_golden_lion" => award_weight * 2,
+      "berlin_golden_bear" => award_weight * 2,
+      
+      # Cultural Impact metrics
+      "1001_movies" => cultural_weight * 2,
+      "criterion" => cultural_weight * 2,
+      "sight_sound_critics_2022" => cultural_weight * 1.5,
+      "national_film_registry" => cultural_weight * 1.5
+    }
+  end
+  
+  defp normalize_weights(weights) do
+    total = Enum.sum(Map.values(weights))
+    
+    if total == 0 do
+      %{popular_opinion: 0.25, critical_acclaim: 0.25, 
+        industry_recognition: 0.25, cultural_impact: 0.25}
+    else
+      Map.new(weights, fn {k, v} -> {k, v / total} end)
+    end
+  end
+  
+  defp join_external_metrics(query) do
+    query
+    |> join(:left, [m], em_tmdb in "external_metrics",
+      on: em_tmdb.movie_id == m.id and 
+          em_tmdb.source == "tmdb" and 
+          em_tmdb.metric_type == "rating_average",
+      as: :tmdb_rating
+    )
+    |> join(:left, [m], em_imdb in "external_metrics",
+      on: em_imdb.movie_id == m.id and 
+          em_imdb.source == "imdb" and 
+          em_imdb.metric_type == "rating_average",
+      as: :imdb_rating
+    )
+    |> join(:left, [m], em_meta in "external_metrics",
+      on: em_meta.movie_id == m.id and 
+          em_meta.source == "metacritic" and 
+          em_meta.metric_type == "metascore",
+      as: :metacritic
+    )
+    |> join(:left, [m], em_rt in "external_metrics",
+      on: em_rt.movie_id == m.id and 
+          em_rt.source == "rotten_tomatoes" and 
+          em_rt.metric_type == "tomatometer",
+      as: :rotten_tomatoes
+    )
+    |> join(:left, [m], em_pop in "external_metrics",
+      on: em_pop.movie_id == m.id and 
+          em_pop.source == "tmdb" and 
+          em_pop.metric_type == "popularity_score",
+      as: :popularity
+    )
+  end
+  
+  defp join_festival_data(query) do
+    festival_subquery = 
+      from(f in "festival_nominations",
+        group_by: f.movie_id,
+        select: %{
+          movie_id: f.movie_id,
+          wins: count(fragment("CASE WHEN ? = true THEN 1 END", f.won)),
+          nominations: count(f.id)
+        }
+      )
+    
+    join(query, :left, [m], f in subquery(festival_subquery),
+      on: f.movie_id == m.id,
+      as: :festivals
+    )
+  end
+  
+  defp select_with_scores(query, weights) do
+    select_merge(query,
+      [m, tmdb_rating: tr, imdb_rating: ir, metacritic: mc, 
+       rotten_tomatoes: rt, popularity: pop, festivals: f],
+      %{
+        discovery_score: fragment(
+          "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+          ^weights.popular_opinion, tr.value, ir.value,
+          ^weights.critical_acclaim, mc.value, rt.value,
+          ^weights.industry_recognition, f.wins, f.nominations,
+          ^weights.cultural_impact, m.canonical_sources, pop.value
+        ),
+        score_components: %{
+          popular_opinion: fragment(
+            "COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0)",
+            tr.value, ir.value
+          ),
+          critical_acclaim: fragment(
+            "COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0)",
+            mc.value, rt.value
+          ),
+          industry_recognition: fragment(
+            "COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0)",
+            f.wins, f.nominations
+          ),
+          cultural_impact: fragment(
+            "COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+            m.canonical_sources, pop.value
+          )
+        }
+      }
+    )
+  end
+  
+  defp filter_by_min_score(query, weights, min_score) do
+    where(query,
+      [m, tmdb_rating: tr, imdb_rating: ir, metacritic: mc,
+       rotten_tomatoes: rt, popularity: pop, festivals: f],
+      fragment(
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0) >= ?",
+        ^weights.popular_opinion, tr.value, ir.value,
+        ^weights.critical_acclaim, mc.value, rt.value,
+        ^weights.industry_recognition, f.wins, f.nominations,
+        ^weights.cultural_impact, m.canonical_sources, pop.value,
+        ^min_score
+      )
+    )
+  end
+  
+  defp order_by_score(query, weights) do
+    order_by(query,
+      [m, tmdb_rating: tr, imdb_rating: ir, metacritic: mc,
+       rotten_tomatoes: rt, popularity: pop, festivals: f],
+      desc: fragment(
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+        ^weights.popular_opinion, tr.value, ir.value,
+        ^weights.critical_acclaim, mc.value, rt.value,
+        ^weights.industry_recognition, f.wins, f.nominations,
+        ^weights.cultural_impact, m.canonical_sources, pop.value
+      )
+    )
+  end
+end

--- a/lib/cinegraph/movies/movie.ex
+++ b/lib/cinegraph/movies/movie.ex
@@ -166,6 +166,12 @@ defmodule Cinegraph.Movies.Movie do
   end
 
   @doc """
+  Gets the release year from release_date
+  """
+  def release_year(%__MODULE__{release_date: nil}), do: nil
+  def release_year(%__MODULE__{release_date: date}), do: date.year
+
+  @doc """
   Checks if a movie is in a canonical source. source_key is required.
   """
   def is_canonical?(%__MODULE__{canonical_sources: sources}, source_key) do

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -351,7 +351,7 @@
                   <div class="flex-1">
                     <div class="flex items-center gap-2 mb-1">
                       <h5 class="font-medium text-sm text-gray-900">
-                        {nomination.category.name}
+                        <%= nomination.category_name %>
                       </h5>
                       <%= if nomination.won do %>
                         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-bold bg-yellow-200 text-yellow-900 border border-yellow-300">
@@ -380,10 +380,10 @@
 
                   <div class="text-right">
                     <span class="text-sm font-bold text-gray-700">
-                      {nomination.ceremony.year}
+                      <%= nomination.ceremony_year %>
                     </span>
                     <p class="text-xs text-gray-500">
-                      {format_ordinal(nomination.ceremony.ceremony_number)} Ceremony
+                      <%= format_ordinal(nomination.ceremony_number) %> Ceremony
                     </p>
                   </div>
                 </div>

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -23,6 +23,7 @@ defmodule CinegraphWeb.Router do
     live "/movies", MovieLive.Index, :index
     live "/movies/discover", MovieLive.DiscoveryTuner, :index
     live "/movies/:id", MovieLive.Show, :show
+    live "/movies/:id/metrics", MovieMetricsLive.Show, :show
 
     # People routes
     live "/people", PersonLive.Index, :index
@@ -35,6 +36,7 @@ defmodule CinegraphWeb.Router do
 
     # Import dashboard
     live "/imports", ImportDashboardLive, :index
+
 
     # Festival Events management
     live "/festival-events", FestivalEventLive.Index, :index

--- a/priv/repo/migrations/20250813101923_create_metric_cri_system.exs
+++ b/priv/repo/migrations/20250813101923_create_metric_cri_system.exs
@@ -1,0 +1,187 @@
+defmodule Cinegraph.Repo.Migrations.CreateMetricCriSystem do
+  use Ecto.Migration
+
+  def change do
+    # ========== TABLES ==========
+    
+    # 1. Metric definitions - metadata about how to interpret each metric
+    create table(:metric_definitions) do
+      add :code, :string, null: false  # e.g., 'imdb_rating', 'oscar_wins'
+      add :name, :string, null: false
+      add :description, :text
+      
+      # Source information
+      add :source_table, :string, null: false  # 'external_metrics', 'festival_nominations', 'canonical_sources'
+      add :source_type, :string  # e.g., 'imdb', 'tmdb', 'metacritic' for external_metrics
+      add :source_field, :string  # e.g., 'rating_average', 'metascore'
+      
+      # Category mapping (replaces CRI dimension)
+      add :category, :string, null: false  # 'ratings', 'awards', 'financial', 'cultural'
+      add :subcategory, :string  # e.g., 'critic_rating', 'audience_rating', 'major_award', 'festival_award'
+      
+      # Normalization
+      add :normalization_type, :string, null: false  # 'linear', 'logarithmic', 'sigmoid', 'boolean', 'custom'
+      add :normalization_params, :map, default: %{}  # Parameters for normalization
+      add :raw_scale_min, :float
+      add :raw_scale_max, :float
+      
+      # Display information
+      add :display_format, :string  # 'percentage', 'score', 'money', 'count', 'boolean'
+      add :display_unit, :string  # '%', '/10', '/100', '$', null
+      
+      # Metadata
+      add :source_reliability, :float, default: 1.0  # 0.0 to 1.0
+      add :active, :boolean, default: true
+      
+      timestamps()
+    end
+    
+    create unique_index(:metric_definitions, [:code])
+    create index(:metric_definitions, [:source_table])
+    create index(:metric_definitions, [:category])
+    create index(:metric_definitions, [:subcategory])
+    create index(:metric_definitions, [:active])
+    
+    # 2. Simplified weight profiles for different scoring strategies
+    create table(:metric_weight_profiles) do
+      add :name, :string, null: false
+      add :description, :text
+      
+      # Simple JSON for all weights by metric code
+      add :weights, :map, null: false, default: %{}
+      # Example: {"imdb_rating": 1.0, "oscar_wins": 2.0, "revenue_worldwide": 0.8}
+      
+      # Category multipliers (optional) - applied after individual weights
+      add :category_weights, :map, default: %{"ratings" => 1.0, "awards" => 1.0, "financial" => 1.0, "cultural" => 1.0}
+      
+      # Usage tracking
+      add :usage_count, :integer, default: 0
+      add :last_used_at, :utc_datetime
+      
+      # Status
+      add :active, :boolean, default: true
+      add :is_default, :boolean, default: false
+      add :is_system, :boolean, default: false  # System profiles can't be deleted
+      
+      timestamps()
+    end
+    
+    create unique_index(:metric_weight_profiles, [:name])
+    create index(:metric_weight_profiles, [:active])
+    create index(:metric_weight_profiles, [:is_default])
+    
+    # Ensure only one default profile
+    execute """
+      CREATE UNIQUE INDEX only_one_default_profile 
+      ON metric_weight_profiles (is_default) 
+      WHERE is_default = true
+    """, "DROP INDEX IF EXISTS only_one_default_profile"
+    
+    # Note: metric_scores table removed - scores are calculated on-the-fly
+    # The system calculates scores dynamically using SQL queries for better flexibility
+    
+    # ========== VIEWS ==========
+    
+    # Create a VIEW that aggregates all metric data from existing tables
+    # This avoids duplicating data that already exists
+    execute """
+      CREATE VIEW metric_values_view AS
+      
+      -- External metrics (IMDb, TMDb, Metacritic, RT)
+      SELECT 
+        em.movie_id,
+        CONCAT(em.source, '_', em.metric_type) as metric_code,
+        em.value as raw_value_numeric,
+        NULL as raw_value_text,
+        em.source as source_type,
+        em.fetched_at as observed_at,
+        'external_metrics' as source_table
+      FROM external_metrics em
+      WHERE em.value IS NOT NULL
+      
+      UNION ALL
+      
+      -- Festival nominations (Oscars, Cannes, etc.)
+      SELECT 
+        fn.movie_id,
+        CASE 
+          WHEN fo.abbreviation = 'AMPAS' AND fn.won = true THEN 'oscar_wins'
+          WHEN fo.abbreviation = 'AMPAS' AND fn.won = false THEN 'oscar_nominations'
+          WHEN fo.abbreviation = 'CANNES' AND fn.won = true THEN 'cannes_palme_dor'
+          WHEN fo.abbreviation = 'VIFF' AND fn.won = true THEN 'venice_golden_lion'
+          WHEN fo.abbreviation = 'BERLINALE' AND fn.won = true THEN 'berlin_golden_bear'
+          ELSE CONCAT(LOWER(fo.abbreviation), '_', CASE WHEN fn.won THEN 'win' ELSE 'nom' END)
+        END as metric_code,
+        1 as raw_value_numeric,  -- Count will be aggregated
+        CASE WHEN fn.won THEN 'true' ELSE 'false' END as raw_value_text,
+        fo.abbreviation as source_type,
+        fc.date as observed_at,
+        'festival_nominations' as source_table
+      FROM festival_nominations fn
+      JOIN festival_ceremonies fc ON fn.ceremony_id = fc.id
+      JOIN festival_organizations fo ON fc.organization_id = fo.id
+      WHERE fn.movie_id IS NOT NULL
+      
+      UNION ALL
+      
+      -- Canonical sources (1001 Movies, AFI Top 100, etc.)
+      SELECT 
+        m.id as movie_id,
+        key as metric_code,
+        CASE 
+          WHEN value::text = 'true' THEN 1
+          WHEN value::text ~ '^[0-9]+$' THEN value::text::integer
+          ELSE NULL
+        END as raw_value_numeric,
+        value::text as raw_value_text,
+        key as source_type,
+        m.updated_at as observed_at,
+        'canonical_sources' as source_table
+      FROM movies m,
+      LATERAL jsonb_each(m.canonical_sources) as sources(key, value)
+      WHERE m.canonical_sources IS NOT NULL
+    """, "DROP VIEW IF EXISTS metric_values_view"
+    
+    # ========== FUNCTIONS ==========
+    
+    # Function to calculate normalized value based on metric definition
+    execute """
+      CREATE OR REPLACE FUNCTION normalize_metric_value(
+        p_value FLOAT,
+        p_normalization_type TEXT,
+        p_params JSONB,
+        p_min FLOAT,
+        p_max FLOAT
+      ) RETURNS FLOAT AS $$
+      DECLARE
+        v_result FLOAT;
+      BEGIN
+        CASE p_normalization_type
+          WHEN 'linear' THEN
+            IF p_max = p_min OR p_max IS NULL OR p_min IS NULL THEN
+              v_result := 0.0;
+            ELSE
+              v_result := (p_value - p_min) / (p_max - p_min);
+            END IF;
+          
+          WHEN 'logarithmic' THEN
+            v_result := LN(p_value + 1) / LN(COALESCE((p_params->>'threshold')::FLOAT, 1000000) + 1);
+          
+          WHEN 'sigmoid' THEN
+            v_result := 1 / (1 + EXP(-COALESCE((p_params->>'k')::FLOAT, 0.05) * 
+                       (COALESCE((p_params->>'midpoint')::FLOAT, 50) - p_value)));
+          
+          WHEN 'boolean' THEN
+            v_result := CASE WHEN p_value > 0 THEN 1.0 ELSE 0.0 END;
+          
+          ELSE
+            v_result := p_value;  -- Custom normalization handled in application
+        END CASE;
+        
+        -- Ensure result is between 0 and 1
+        RETURN GREATEST(0.0, LEAST(1.0, v_result));
+      END;
+      $$ LANGUAGE plpgsql IMMUTABLE;
+    """, "DROP FUNCTION IF EXISTS normalize_metric_value"
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -576,4 +576,11 @@ end
 create_festival_dates.()
 Logger.info("  ✅ Created festival dates for 2024/2025")
 
+# Seed metric definitions and weight profiles for discovery system
+Logger.info("Seeding metric definitions...")
+Code.eval_file("priv/repo/seeds/metric_definitions.exs")
+
+Logger.info("Seeding discovery weight profiles...")
+Code.eval_file("priv/repo/seeds/metric_weight_profiles.exs")
+
 Logger.info("Seeds completed!")

--- a/priv/repo/seeds/metric_definitions.exs
+++ b/priv/repo/seeds/metric_definitions.exs
@@ -1,0 +1,388 @@
+# Seed file for metric definitions
+# Run with: mix run priv/repo/seeds/metric_definitions.exs
+
+alias Cinegraph.Repo
+import Ecto.Query
+
+# Clear existing definitions
+Repo.delete_all(from md in "metric_definitions")
+
+metric_definitions = [
+  # ========== RATINGS (Public Opinion) ==========
+  %{
+    code: "imdb_rating",
+    name: "IMDb Rating",
+    description: "Average user rating on IMDb",
+    source_table: "external_metrics",
+    source_type: "imdb",
+    source_field: "rating_average",
+    category: "ratings",
+    subcategory: "audience_rating",
+    normalization_type: "linear",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 10.0,
+    source_reliability: 0.95,
+    active: true
+  },
+  %{
+    code: "tmdb_rating",
+    name: "TMDb Rating",
+    description: "Average user rating on The Movie Database",
+    source_table: "external_metrics",
+    source_type: "tmdb",
+    source_field: "rating_average",
+    category: "ratings",
+    subcategory: "audience_rating",
+    normalization_type: "linear",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 10.0,
+    source_reliability: 0.9,
+    active: true
+  },
+  
+  # ========== CRITICAL RATINGS (Artistic Impact) ==========
+  %{
+    code: "metacritic_metascore",
+    name: "Metacritic Score",
+    description: "Weighted average of critic reviews",
+    source_table: "external_metrics",
+    source_type: "metacritic",
+    source_field: "metascore",
+    category: "ratings",
+    subcategory: "critic_rating",
+    normalization_type: "linear",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 100.0,
+    source_reliability: 0.85,
+    active: true
+  },
+  %{
+    code: "rotten_tomatoes_tomatometer",
+    name: "Rotten Tomatoes Tomatometer",
+    description: "Percentage of positive critic reviews",
+    source_table: "external_metrics",
+    source_type: "rotten_tomatoes",
+    source_field: "tomatometer",
+    category: "ratings",
+    subcategory: "critic_rating",
+    normalization_type: "linear",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 100.0,
+    source_reliability: 0.8,
+    active: true
+  },
+  %{
+    code: "rotten_tomatoes_audience_score",
+    name: "Rotten Tomatoes Audience Score",
+    description: "Percentage of positive audience reviews",
+    source_table: "external_metrics",
+    source_type: "rotten_tomatoes",
+    source_field: "audience_score",
+    category: "ratings",
+    subcategory: "audience_rating",
+    normalization_type: "linear",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 100.0,
+    source_reliability: 0.75,
+    active: true
+  },
+  
+  # ========== POPULARITY METRICS (Cultural Penetration) ==========
+  %{
+    code: "imdb_rating_votes",
+    name: "IMDb Vote Count",
+    description: "Number of user ratings on IMDb",
+    source_table: "external_metrics",
+    source_type: "imdb",
+    source_field: "rating_votes",
+    category: "ratings",
+    subcategory: "audience_rating",
+    normalization_type: "logarithmic",
+    normalization_params: %{"threshold" => 10_000_000},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 0.95,
+    active: true
+  },
+  %{
+    code: "tmdb_rating_votes",
+    name: "TMDb Vote Count",
+    description: "Number of user ratings on TMDb",
+    source_table: "external_metrics",
+    source_type: "tmdb",
+    source_field: "rating_votes",
+    category: "ratings",
+    subcategory: "audience_rating",
+    normalization_type: "logarithmic",
+    normalization_params: %{"threshold" => 1_000_000},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 0.9,
+    active: true
+  },
+  %{
+    code: "tmdb_popularity_score",
+    name: "TMDb Popularity",
+    description: "TMDb's proprietary popularity metric",
+    source_table: "external_metrics",
+    source_type: "tmdb",
+    source_field: "popularity_score",
+    category: "ratings",
+    subcategory: "audience_rating",
+    normalization_type: "logarithmic",
+    normalization_params: %{"threshold" => 1000},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 0.7,
+    active: true
+  },
+  
+  # ========== FINANCIAL METRICS (Cultural Penetration) ==========
+  %{
+    code: "tmdb_budget",
+    name: "Production Budget",
+    description: "Movie production budget",
+    source_table: "external_metrics",
+    source_type: "tmdb",
+    source_field: "budget",
+    category: "financial",
+    subcategory: "box_office",
+    normalization_type: "logarithmic",
+    normalization_params: %{"threshold" => 500_000_000},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 0.7,
+    active: true
+  },
+  %{
+    code: "tmdb_revenue_worldwide",
+    name: "Worldwide Revenue",
+    description: "Total worldwide box office revenue",
+    source_table: "external_metrics",
+    source_type: "tmdb",
+    source_field: "revenue_worldwide",
+    category: "financial",
+    subcategory: "box_office",
+    normalization_type: "logarithmic",
+    normalization_params: %{"threshold" => 2_000_000_000},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 0.7,
+    active: true
+  },
+  %{
+    code: "omdb_revenue_domestic",
+    name: "Domestic Box Office",
+    description: "US domestic box office revenue",
+    source_table: "external_metrics",
+    source_type: "omdb",
+    source_field: "revenue_domestic",
+    category: "financial",
+    subcategory: "box_office",
+    normalization_type: "logarithmic",
+    normalization_params: %{"threshold" => 1_000_000_000},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 0.65,
+    active: true
+  },
+  
+  # ========== AWARDS (Institutional Recognition) ==========
+  %{
+    code: "oscar_wins",
+    name: "Oscar Wins",
+    description: "Number of Academy Awards won",
+    source_table: "festival_nominations",
+    source_type: "AMPAS",
+    source_field: "won",
+    category: "awards",
+    subcategory: "major_award",
+    normalization_type: "custom",
+    normalization_params: %{"0" => 0.0, "1" => 0.6, "2" => 0.8, "3+" => 1.0},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 1.0,
+    active: true
+  },
+  %{
+    code: "oscar_nominations",
+    name: "Oscar Nominations",
+    description: "Number of Academy Award nominations",
+    source_table: "festival_nominations",
+    source_type: "AMPAS",
+    source_field: "nominated",
+    category: "awards",
+    subcategory: "major_award",
+    normalization_type: "custom",
+    normalization_params: %{"0" => 0.0, "1" => 0.5, "2" => 0.7, "3+" => 1.0},
+    raw_scale_min: 0.0,
+    raw_scale_max: nil,
+    source_reliability: 1.0,
+    active: true
+  },
+  %{
+    code: "cannes_palme_dor",
+    name: "Cannes Palme d'Or",
+    description: "Won the Palme d'Or at Cannes Film Festival",
+    source_table: "festival_nominations",
+    source_type: "CANNES",
+    source_field: "won",
+    category: "awards",
+    subcategory: "major_award",
+    normalization_type: "boolean",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 1.0,
+    source_reliability: 1.0,
+    active: true
+  },
+  %{
+    code: "venice_golden_lion",
+    name: "Venice Golden Lion",
+    description: "Won the Golden Lion at Venice Film Festival",
+    source_table: "festival_nominations",
+    source_type: "VIFF",
+    source_field: "won",
+    category: "awards",
+    subcategory: "major_award",
+    normalization_type: "boolean",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 1.0,
+    source_reliability: 1.0,
+    active: true
+  },
+  %{
+    code: "berlin_golden_bear",
+    name: "Berlin Golden Bear",
+    description: "Won the Golden Bear at Berlin Film Festival",
+    source_table: "festival_nominations",
+    source_type: "BERLINALE",
+    source_field: "won",
+    category: "awards",
+    subcategory: "major_award",
+    normalization_type: "boolean",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 1.0,
+    source_reliability: 1.0,
+    active: true
+  },
+  
+  # ========== CANONICAL LISTS (Timelessness) ==========
+  %{
+    code: "1001_movies",
+    name: "1001 Movies Before You Die",
+    description: "Included in the 1001 Movies list",
+    source_table: "canonical_sources",
+    source_type: "1001_movies",
+    source_field: "included",
+    category: "cultural",
+    subcategory: "canonical_list",
+    normalization_type: "boolean",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 1.0,
+    source_reliability: 0.85,
+    active: true
+  },
+  %{
+    code: "criterion",
+    name: "Criterion Collection",
+    description: "Part of the Criterion Collection",
+    source_table: "canonical_sources",
+    source_type: "criterion",
+    source_field: "included",
+    category: "cultural",
+    subcategory: "canonical_list",
+    normalization_type: "boolean",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 1.0,
+    source_reliability: 0.9,
+    active: true
+  },
+  %{
+    code: "national_film_registry",
+    name: "National Film Registry",
+    description: "Preserved in the National Film Registry",
+    source_table: "canonical_sources",
+    source_type: "national_film_registry",
+    source_field: "included",
+    category: "cultural",
+    subcategory: "canonical_list",
+    normalization_type: "boolean",
+    normalization_params: %{},
+    raw_scale_min: 0.0,
+    raw_scale_max: 1.0,
+    source_reliability: 0.95,
+    active: true
+  },
+  %{
+    code: "sight_sound_critics_2022",
+    name: "Sight & Sound Critics' Poll 2022",
+    description: "Ranked in the 2022 Sight & Sound critics' poll",
+    source_table: "canonical_sources",
+    source_type: "sight_sound_critics_2022",
+    source_field: "rank",
+    category: "cultural",
+    subcategory: "critics_poll",
+    normalization_type: "sigmoid",
+    normalization_params: %{"k" => 0.02, "midpoint" => 125},
+    raw_scale_min: 1.0,
+    raw_scale_max: 250.0,
+    source_reliability: 0.95,
+    active: true
+  },
+  %{
+    code: "afi_top_100",
+    name: "AFI Top 100",
+    description: "Rank in AFI's Top 100 Films",
+    source_table: "canonical_sources",
+    source_type: "afi_top_100",
+    source_field: "rank",
+    category: "cultural",
+    subcategory: "critics_poll",
+    normalization_type: "sigmoid",
+    normalization_params: %{"k" => 0.05, "midpoint" => 50},
+    raw_scale_min: 1.0,
+    raw_scale_max: 100.0,
+    source_reliability: 0.9,
+    active: true
+  },
+  %{
+    code: "bfi_top_100",
+    name: "BFI Top 100",
+    description: "Rank in BFI's Top 100 Films",
+    source_table: "canonical_sources",
+    source_type: "bfi_top_100",
+    source_field: "rank",
+    category: "cultural",
+    subcategory: "critics_poll",
+    normalization_type: "sigmoid",
+    normalization_params: %{"k" => 0.05, "midpoint" => 50},
+    raw_scale_min: 1.0,
+    raw_scale_max: 100.0,
+    source_reliability: 0.9,
+    active: true
+  }
+]
+
+# Insert all metric definitions
+now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+Enum.each(metric_definitions, fn definition ->
+  Repo.insert_all("metric_definitions", [
+    Map.merge(definition, %{
+      inserted_at: now,
+      updated_at: now
+    })
+  ])
+end)
+
+IO.puts "Inserted #{length(metric_definitions)} metric definitions"

--- a/priv/repo/seeds/metric_weight_profiles.exs
+++ b/priv/repo/seeds/metric_weight_profiles.exs
@@ -1,0 +1,207 @@
+# Seed file for metric weight profiles
+# Run with: mix run priv/repo/seeds/metric_weight_profiles.exs
+
+alias Cinegraph.Repo
+import Ecto.Query
+
+# Clear existing profiles
+Repo.delete_all(from mwp in "metric_weight_profiles")
+
+weight_profiles = [
+  %{
+    name: "Balanced",
+    description: "Equal weight across critical acclaim, cultural impact, industry recognition, and popular opinion",
+    weights: %{
+      # Critical Acclaim (25%)
+      "metacritic_metascore" => 1.0,
+      "rotten_tomatoes_tomatometer" => 1.0,
+      
+      # Popular Opinion (25%)  
+      "imdb_rating" => 1.0,
+      "tmdb_rating" => 1.0,
+      "imdb_rating_votes" => 0.5,
+      "rotten_tomatoes_audience_score" => 0.8,
+      
+      # Industry Recognition (25%)
+      "oscar_wins" => 2.0,
+      "oscar_nominations" => 1.0,
+      "cannes_palme_dor" => 1.5,
+      "venice_golden_lion" => 1.5,
+      "berlin_golden_bear" => 1.5,
+      
+      # Cultural Impact (25%)
+      "1001_movies" => 1.5,
+      "criterion" => 1.5,
+      "national_film_registry" => 1.5,
+      "sight_sound_critics_2022" => 1.5,
+      "afi_top_100" => 1.0,
+      "bfi_top_100" => 1.0,
+      
+      # Financial (included but lower weight in balanced)
+      "tmdb_revenue_worldwide" => 0.5,
+      "tmdb_budget" => 0.3
+    },
+    category_weights: %{
+      "ratings" => 1.0,
+      "awards" => 1.0,
+      "financial" => 0.5,
+      "cultural" => 1.0
+    },
+    active: true,
+    is_default: true,
+    is_system: true
+  },
+  
+  %{
+    name: "Award Winner",
+    description: "Emphasizes festival awards and industry recognition",
+    weights: %{
+      # Industry Recognition (50%)
+      "oscar_wins" => 3.0,
+      "oscar_nominations" => 2.0,
+      "cannes_palme_dor" => 2.5,
+      "venice_golden_lion" => 2.5,
+      "berlin_golden_bear" => 2.5,
+      
+      # Critical Acclaim (30%)
+      "metacritic_metascore" => 1.5,
+      "rotten_tomatoes_tomatometer" => 1.5,
+      
+      # Cultural Impact (15%)
+      "1001_movies" => 1.0,
+      "criterion" => 1.0,
+      "sight_sound_critics_2022" => 1.0,
+      
+      # Popular Opinion (5%)
+      "imdb_rating" => 0.5,
+      "tmdb_rating" => 0.5
+    },
+    category_weights: %{
+      "ratings" => 0.5,
+      "awards" => 2.0,
+      "financial" => 0.2,
+      "cultural" => 0.8
+    },
+    active: true,
+    is_default: false,
+    is_system: true
+  },
+  
+  %{
+    name: "Critics Choice",
+    description: "Prioritizes critical acclaim from professional reviewers",
+    weights: %{
+      # Critical Acclaim (50%)
+      "metacritic_metascore" => 2.5,
+      "rotten_tomatoes_tomatometer" => 2.5,
+      
+      # Cultural Impact (30%)
+      "sight_sound_critics_2022" => 2.0,
+      "criterion" => 2.0,
+      "1001_movies" => 1.5,
+      "national_film_registry" => 1.5,
+      
+      # Industry Recognition (15%)
+      "oscar_wins" => 1.0,
+      "oscar_nominations" => 0.8,
+      "cannes_palme_dor" => 1.0,
+      
+      # Popular Opinion (5%)
+      "imdb_rating" => 0.3,
+      "tmdb_rating" => 0.3
+    },
+    category_weights: %{
+      "ratings" => 1.5,  # But only critic ratings weighted high
+      "awards" => 0.8,
+      "financial" => 0.1,
+      "cultural" => 1.2
+    },
+    active: true,
+    is_default: false,
+    is_system: true
+  },
+  
+  %{
+    name: "Crowd Pleaser", 
+    description: "Focuses on popular opinion and box office success",
+    weights: %{
+      # Popular Opinion (50%)
+      "imdb_rating" => 2.5,
+      "tmdb_rating" => 2.0,
+      "imdb_rating_votes" => 1.5,
+      "rotten_tomatoes_audience_score" => 2.0,
+      
+      # Financial Success (30%)
+      "tmdb_revenue_worldwide" => 2.0,
+      "tmdb_budget" => 0.5,
+      "omdb_revenue_domestic" => 1.5,
+      
+      # Industry Recognition (15%)
+      "oscar_wins" => 0.5,
+      "oscar_nominations" => 0.3,
+      
+      # Critical Acclaim (5%)
+      "metacritic_metascore" => 0.3,
+      "rotten_tomatoes_tomatometer" => 0.3
+    },
+    category_weights: %{
+      "ratings" => 2.0,  # Audience ratings weighted high
+      "awards" => 0.3,
+      "financial" => 1.5,
+      "cultural" => 0.2
+    },
+    active: true,
+    is_default: false,
+    is_system: true
+  },
+  
+  %{
+    name: "Cult Classic",
+    description: "Finds films with dedicated followings despite mainstream metrics",
+    weights: %{
+      # Cultural Lists (40%)
+      "criterion" => 2.5,
+      "1001_movies" => 2.0,
+      "sight_sound_critics_2022" => 1.5,
+      
+      # Moderate ratings with specific engagement patterns (30%)
+      "imdb_rating" => 1.0,
+      "metacritic_metascore" => 0.8,
+      "imdb_rating_votes" => -0.5,  # Negative weight for too popular
+      
+      # Festival presence (20%)
+      "cannes_palme_dor" => 1.5,
+      "venice_golden_lion" => 1.5,
+      "berlin_golden_bear" => 1.5,
+      
+      # Low financial success (10%)
+      "tmdb_revenue_worldwide" => -0.3,  # Negative weight for blockbusters
+      "tmdb_budget" => -0.2
+    },
+    category_weights: %{
+      "ratings" => 0.8,
+      "awards" => 0.6,
+      "financial" => -0.2,  # Penalize high revenue
+      "cultural" => 2.0
+    },
+    active: true,
+    is_default: false,
+    is_system: true
+  }
+]
+
+# Insert all weight profiles
+now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+Enum.each(weight_profiles, fn profile ->
+  Repo.insert_all("metric_weight_profiles", [
+    Map.merge(profile, %{
+      usage_count: 0,
+      last_used_at: nil,
+      inserted_at: now,
+      updated_at: now
+    })
+  ])
+end)
+
+IO.puts "Inserted #{length(weight_profiles)} metric weight profiles"

--- a/scripts/clear_database.sh
+++ b/scripts/clear_database.sh
@@ -14,9 +14,6 @@ NC='\033[0m' # No Color
 # Load environment variables
 source .env
 
-echo -e "${YELLOW}🗑️  Clearing all data from Cinegraph database...${NC}"
-echo ""
-
 # Extract connection details from DATABASE_URL
 if [[ -z "$SUPABASE_DATABASE_URL" ]]; then
     echo -e "${RED}Error: SUPABASE_DATABASE_URL not found in .env${NC}"
@@ -43,7 +40,20 @@ if [[ -z "$DB_HOST" || -z "$DB_PORT" || -z "$DB_NAME" || -z "$DB_USER" ]]; then
     exit 1
 fi
 
+echo -e "${RED}⚠️  WARNING: This will permanently delete ALL data from the Cinegraph database!${NC}"
+echo -e "${YELLOW}This includes movies, people, collaborations, festivals, and all other data.${NC}"
+echo ""
 echo "Database: $DB_NAME on $DB_HOST:$DB_PORT"
+echo ""
+echo "Are you sure you want to continue? This action cannot be undone."
+echo "Type 'yes' to proceed or anything else to cancel:"
+read -r confirmation
+
+if [[ "$confirmation" != "yes" ]]; then
+    echo -e "${GREEN}Cancelled. Database was not modified.${NC}"
+    exit 0
+fi
+
 echo ""
 
 # First, try to terminate any active connections (this might fail but that's OK)


### PR DESCRIPTION
### TL;DR

Implemented a database-driven movie scoring system with customizable weight profiles to replace the hard-coded discovery scoring system.

### What changed?

- Created new schemas for metric definitions, weight profiles, and scoring
- Added a flexible `ScoringService` module to calculate movie scores using database-driven weights
- Updated the discovery tuner UI to use database profiles instead of hard-coded presets
- Added database migrations and seed files for metric definitions and weight profiles
- Added an Oban queue for CRI (Cinematic Relevance Index) calculation jobs
- Enhanced the movie discovery UI with better explanations and profile information

### How to test?

1. Run migrations to create the new tables
2. Seed the database with metric definitions and weight profiles
3. Visit the movie discovery page to see the new database-driven scoring system
4. Try different weight profiles and observe how movie rankings change
5. Check that the UI shows which database profile is being used

### Why make this change?

The previous hard-coded scoring system was inflexible and difficult to maintain. This database-driven approach allows:

1. Easy creation and modification of scoring profiles without code changes
2. Better transparency about how scores are calculated
3. More sophisticated normalization of different metrics
4. Categorization of metrics into logical groups (ratings, awards, financial, cultural)
5. Future extensibility for user-created custom profiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Discovery scoring now supports database-backed weight profiles with selectable presets and custom weights.
  - Discovery Tuner shows the active profile, allows live weight adjustments, and includes a help panel for Minimum Score Threshold.
  - Added a movie metrics page at /movies/:id/metrics.

- Chores
  - Introduced a metrics system with normalization, views, and seed data for metric definitions and weight profiles.
  - Added a new background job queue for metric calculations.
  - Made the database clear script safer with an interactive confirmation prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->