### PR TITLE
fixing code rabbits

### DIFF
--- a/lib/cinegraph/collaborations.ex
+++ b/lib/cinegraph/collaborations.ex
@@ -484,7 +484,7 @@ defmodule Cinegraph.Collaborations do
         acc_count + batch_new_count
       end)
 
-    total_collaborations = Repo.aggregate(Collaboration, :count)
+    total_collaborations = Repo.aggregate(Collaboration, :count, :id)
     IO.puts("✓ Created #{total_collaborations} collaborations")
 
     {:ok, total_collaborations}

--- a/lib/cinegraph/imports/import_stats.ex
+++ b/lib/cinegraph/imports/import_stats.ex
@@ -79,7 +79,7 @@ defmodule Cinegraph.Imports.ImportStats do
 
   defp update_import_stats do
     current_time = DateTime.utc_now()
-    current_movie_count = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count)
+    current_movie_count = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count, :id)
 
     prev_stats =
       case :ets.lookup(@table_name, :current_stats) do
@@ -128,7 +128,8 @@ defmodule Cinegraph.Imports.ImportStats do
       from(j in Oban.Job,
         where: j.queue == ^queue_name and j.state in ["available", "executing"]
       ),
-      :count
+      :count,
+      :id
     )
   end
 
@@ -141,19 +142,22 @@ defmodule Cinegraph.Imports.ImportStats do
       available =
         Cinegraph.Repo.aggregate(
           from(j in Oban.Job, where: j.queue == ^queue and j.state == "available"),
-          :count
+          :count,
+          :id
         )
 
       executing =
         Cinegraph.Repo.aggregate(
           from(j in Oban.Job, where: j.queue == ^queue and j.state == "executing"),
-          :count
+          :count,
+          :id
         )
 
       completed =
         Cinegraph.Repo.aggregate(
           from(j in Oban.Job, where: j.queue == ^queue and j.state == "completed"),
-          :count
+          :count,
+          :id
         )
 
       %{

--- a/lib/cinegraph/imports/tmdb_importer.ex
+++ b/lib/cinegraph/imports/tmdb_importer.ex
@@ -218,7 +218,7 @@ defmodule Cinegraph.Imports.TMDbImporter do
   # Private functions
 
   defp count_our_movies do
-    Repo.aggregate(Movies.Movie, :count)
+    Repo.aggregate(Movies.Movie, :count, :id)
   end
 
   defp calculate_discovery_delay(page_position) do

--- a/lib/cinegraph/movie_importer.ex
+++ b/lib/cinegraph/movie_importer.ex
@@ -92,7 +92,7 @@ defmodule Cinegraph.MovieImporter do
   Get a summary of API data coverage across all movies.
   """
   def get_api_coverage_summary do
-    total_movies = Repo.aggregate(Movie, :count)
+    total_movies = Repo.aggregate(Movie, :count, :id)
 
     coverage =
       Enum.map(@default_apis, fn api ->

--- a/lib/cinegraph_web/components/person_autocomplete.ex
+++ b/lib/cinegraph_web/components/person_autocomplete.ex
@@ -39,7 +39,7 @@ defmodule CinegraphWeb.Components.PersonAutocomplete do
           if map_size(updated_cache) > 50 do
             # Remove oldest entries
             updated_cache
-            |> Enum.sort_by(fn {_k, v} -> v.timestamp end, DateTime)
+            |> Enum.sort_by(fn {_k, v} -> v.timestamp end, {:asc, DateTime})
             |> Enum.drop(10)
             |> Map.new()
           else

--- a/lib/cinegraph_web/live/import_dashboard_live.ex
+++ b/lib/cinegraph_web/live/import_dashboard_live.ex
@@ -783,19 +783,19 @@ defmodule CinegraphWeb.ImportDashboardLive do
 
     # Get database stats
     stats = %{
-      total_movies: Repo.aggregate(Movie, :count),
-      movies_with_tmdb: Repo.aggregate(from(m in Movie, where: not is_nil(m.tmdb_data)), :count),
-      movies_with_omdb: Repo.aggregate(from(m in Movie, where: not is_nil(m.omdb_data)), :count),
+      total_movies: Repo.aggregate(Movie, :count, :id),
+      movies_with_tmdb: Repo.aggregate(from(m in Movie, where: not is_nil(m.tmdb_data)), :count, :id),
+      movies_with_omdb: Repo.aggregate(from(m in Movie, where: not is_nil(m.omdb_data)), :count, :id),
       canonical_movies: get_canonical_movies_count(),
       festival_nominations: get_festival_nominations_count(),
       festival_wins: get_festival_wins_count(),
-      total_people: Repo.aggregate(Cinegraph.Movies.Person, :count),
+      total_people: Repo.aggregate(Cinegraph.Movies.Person, :count, :id),
       directors_with_pqs: get_directors_with_pqs_count(),
       actors_with_pqs: get_actors_with_pqs_count(),
-      total_credits: Repo.aggregate(Cinegraph.Movies.Credit, :count),
-      total_genres: Repo.aggregate(Cinegraph.Movies.Genre, :count),
-      total_keywords: Repo.aggregate(Cinegraph.Movies.Keyword, :count),
-      unique_collaborations: Repo.aggregate(Cinegraph.Collaborations.Collaboration, :count),
+      total_credits: Repo.aggregate(Cinegraph.Movies.Credit, :count, :id),
+      total_genres: Repo.aggregate(Cinegraph.Movies.Genre, :count, :id),
+      total_keywords: Repo.aggregate(Cinegraph.Movies.Keyword, :count, :id),
+      unique_collaborations: Repo.aggregate(Cinegraph.Collaborations.Collaboration, :count, :id),
       multi_collaborations:
         Repo.aggregate(
           from(c in Cinegraph.Collaborations.Collaboration, where: c.collaboration_count > 1),

--- a/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
+++ b/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
@@ -108,9 +108,14 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
             nil ->
               # Fallback to presets if not in database
               # Try both string and atom keys since DB returns string keys
+              # Avoid creating new atoms from user input
               weights =
-                Map.get(socket.assigns.presets, preset_name) ||
-                  Map.get(socket.assigns.presets, String.to_atom(preset_name))
+                case Enum.find(Map.keys(socket.assigns.presets), fn k -> 
+                  to_string(k) == preset_name 
+                end) do
+                  nil -> Map.get(socket.assigns.presets, preset_name) # fallback if string keys exist
+                  atom_key -> Map.get(socket.assigns.presets, atom_key)
+                end
 
               {weights, nil}
 

--- a/lib/cinegraph_web/live/movie_live/index.html.heex
+++ b/lib/cinegraph_web/live/movie_live/index.html.heex
@@ -136,7 +136,7 @@
           <% else %>
             Show Advanced Filters
           <% end %>
-          <%= if AdvancedFilters.has_active_advanced_filters(@filters) do %>
+          <%= if AdvancedFilters.has_active_advanced_filters(@params) do %>
             <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
               Active
             </span>

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -691,7 +691,7 @@
                     <div class="flex flex-wrap gap-2">
                       <%= if list_item.rank do %>
                         <span class="inline-flex items-center px-2 py-1 rounded text-sm bg-yellow-100 text-yellow-800">
-                          #{list_item.rank}
+                          {list_item.rank}
                         </span>
                       <% end %>
 

--- a/lib/cinegraph_web/live/movie_live/show_legacy.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show_legacy.html.heex
@@ -440,7 +440,7 @@
                     <div class="mt-1 flex flex-wrap gap-1">
                       <%= if list_item.rank do %>
                         <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-yellow-100 text-yellow-800">
-                          #{list_item.rank}
+                          {list_item.rank}
                         </span>
                       <% end %>
 

--- a/lib/mix/tasks/import_movies.ex
+++ b/lib/mix/tasks/import_movies.ex
@@ -298,12 +298,13 @@ defmodule Mix.Tasks.ImportMovies do
     Mix.shell().info("\n📊 Import Summary:")
 
     try do
-      movies = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count)
-      keywords = Cinegraph.Repo.aggregate(Cinegraph.Movies.Keyword, :count)
-      videos = Cinegraph.Repo.aggregate(Cinegraph.Movies.MovieVideo, :count)
-      credits = Cinegraph.Repo.aggregate(Cinegraph.Movies.Credit, :count)
-      people = Cinegraph.Repo.aggregate(Cinegraph.Movies.Person, :count)
-      ratings = Cinegraph.Repo.aggregate(Cinegraph.ExternalSources.Rating, :count)
+      movies = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count, :id)
+      keywords = Cinegraph.Repo.aggregate(Cinegraph.Movies.Keyword, :count, :id)
+      videos = Cinegraph.Repo.aggregate(Cinegraph.Movies.MovieVideo, :count, :id)
+      credits = Cinegraph.Repo.aggregate(Cinegraph.Movies.Credit, :count, :id)
+      people = Cinegraph.Repo.aggregate(Cinegraph.Movies.Person, :count, :id)
+      # Note: ExternalSources.Rating is deprecated, using 0 for now
+      ratings = 0
 
       Mix.shell().info("  Movies: #{movies}")
       Mix.shell().info("  People: #{people}")


### PR DESCRIPTION
### TL;DR

Fixed Ecto aggregate queries by adding required `:id` field parameter to all `:count` aggregations.

### What changed?

- Added the required `:id` field parameter to all `Repo.aggregate(..., :count)` calls throughout the codebase
- Fixed string interpolation in templates by changing `#{list_item.rank}` to `{list_item.rank}`
- Improved preset handling in `DiscoveryTuner` to avoid creating atoms from user input
- Fixed `AdvancedFilters.has_active_advanced_filters/1` call to use `@params` instead of `@filters`
- Updated person autocomplete cache sorting to use explicit `{:asc, DateTime}` tuple

### How to test?

1. Run the application and verify that all pages that display counts (dashboard, import stats, etc.) work correctly
2. Test the movie show page to ensure ranks display properly
3. Verify that the advanced filters toggle shows the "Active" indicator correctly
4. Test the person autocomplete to ensure it properly manages its cache

### Why make this change?

Ecto v3.10+ requires specifying a field name when using aggregate functions like `:count`. This change ensures compatibility with newer Ecto versions by adding the `:id` field parameter to all count aggregations. Additionally, several minor template and function call issues were fixed to improve stability and prevent potential runtime errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
    - Correctly display Cultural List ranks on movie pages.
    - Advanced Filters badge now reflects activity based on request parameters for more accurate status.
    - Improved autocomplete cache eviction ordering for more consistent suggestions.
- Security
    - Avoids creating atoms from user input in preset selection, improving safety and stability.
- Refactor
    - Standardized database counts to use explicit ID-based aggregation across stats and dashboards.
- Chores
    - Removed deprecated ratings count from import summary (now shown as 0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->