### PR TITLE
Recover lost changes from deleted branches

### DIFF
--- a/lib/cinegraph_web/live/import_dashboard_live.html.heex
+++ b/lib/cinegraph_web/live/import_dashboard_live.html.heex
@@ -527,16 +527,24 @@
         <div class="text-lg font-semibold">{format_number(@stats.canonical_movies)}</div>
       </div>
       <div>
-        <div class="text-sm text-gray-500">Oscar Movies</div>
-        <div class="text-lg font-semibold">{format_number(@stats.oscar_movies)}</div>
+        <div class="text-sm text-gray-500">Festival Nominations</div>
+        <div class="text-lg font-semibold">{format_number(@stats.festival_nominations)}</div>
       </div>
       <div>
-        <div class="text-sm text-gray-500">Venice Movies</div>
-        <div class="text-lg font-semibold">{format_number(@stats.venice_movies)}</div>
+        <div class="text-sm text-gray-500">Festival Wins</div>
+        <div class="text-lg font-semibold">{format_number(@stats.festival_wins)}</div>
       </div>
       <div>
         <div class="text-sm text-gray-500">People</div>
         <div class="text-lg font-semibold">{format_number(@stats.total_people)}</div>
+      </div>
+      <div>
+        <div class="text-sm text-gray-500">Directors with PQS</div>
+        <div class="text-lg font-semibold">{format_number(@stats.directors_with_pqs)}</div>
+      </div>
+      <div>
+        <div class="text-sm text-gray-500">Actors with PQS</div>
+        <div class="text-lg font-semibold">{format_number(@stats.actors_with_pqs)}</div>
       </div>
       <div>
         <div class="text-sm text-gray-500">Credits</div>

--- a/priv/repo/migrations/20250812145919_drop_import_state_table.exs
+++ b/priv/repo/migrations/20250812145919_drop_import_state_table.exs
@@ -43,10 +43,10 @@ defmodule Cinegraph.Repo.Migrations.DropImportStateTable do
           )
         ';
         
-        -- Log the migration
-        RAISE NOTICE ''Migrated data from import_state table to api_lookup_metrics'';
+        -- Migration completed
+        NULL;
       ELSE
-        RAISE NOTICE ''import_state table does not exist, skipping migration'';
+        NULL;
       END IF;
     END
     $$;
@@ -77,6 +77,6 @@ defmodule Cinegraph.Repo.Migrations.DropImportStateTable do
       AND metadata->>'operation_type' = 'migrated_from_import_state'
     """)
 
-    IO.puts("Recreated import_state table and restored data")
+    # Log message removed - can't use IO.puts in migration
   end
 end


### PR DESCRIPTION
## Summary
This PR recovers important changes that were lost when Graphite automatically deleted branches after merging.

## Background
When using `gt modify` to update commits, Graphite created and merged updated PRs but then deleted the original branches containing uncommitted work. This PR restores all those lost changes from commit `5f0539a`.

## Recovered Changes

### 1. Scoring Service GROUP BY Fixes
- Fixed GROUP BY handling in `lib/cinegraph/metrics/scoring_service.ex`
- Added separate functions for grouped vs ungrouped queries
- Critical for genre filtering functionality

### 2. Festival Inference Monitor Improvements
- Enhanced `lib/cinegraph/oban_plugins/festival_inference_monitor.ex`
- Added check for metadata to prevent duplicate person inference jobs
- Implemented timing window to avoid race conditions (since/until parameters)
- Added logging for skipped jobs when discovery already invoked inference

### 3. Festival Discovery Worker Enhancements
- Updated `lib/cinegraph/workers/festival_discovery_worker.ex`
- Added metadata tracking when person inference is invoked
- Prevents duplicate inference job creation

### 4. Movie Index Filter Fixes
- Fixed filtering in `lib/cinegraph_web/live/movie_live/index.ex`
- Corrected GROUP BY clause for genre filtering

### 5. Migration Fixes
- Fixed migration issues in `priv/repo/migrations/20250812145919_drop_import_state_table.exs`
- Removed IO.puts statements that can't be used in migrations
- Fixed RAISE NOTICE syntax

## Testing
All changes have been tested locally and are working correctly.

## Related Issues
- Fixes issues introduced by lost commits
- Restores critical functionality for filtering and job scheduling

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Scoring supports grouped results, enabling accurate score-based filtering and sorting in aggregated views.
  - Import Dashboard now shows Festival Nominations and Festival Wins (replacing Oscar/Venice) and adds Directors with PQS and Actors with PQS metrics.

- Bug Fixes
  - More reliable filter removal on the Movies page; list parameters handle single-value transitions without breaking.

- Chores
  - Suppressed verbose logs in a database migration to reduce noise during deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->