### PR TITLE
small changes to be better

### DIFF
--- a/lib/cinegraph/cache/predictions_cache.ex
+++ b/lib/cinegraph/cache/predictions_cache.ex
@@ -224,7 +224,7 @@ defmodule Cinegraph.Cache.PredictionsCache do
   defp profile_hash(profile) do
     profile.category_weights
     |> :erlang.term_to_binary()
-    |> :crypto.hash(:md5)
+    |> then(&:crypto.hash(:md5, &1))
     |> Base.encode16(case: :lower)
   end
 

--- a/lib/cinegraph/predictions/historical_validator.ex
+++ b/lib/cinegraph/predictions/historical_validator.ex
@@ -38,23 +38,28 @@ defmodule Cinegraph.Predictions.HistoricalValidator do
     profile = get_weight_profile(profile_or_weights)
     decades = get_all_decades()
     
-    # Only validate decades before 2020 (since 2020s are our prediction target)
-    historical_decades = Enum.filter(decades, & &1 < 2020)
+    # Include ALL decades with data, including 2020s if they have confirmed additions
+    # This gives us a complete picture of how well our algorithm works
+    all_decades_with_data = decades
     
     decade_results = 
-      Enum.map(historical_decades, fn decade ->
+      Enum.map(all_decades_with_data, fn decade ->
         validate_decade(decade, profile)
       end)
     
     overall_accuracy = calculate_overall_accuracy(decade_results)
+    
+    # Calculate the actual range dynamically
+    min_decade = if length(all_decades_with_data) > 0, do: Enum.min(all_decades_with_data), else: 1920
+    max_decade = if length(all_decades_with_data) > 0, do: Enum.max(all_decades_with_data), else: 2020
     
     %{
       decade_results: decade_results,
       overall_accuracy: overall_accuracy,
       profile_used: profile.name,
       weights_used: ScoringService.profile_to_discovery_weights(profile),
-      decades_analyzed: length(historical_decades),
-      decade_range: "#{Enum.min(historical_decades, fn -> 1920 end)}s-#{Enum.max(historical_decades, fn -> 2010 end)}s"
+      decades_analyzed: length(all_decades_with_data),
+      decade_range: "#{min_decade}s-#{max_decade}s"
     }
   end
 


### PR DESCRIPTION
### TL;DR

Include 2020s data in historical validation and fix crypto hash function call.

### What changed?

- Fixed the `profile_hash/1` function in `PredictionsCache` by properly passing the binary data to `:crypto.hash/2` using a `then/2` pipe
- Modified the `validate_profile/1` function in `HistoricalValidator` to:
    - Include all decades with data (including 2020s) instead of filtering out 2020s
    - Calculate decade range dynamically based on available data
    - Improve decade range calculation with proper fallback values

### How to test?

1. Run historical validation with different profiles and verify that 2020s data is now included in the results
2. Check that the decade range in validation results correctly reflects the available data
3. Verify that profile hashing still works correctly in the cache

### Why make this change?

Including 2020s data in historical validation provides a more complete picture of algorithm performance across all available decades. The crypto hash function fix ensures proper data handling when generating profile hashes. These changes improve both the accuracy of our validation metrics and the reliability of our caching mechanism.