### PR TITLE
more rabbitz the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Watch the import progress at http://localhost:4001/imports or check in IEx:
 Cinegraph.Imports.TMDbImporter.get_import_status()
 
 # Get current movie count
-Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count)
+Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count, :id)
 ```
 
 ##### Recommendations

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -556,7 +556,7 @@ defmodule Cinegraph.Movies do
   """
   def count_canonical_movies(source_key) do
     from(m in Movie, where: fragment("? \\? ?", m.canonical_sources, ^source_key))
-    |> Repo.aggregate(:count)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """
@@ -564,7 +564,7 @@ defmodule Cinegraph.Movies do
   """
   def count_any_canonical_movies do
     from(m in Movie, where: m.canonical_sources != ^%{})
-    |> Repo.aggregate(:count)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """

--- a/lib/cinegraph/movies/query/params.ex
+++ b/lib/cinegraph/movies/query/params.ex
@@ -250,9 +250,19 @@ defmodule Cinegraph.Movies.Query.Params do
 
     Enum.reduce(enum_fields, params, fn f, acc ->
       case Map.get(acc, f) do
-        "" -> Map.delete(acc, f)
-        v when is_binary(v) -> Map.put(acc, f, String.trim(v))
-        _ -> acc
+        nil ->
+          acc
+
+        v when is_binary(v) ->
+          trimmed = String.trim(v)
+          if trimmed == "" do
+            Map.delete(acc, f)
+          else
+            Map.put(acc, f, trimmed)
+          end
+
+        _ ->
+          acc
       end
     end)
   end

--- a/lib/cinegraph/movies/search.ex
+++ b/lib/cinegraph/movies/search.ex
@@ -8,7 +8,6 @@ defmodule Cinegraph.Movies.Search do
   alias Cinegraph.Repo
   alias Cinegraph.Movies.Movie
   alias Cinegraph.Movies.Query.{Params, CustomFilters, CustomSorting}
-  alias Cinegraph.Metrics.ScoringService
 
   @doc """
   Search movies with validated parameters.

--- a/scripts/reset_and_populate.exs
+++ b/scripts/reset_and_populate.exs
@@ -85,11 +85,11 @@ defmodule ResetAndPopulate do
     
     # Only try to query if app is started and not in dry run
     try do
-      movies = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count)
-      keywords = Cinegraph.Repo.aggregate(Cinegraph.Movies.Keyword, :count)
-      videos = Cinegraph.Repo.aggregate(Cinegraph.Movies.MovieVideo, :count)
-      credits = Cinegraph.Repo.aggregate(Cinegraph.Movies.Credit, :count)
-      ratings = Cinegraph.Repo.aggregate(Cinegraph.ExternalSources.Rating, :count)
+      movies = Cinegraph.Repo.aggregate(Cinegraph.Movies.Movie, :count, :id)
+      keywords = Cinegraph.Repo.aggregate(Cinegraph.Movies.Keyword, :count, :id)
+      videos = Cinegraph.Repo.aggregate(Cinegraph.Movies.MovieVideo, :count, :id)
+      credits = Cinegraph.Repo.aggregate(Cinegraph.Movies.Credit, :count, :id)
+      ratings = Cinegraph.Repo.aggregate(Cinegraph.ExternalSources.Rating, :count, :id)
       
       IO.puts("  Movies: #{movies}")
       IO.puts("  Keywords: #{keywords}")

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -36,29 +36,5 @@ defmodule CinegraphWeb.ConnCase do
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 
-  @doc """
-  Setup helper that registers and logs in users.
-
-      setup :register_and_log_in_user
-
-  It stores an updated connection and a registered user in the
-  test context.
-  """
-  def register_and_log_in_user(%{conn: conn}) do
-    user = Cinegraph.AccountsFixtures.user_fixture()
-    %{conn: log_in_user(conn, user), user: user}
-  end
-
-  @doc """
-  Logs the given `user` into the `conn`.
-
-  It returns an updated `conn`.
-  """
-  def log_in_user(conn, user) do
-    token = Cinegraph.Accounts.generate_user_session_token(user)
-
-    conn
-    |> Phoenix.ConnTest.init_test_session(%{})
-    |> Plug.Conn.put_session(:user_token, token)
-  end
+# User authentication functions removed as this project doesn't use user accounts
 end


### PR DESCRIPTION
### TL;DR

Fix Ecto aggregate count queries by specifying the column to count and improve string handling in query parameters.

### What changed?

- Updated all `Repo.aggregate(:count)` calls to use `Repo.aggregate(:count, :id)` to explicitly specify which column to count
- Enhanced string handling in `Params.clean_enum_fields/2` to properly handle nil values and empty strings
- Removed unused `ScoringService` alias in the Search module
- Removed unused user authentication functions from the test support ConnCase module

### How to test?

- Run existing tests to ensure they pass with the updated aggregate count syntax
- Test movie search functionality with various parameter inputs including empty strings and nil values
- Verify that movie counts display correctly in the application

### Why make this change?

The `:count` aggregate in Ecto requires a field to count against for proper SQL generation. Using `:count` without specifying a field is deprecated. This change ensures all count queries use the proper syntax to avoid future deprecation warnings and potential errors. The parameter handling improvements ensure consistent behavior when processing search parameters with empty or nil values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved search filtering: whitespace-only enum values are trimmed and ignored, producing more accurate results.
  - Counts now explicitly use ID-based aggregation, improving accuracy in displayed totals.
- Documentation
  - Updated README example for counting records.
- Chores
  - Updated maintenance scripts to use explicit ID-based counting.
- Refactor
  - Removed an unused dependency from the search module.
- Tests
  - Removed obsolete user authentication helpers from test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->