### PR TITLE
fixes for code rabbit

### DIFF
--- a/lib/cinegraph/metrics/normalization_helper.ex
+++ b/lib/cinegraph/metrics/normalization_helper.ex
@@ -1,0 +1,139 @@
+defmodule Cinegraph.Metrics.NormalizationHelper do
+  @moduledoc """
+  Centralized normalization functions for metrics across the application.
+  Provides consistent normalization strategies aligned with the metrics system documentation.
+  """
+
+  @doc """
+  Returns the SQL fragment for normalizing TMDb popularity score using logarithmic normalization.
+  This follows the documented approach: log(x+1)/log(threshold+1)
+  
+  ## Parameters
+    - threshold: The threshold value for normalization (default: 1000 as per metric_definitions)
+  
+  ## Example
+      fragment(NormalizationHelper.tmdb_popularity_sql(), ^movie_id)
+  """
+  def tmdb_popularity_sql(_threshold \\ 1000) do
+    """
+    COALESCE(
+      (SELECT CASE 
+        WHEN value IS NULL OR value = 0 THEN 0
+        ELSE LN(value + 1) / LN(? + 1)
+      END
+      FROM external_metrics 
+      WHERE movie_id = ? 
+        AND source = 'tmdb' 
+        AND metric_type = 'popularity_score' 
+      LIMIT 1), 
+      0
+    )
+    """
+  end
+
+  @doc """
+  Returns the SQL fragment for calculating canonical sources impact.
+  Uses a configurable weight multiplier for each canonical source.
+  
+  ## Parameters
+    - weight: The weight multiplier for each canonical source (default: 0.1)
+  """
+  def canonical_sources_sql(_weight \\ 0.1) do
+    """
+    COALESCE(
+      (SELECT COUNT(*) * ?
+       FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 
+      0
+    )
+    """
+  end
+
+  @doc """
+  Returns the complete SQL fragment for cultural impact calculation.
+  Combines TMDb popularity (log-normalized) and canonical sources presence.
+  
+  ## Parameters
+    - canonical_weight: Weight for canonical sources (default: 0.1)
+    - popularity_threshold: Threshold for TMDb popularity normalization (default: 1000)
+    - max_value: Maximum value cap for the result (default: 1.0)
+  """
+  def cultural_impact_sql(opts \\ []) do
+    canonical_weight = Keyword.get(opts, :canonical_weight, 0.1)
+    popularity_threshold = Keyword.get(opts, :popularity_threshold, 1000)
+    max_value = Keyword.get(opts, :max_value, 1.0)
+    
+    """
+    COALESCE(
+      LEAST(#{max_value}, 
+        COALESCE(
+          (SELECT COUNT(*) * #{canonical_weight}
+           FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 
+          0
+        ) + 
+        COALESCE(
+          (SELECT CASE 
+            WHEN value IS NULL OR value = 0 THEN 0
+            ELSE LN(value + 1) / LN(#{popularity_threshold} + 1)
+          END
+          FROM external_metrics 
+          WHERE movie_id = ? 
+            AND source = 'tmdb' 
+            AND metric_type = 'popularity_score' 
+          LIMIT 1), 
+          0
+        )
+      ), 
+      0
+    )
+    """
+  end
+
+  @doc """
+  Normalizes a value using logarithmic normalization.
+  Formula: log(value + 1) / log(threshold + 1)
+  
+  ## Examples
+      iex> NormalizationHelper.logarithmic_normalize(100, 1000)
+      0.6648
+      
+      iex> NormalizationHelper.logarithmic_normalize(1000, 1000)
+      1.0
+      
+      iex> NormalizationHelper.logarithmic_normalize(0, 1000)
+      0.0
+  """
+  def logarithmic_normalize(value, threshold) when is_number(value) and is_number(threshold) and threshold > 0 do
+    if value <= 0 do
+      0.0
+    else
+      :math.log(value + 1) / :math.log(threshold + 1)
+    end
+  end
+
+  @doc """
+  Normalizes a value using linear normalization.
+  Formula: value / max_value
+  
+  ## Examples
+      iex> NormalizationHelper.linear_normalize(50, 100)
+      0.5
+      
+      iex> NormalizationHelper.linear_normalize(100, 100)
+      1.0
+  """
+  def linear_normalize(value, max_value) when is_number(value) and is_number(max_value) and max_value > 0 do
+    min(value / max_value, 1.0)
+  end
+
+  @doc """
+  Configuration for cultural impact weights.
+  Can be overridden via application config.
+  """
+  def cultural_impact_config do
+    %{
+      canonical_weight: Application.get_env(:cinegraph, :canonical_weight, 0.1),
+      popularity_threshold: Application.get_env(:cinegraph, :popularity_threshold, 1000),
+      max_value: Application.get_env(:cinegraph, :max_cap, 1.0)
+    }
+  end
+end

--- a/lib/cinegraph/movies/discovery_scoring_simple.ex
+++ b/lib/cinegraph/movies/discovery_scoring_simple.ex
@@ -86,7 +86,7 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
       %{
         discovery_score:
           fragment(
-            "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+            "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
             ^normalized_weights.popular_opinion,
             tr.value,
             ir.value,
@@ -98,6 +98,7 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
             f.nominations,
             ^normalized_weights.cultural_impact,
             m.canonical_sources,
+            pop.value,
             pop.value
           ),
         score_components: %{
@@ -121,8 +122,9 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
             ),
           cultural_impact:
             fragment(
-              "COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+              "COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
               m.canonical_sources,
+              pop.value,
               pop.value
             )
         }
@@ -139,7 +141,7 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
         festivals: f
       ],
       fragment(
-        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0) >= ?",
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) >= ?",
         ^normalized_weights.popular_opinion,
         tr.value,
         ir.value,
@@ -151,6 +153,7 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
         f.nominations,
         ^normalized_weights.cultural_impact,
         m.canonical_sources,
+        pop.value,
         pop.value,
         ^min_score
       )
@@ -167,7 +170,7 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
       ],
       desc:
         fragment(
-          "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + COALESCE(?, 0) / 1000.0), 0)",
+          "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
           ^normalized_weights.popular_opinion,
           tr.value,
           ir.value,
@@ -179,6 +182,7 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
           f.nominations,
           ^normalized_weights.cultural_impact,
           m.canonical_sources,
+          pop.value,
           pop.value
         )
     )

--- a/test/cinegraph/metrics/normalization_helper_test.exs
+++ b/test/cinegraph/metrics/normalization_helper_test.exs
@@ -1,0 +1,135 @@
+defmodule Cinegraph.Metrics.NormalizationHelperTest do
+  use ExUnit.Case, async: true
+  alias Cinegraph.Metrics.NormalizationHelper
+  
+  describe "logarithmic_normalize/2" do
+    test "returns 0 for zero input" do
+      assert NormalizationHelper.logarithmic_normalize(0, 1000) == 0.0
+    end
+    
+    test "returns 0 for negative input" do
+      assert NormalizationHelper.logarithmic_normalize(-10, 1000) == 0.0
+    end
+    
+    test "returns 1.0 for input equal to threshold" do
+      result = NormalizationHelper.logarithmic_normalize(1000, 1000)
+      assert_in_delta(result, 1.0, 0.001)
+    end
+    
+    test "returns value between 0 and 1 for input less than threshold" do
+      result = NormalizationHelper.logarithmic_normalize(100, 1000)
+      assert result > 0.0
+      assert result < 1.0
+      # Expected value: ln(101)/ln(1001) ≈ 0.6655
+      assert_in_delta(result, 0.6655, 0.001)
+    end
+    
+    test "returns value greater than 1 for input greater than threshold" do
+      result = NormalizationHelper.logarithmic_normalize(5000, 1000)
+      assert result > 1.0
+    end
+    
+    test "normalizes TMDb popularity values correctly" do
+      # Common TMDb popularity values
+      assert_in_delta(NormalizationHelper.logarithmic_normalize(10, 1000), 0.3320, 0.001)
+      assert_in_delta(NormalizationHelper.logarithmic_normalize(50, 1000), 0.5639, 0.001)
+      assert_in_delta(NormalizationHelper.logarithmic_normalize(100, 1000), 0.6655, 0.001)
+      assert_in_delta(NormalizationHelper.logarithmic_normalize(500, 1000), 0.8988, 0.001)
+    end
+  end
+  
+  describe "linear_normalize/2" do
+    test "returns 0 for zero input" do
+      assert NormalizationHelper.linear_normalize(0, 100) == 0.0
+    end
+    
+    test "returns 0.5 for input half of max" do
+      assert NormalizationHelper.linear_normalize(50, 100) == 0.5
+    end
+    
+    test "returns 1.0 for input equal to max" do
+      assert NormalizationHelper.linear_normalize(100, 100) == 1.0
+    end
+    
+    test "caps at 1.0 for input greater than max" do
+      assert NormalizationHelper.linear_normalize(200, 100) == 1.0
+    end
+  end
+  
+  describe "tmdb_popularity_sql/1" do
+    test "generates SQL with default threshold" do
+      sql = NormalizationHelper.tmdb_popularity_sql()
+      assert String.contains?(sql, "LN(value + 1) / LN(? + 1)")
+      assert String.contains?(sql, "tmdb")
+      assert String.contains?(sql, "popularity_score")
+    end
+    
+    test "generates SQL with custom threshold" do
+      sql = NormalizationHelper.tmdb_popularity_sql(5000)
+      assert String.contains?(sql, "LN(value + 1) / LN(? + 1)")
+    end
+  end
+  
+  describe "canonical_sources_sql/1" do
+    test "generates SQL with default weight" do
+      sql = NormalizationHelper.canonical_sources_sql()
+      assert String.contains?(sql, "COUNT(*) * ?")
+      assert String.contains?(sql, "jsonb_each")
+    end
+    
+    test "generates SQL with custom weight" do
+      sql = NormalizationHelper.canonical_sources_sql(0.2)
+      assert String.contains?(sql, "COUNT(*) * ?")
+    end
+  end
+  
+  describe "cultural_impact_sql/1" do
+    test "generates complete cultural impact SQL with defaults" do
+      sql = NormalizationHelper.cultural_impact_sql()
+      assert String.contains?(sql, "LN(value + 1) / LN(1000 + 1)")
+      assert String.contains?(sql, "COUNT(*) * 0.1")
+      assert String.contains?(sql, "LEAST(1.0")
+    end
+    
+    test "generates SQL with custom parameters" do
+      sql = NormalizationHelper.cultural_impact_sql(
+        canonical_weight: 0.2,
+        popularity_threshold: 5000,
+        max_value: 2.0
+      )
+      assert String.contains?(sql, "LN(value + 1) / LN(5000 + 1)")
+      assert String.contains?(sql, "COUNT(*) * 0.2")
+      assert String.contains?(sql, "LEAST(2.0")
+    end
+  end
+  
+  describe "cultural_impact_config/0" do
+    test "returns default configuration" do
+      config = NormalizationHelper.cultural_impact_config()
+      assert config.canonical_weight == 0.1
+      assert config.popularity_threshold == 1000
+      assert config.max_value == 1.0
+    end
+  end
+  
+  describe "comparison with linear normalization" do
+    test "logarithmic normalization produces more gradual scaling than linear" do
+      # For TMDb popularity, logarithmic scaling should compress high values
+      # and expand low-to-mid values compared to linear scaling
+      
+      values = [1, 10, 50, 100, 500, 1000]
+      threshold = 1000
+      
+      for value <- values do
+        log_result = NormalizationHelper.logarithmic_normalize(value, threshold)
+        linear_result = NormalizationHelper.linear_normalize(value, threshold)
+        
+        if value < 100 do
+          # For small values, log normalization should give higher results
+          assert log_result > linear_result,
+                 "Expected log(#{value}) > linear(#{value}), got #{log_result} <= #{linear_result}"
+        end
+      end
+    end
+  end
+end

--- a/test/cinegraph/metrics/scoring_service_test.exs
+++ b/test/cinegraph/metrics/scoring_service_test.exs
@@ -1,0 +1,102 @@
+defmodule Cinegraph.Metrics.ScoringServiceTest do
+  use Cinegraph.DataCase, async: true
+  alias Cinegraph.Metrics.{ScoringService, MetricWeightProfile}
+
+  describe "profile_to_discovery_weights/1" do
+    test "correctly splits ratings weight 50/50 between popular and critical" do
+      profile = %MetricWeightProfile{
+        name: "Test Profile",
+        category_weights: %{
+          "ratings" => 0.60,
+          "awards" => 0.20,
+          "cultural" => 0.20,
+          "financial" => 0.00
+        }
+      }
+      
+      result = ScoringService.profile_to_discovery_weights(profile)
+      
+      # Ratings weight should be split evenly
+      assert result.popular_opinion == 0.30
+      assert result.critical_acclaim == 0.30
+      
+      # Other weights should pass through
+      assert result.industry_recognition == 0.20
+      assert result.cultural_impact == 0.20
+    end
+    
+    test "folds financial weight into cultural impact" do
+      profile = %MetricWeightProfile{
+        name: "Test Profile",
+        category_weights: %{
+          "ratings" => 0.40,
+          "awards" => 0.20,
+          "cultural" => 0.30,
+          "financial" => 0.10
+        }
+      }
+      
+      result = ScoringService.profile_to_discovery_weights(profile)
+      
+      # Ratings weight should be split evenly
+      assert result.popular_opinion == 0.20
+      assert result.critical_acclaim == 0.20
+      
+      # Awards weight should pass through
+      assert result.industry_recognition == 0.20
+      
+      # Cultural impact should include half of financial weight
+      # cultural (0.30) + financial (0.10) * 0.5 = 0.35
+      assert result.cultural_impact == 0.35
+    end
+    
+    test "uses default weights when categories are missing" do
+      profile = %MetricWeightProfile{
+        name: "Empty Profile",
+        category_weights: %{}
+      }
+      
+      result = ScoringService.profile_to_discovery_weights(profile)
+      
+      # Should use defaults: ratings=0.5, awards=0.25, cultural=0.25
+      assert result.popular_opinion == 0.25  # 0.5 * 0.5
+      assert result.critical_acclaim == 0.25  # 0.5 * 0.5
+      assert result.industry_recognition == 0.25
+      assert result.cultural_impact == 0.25
+    end
+    
+    test "handles nil category_weights gracefully" do
+      profile = %MetricWeightProfile{
+        name: "Nil Profile",
+        category_weights: nil
+      }
+      
+      result = ScoringService.profile_to_discovery_weights(profile)
+      
+      # Should use defaults
+      assert result.popular_opinion == 0.25
+      assert result.critical_acclaim == 0.25
+      assert result.industry_recognition == 0.25
+      assert result.cultural_impact == 0.25
+    end
+  end
+  
+  describe "discovery_weights_to_profile/2" do
+    test "converts discovery weights back to profile format" do
+      weights = %{
+        popular_opinion: 0.30,
+        critical_acclaim: 0.20,
+        industry_recognition: 0.25,
+        cultural_impact: 0.25
+      }
+      
+      result = ScoringService.discovery_weights_to_profile(weights, "Custom Test")
+      
+      assert result.name == "Custom Test"
+      # Note: Current implementation only uses popular_opinion for ratings
+      assert result.category_weights["ratings"] == 0.30
+      assert result.category_weights["awards"] == 0.25
+      assert result.category_weights["cultural"] == 0.25
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Implemented logarithmic normalization for TMDb popularity scores to improve cultural impact calculations.

### What changed?

- Created a new `NormalizationHelper` module to centralize normalization functions
- Replaced linear normalization (value/1000) with logarithmic normalization (ln(value+1)/ln(threshold+1)) for TMDb popularity scores
- Updated SQL fragments in `ScoringService`, `DiscoveryScoring`, `DiscoveryScoringSimple`, and `Filters` modules
- Modified `profile_to_discovery_weights` to fold financial weight into cultural impact
- Updated metric weight profiles in seeds to better align with the new normalization approach
- Added comprehensive tests for the new normalization functions

### How to test?

1. Run the test suite to verify the new normalization functions work correctly
2. Compare movie discovery scores before and after the change - movies with moderate popularity should see improved cultural impact scores
3. Verify that the logarithmic normalization produces more gradual scaling than linear normalization
4. Check that financial metrics now properly contribute to cultural impact scores

### Why make this change?

Linear normalization (value/1000) was giving too much weight to extremely popular movies while undervaluing moderately popular ones. Logarithmic normalization provides a more balanced approach by:

1. Compressing the range of very high popularity values
2. Expanding the range of low-to-mid popularity values
3. Creating a more natural distribution that better reflects real-world cultural impact
4. Ensuring that movies with moderate popularity still receive meaningful cultural impact scores

This change aligns with the metrics system documentation and provides a more accurate representation of a movie's cultural significance.