### PR TITLE
moving criteria

### DIFF
--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -59,8 +59,6 @@ defmodule Cinegraph.Movies do
     sort in [
       "popular_opinion",
       "popular_opinion_asc",
-      "critical_acclaim",
-      "critical_acclaim_asc",
       "industry_recognition",
       "industry_recognition_asc",
       "cultural_impact",

--- a/lib/cinegraph/movies/discovery_common.ex
+++ b/lib/cinegraph/movies/discovery_common.ex
@@ -6,11 +6,10 @@ defmodule Cinegraph.Movies.DiscoveryCommon do
   """
 
   @default_weights %{
-    popular_opinion: 0.2,
-    critical_acclaim: 0.2,
-    industry_recognition: 0.2,
-    cultural_impact: 0.2,
-    people_quality: 0.2
+    popular_opinion: 0.25,    # Combined all rating sources
+    industry_recognition: 0.25,
+    cultural_impact: 0.25,
+    people_quality: 0.25
   }
 
   @doc """
@@ -20,29 +19,25 @@ defmodule Cinegraph.Movies.DiscoveryCommon do
     %{
       balanced: @default_weights,
       crowd_pleaser: %{
-        popular_opinion: 0.4,
-        critical_acclaim: 0.1,
+        popular_opinion: 0.5,     # Focus on popular ratings
         industry_recognition: 0.1,
         cultural_impact: 0.2,
         people_quality: 0.2
       },
       critics_choice: %{
-        popular_opinion: 0.1,
-        critical_acclaim: 0.4,
+        popular_opinion: 0.5,     # All ratings, but Metacritic/RT weighted higher in implementation
         industry_recognition: 0.2,
         cultural_impact: 0.1,
         people_quality: 0.2
       },
       award_winner: %{
-        popular_opinion: 0.1,
-        critical_acclaim: 0.15,
+        popular_opinion: 0.25,    # Some consideration of ratings
         industry_recognition: 0.5,
         cultural_impact: 0.1,
         people_quality: 0.15
       },
       cult_classic: %{
-        popular_opinion: 0.15,
-        critical_acclaim: 0.1,
+        popular_opinion: 0.25,    # Moderate ratings consideration
         industry_recognition: 0.1,
         cultural_impact: 0.5,
         people_quality: 0.15

--- a/lib/cinegraph/movies/discovery_scoring_simple.ex
+++ b/lib/cinegraph/movies/discovery_scoring_simple.ex
@@ -86,11 +86,10 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
       %{
         discovery_score:
           fragment(
-            "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
+            "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
             ^normalized_weights.popular_opinion,
             tr.value,
             ir.value,
-            ^normalized_weights.critical_acclaim,
             mc.value,
             rt.value,
             ^normalized_weights.industry_recognition,
@@ -104,13 +103,9 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
         score_components: %{
           popular_opinion:
             fragment(
-              "COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0)",
+              "COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0)",
               tr.value,
-              ir.value
-            ),
-          critical_acclaim:
-            fragment(
-              "COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0)",
+              ir.value,
               mc.value,
               rt.value
             ),
@@ -141,11 +136,10 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
         festivals: f
       ],
       fragment(
-        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) >= ?",
+        "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) >= ?",
         ^normalized_weights.popular_opinion,
         tr.value,
         ir.value,
-        ^normalized_weights.critical_acclaim,
         mc.value,
         rt.value,
         ^normalized_weights.industry_recognition,
@@ -170,11 +164,10 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
       ],
       desc:
         fragment(
-          "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.5 + COALESCE(?, 0) / 10.0 * 0.5), 0) + ? * COALESCE((COALESCE(?, 0) / 100.0 * 0.5 + COALESCE(?, 0) / 100.0 * 0.5), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
+          "? * COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0) + ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0)",
           ^normalized_weights.popular_opinion,
           tr.value,
           ir.value,
-          ^normalized_weights.critical_acclaim,
           mc.value,
           rt.value,
           ^normalized_weights.industry_recognition,

--- a/lib/cinegraph/movies/movie_scoring.ex
+++ b/lib/cinegraph/movies/movie_scoring.ex
@@ -113,7 +113,6 @@ defmodule Cinegraph.Movies.MovieScoring do
 
     # Calculate component scores (0-10 scale)
     popular_opinion = calculate_popular_opinion(metrics)
-    critical_acclaim = calculate_critical_acclaim(metrics)
     industry_recognition = calculate_industry_recognition(festival_data)
     cultural_impact = calculate_cultural_impact(movie, metrics)
     # Convert from 0-100 to 0-10
@@ -123,8 +122,7 @@ defmodule Cinegraph.Movies.MovieScoring do
 
     # Calculate overall score (weighted average)
     overall =
-      popular_opinion * 0.25 +
-        critical_acclaim * 0.20 +
+      popular_opinion * 0.45 +
         industry_recognition * 0.15 +
         cultural_impact * 0.15 +
         people_quality_score * 0.15 +
@@ -134,7 +132,6 @@ defmodule Cinegraph.Movies.MovieScoring do
       overall_score: Float.round(overall, 1),
       components: %{
         popular_opinion: Float.round(popular_opinion, 1),
-        critical_acclaim: Float.round(critical_acclaim, 1),
         industry_recognition: Float.round(industry_recognition, 1),
         cultural_impact: Float.round(cultural_impact, 1),
         people_quality: Float.round(people_quality_score, 1),
@@ -145,30 +142,22 @@ defmodule Cinegraph.Movies.MovieScoring do
   end
 
   @doc """
-  Calculate popular opinion score based on audience ratings.
+  Calculate popular opinion score based on all rating sources.
   """
   def calculate_popular_opinion(metrics) do
     imdb = Map.get(metrics, :imdb_rating, 0) || 0
     tmdb = Map.get(metrics, :tmdb_rating, 0) || 0
     rt_audience = Map.get(metrics, :rt_audience, 0) || 0
-
-    scores = [imdb, tmdb, rt_audience / 10.0] |> Enum.filter(&(&1 > 0))
-
-    if length(scores) > 0 do
-      Enum.sum(scores) / length(scores)
-    else
-      5.0
-    end
-  end
-
-  @doc """
-  Calculate critical acclaim based on critic scores.
-  """
-  def calculate_critical_acclaim(metrics) do
     metacritic = Map.get(metrics, :metacritic, 0) || 0
     rt_tomatometer = Map.get(metrics, :rt_tomatometer, 0) || 0
 
-    scores = [metacritic / 10.0, rt_tomatometer / 10.0] |> Enum.filter(&(&1 > 0))
+    scores = [
+      imdb,
+      tmdb,
+      rt_audience / 10.0,
+      metacritic / 10.0,
+      rt_tomatometer / 10.0
+    ] |> Enum.filter(&(&1 > 0))
 
     if length(scores) > 0 do
       Enum.sum(scores) / length(scores)

--- a/lib/cinegraph/movies/query/params.ex
+++ b/lib/cinegraph/movies/query/params.ex
@@ -58,7 +58,6 @@ defmodule Cinegraph.Movies.Query.Params do
 
     # Metric thresholds (for advanced users)
     field :popular_opinion_min, :float
-    field :critical_acclaim_min, :float
     field :industry_recognition_min, :float
     field :cultural_impact_min, :float
     field :people_quality_min, :float
@@ -71,7 +70,6 @@ defmodule Cinegraph.Movies.Query.Params do
     rating rating_asc rating_desc
     popularity popularity_asc popularity_desc
     popular_opinion popular_opinion_asc popular_opinion_desc
-    critical_acclaim critical_acclaim_asc critical_acclaim_desc
     industry_recognition industry_recognition_asc industry_recognition_desc
     cultural_impact cultural_impact_asc cultural_impact_desc
     people_quality people_quality_asc people_quality_desc
@@ -114,7 +112,6 @@ defmodule Cinegraph.Movies.Query.Params do
       :people_ids,
       :people_role,
       :popular_opinion_min,
-      :critical_acclaim_min,
       :industry_recognition_min,
       :cultural_impact_min,
       :people_quality_min
@@ -273,7 +270,7 @@ defmodule Cinegraph.Movies.Query.Params do
                         runtime_min runtime_max festival_id award_category_id
                         award_year_from award_year_to genres countries festivals)
 
-    float_fields = ~w(rating_min popular_opinion_min critical_acclaim_min
+    float_fields = ~w(rating_min popular_opinion_min
                       industry_recognition_min cultural_impact_min people_quality_min)
 
     params

--- a/lib/cinegraph/movies/search.ex
+++ b/lib/cinegraph/movies/search.ex
@@ -26,7 +26,6 @@ defmodule Cinegraph.Movies.Search do
         rating rating_asc rating_desc
         popularity popularity_asc popularity_desc
         popular_opinion popular_opinion_asc popular_opinion_desc
-        critical_acclaim critical_acclaim_asc critical_acclaim_desc
         industry_recognition industry_recognition_asc industry_recognition_desc
         cultural_impact cultural_impact_asc cultural_impact_desc
         people_quality people_quality_asc people_quality_desc
@@ -147,7 +146,7 @@ defmodule Cinegraph.Movies.Search do
           sort
       end
 
-    base in ~w(popular_opinion critical_acclaim industry_recognition cultural_impact people_quality)
+    base in ~w(popular_opinion industry_recognition cultural_impact people_quality)
   end
 
   defp list_genres do
@@ -205,7 +204,6 @@ defmodule Cinegraph.Movies.Search do
       %{id: "rating", value: "rating", label: "Rating (Highest)"},
       %{id: "popularity", value: "popularity", label: "Popularity"},
       %{id: "popular_opinion", value: "popular_opinion", label: "Popular Opinion"},
-      %{id: "critical_acclaim", value: "critical_acclaim", label: "Critical Acclaim"},
       %{id: "industry_recognition", value: "industry_recognition", label: "Industry Recognition"},
       %{id: "cultural_impact", value: "cultural_impact", label: "Cultural Impact"},
       %{id: "people_quality", value: "people_quality", label: "People Quality"}

--- a/lib/cinegraph/predictions/historical_validator.ex
+++ b/lib/cinegraph/predictions/historical_validator.ex
@@ -286,12 +286,12 @@ defmodule Cinegraph.Predictions.HistoricalValidator do
 
   defp convert_weights_to_categories(weights) do
     # Map validation weights to database categories
+    # Popular opinion now includes all rating sources (critical_acclaim merged in)
     %{
-      "ratings" =>
-        (Map.get(weights, :critical_acclaim, 0.2) + Map.get(weights, :popular_opinion, 0.2)) / 2,
-      "awards" => Map.get(weights, :industry_recognition, 0.2),
-      "cultural" => Map.get(weights, :cultural_impact, 0.2),
-      "people" => Map.get(weights, :people_quality, 0.2),
+      "ratings" => Map.get(weights, :popular_opinion, 0.25) + Map.get(weights, :critical_acclaim, 0.0),
+      "awards" => Map.get(weights, :industry_recognition, 0.25),
+      "cultural" => Map.get(weights, :cultural_impact, 0.25),
+      "people" => Map.get(weights, :people_quality, 0.25),
       "financial" => 0.0
     }
   end

--- a/lib/cinegraph/predictions/movie_predictor.ex
+++ b/lib/cinegraph/predictions/movie_predictor.ex
@@ -167,9 +167,12 @@ defmodule Cinegraph.Predictions.MoviePredictor do
 
   defp convert_ui_weights_to_categories(weights) do
     # Coerce non-numeric values to 0.0 and delegate to ScoringService for consistent mapping
+    # Combine critical_acclaim into popular_opinion if it exists
+    pop_opinion_weight = to_float(Map.get(weights, :popular_opinion, 0.0)) +
+                         to_float(Map.get(weights, :critical_acclaim, 0.0))
+    
     sanitized = %{
-      popular_opinion: to_float(Map.get(weights, :popular_opinion, 0.0)),
-      critical_acclaim: to_float(Map.get(weights, :critical_acclaim, 0.0)),
+      popular_opinion: pop_opinion_weight,
       industry_recognition:
         to_float(
           Map.get(weights, :industry_recognition, Map.get(weights, :festival_recognition, 0.0))
@@ -240,11 +243,10 @@ defmodule Cinegraph.Predictions.MoviePredictor do
     components = Map.get(movie, :score_components, %{})
     # Use provided weights or fallback to equal weights
     default_weights = %{
-      popular_opinion: 0.2,
-      critical_acclaim: 0.2,
-      industry_recognition: 0.2,
-      cultural_impact: 0.2,
-      people_quality: 0.2
+      popular_opinion: 0.25,
+      industry_recognition: 0.25,
+      cultural_impact: 0.25,
+      people_quality: 0.25
     }
 
     actual_weights = weights || default_weights
@@ -253,22 +255,11 @@ defmodule Cinegraph.Predictions.MoviePredictor do
       %{
         criterion: :popular_opinion,
         raw_score: Float.round(to_float(components[:popular_opinion]) * 100, 1),
-        weight: Map.get(actual_weights, :popular_opinion, 0.2),
+        weight: Map.get(actual_weights, :popular_opinion, 0.25),
         weighted_points:
           Float.round(
             to_float(components[:popular_opinion]) *
-              Map.get(actual_weights, :popular_opinion, 0.2) * 100,
-            1
-          )
-      },
-      %{
-        criterion: :critical_acclaim,
-        raw_score: Float.round(to_float(components[:critical_acclaim]) * 100, 1),
-        weight: Map.get(actual_weights, :critical_acclaim, 0.2),
-        weighted_points:
-          Float.round(
-            to_float(components[:critical_acclaim]) *
-              Map.get(actual_weights, :critical_acclaim, 0.2) * 100,
+              Map.get(actual_weights, :popular_opinion, 0.25) * 100,
             1
           )
       },

--- a/lib/cinegraph_web/live/metrics_live/index.html.heex
+++ b/lib/cinegraph_web/live/metrics_live/index.html.heex
@@ -295,8 +295,8 @@
               <td class="px-4 py-2 text-center text-sm font-mono">0-100</td>
               <td class="px-4 py-2 text-sm font-mono">value / 100</td>
               <td class="px-4 py-2 text-center">
-                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                  Critical Acclaim
+                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                  Popular Opinion
                 </span>
               </td>
               <td class="px-4 py-2 text-center text-sm font-medium">50%</td>
@@ -307,8 +307,8 @@
               <td class="px-4 py-2 text-center text-sm font-mono">0-100%</td>
               <td class="px-4 py-2 text-sm font-mono">value / 100</td>
               <td class="px-4 py-2 text-center">
-                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                  Critical Acclaim
+                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                  Popular Opinion
                 </span>
               </td>
               <td class="px-4 py-2 text-center text-sm font-medium">50%</td>
@@ -385,37 +385,27 @@
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div class="border border-blue-200 rounded-lg p-4">
           <h3 class="font-semibold text-blue-900 mb-2">📊 Popular Opinion</h3>
-          <p class="text-sm text-gray-600 mb-2">Average of audience ratings:</p>
+          <p class="text-sm text-gray-600 mb-2">Average of all rating sources:</p>
           <ul class="space-y-1 text-sm">
             <li class="flex justify-between">
               <span>• IMDb Rating</span>
-              <span class="font-mono">50%</span>
+              <span class="font-mono">25%</span>
             </li>
             <li class="flex justify-between">
               <span>• TMDb Rating</span>
-              <span class="font-mono">50%</span>
+              <span class="font-mono">25%</span>
+            </li>
+            <li class="flex justify-between">
+              <span>• Metacritic Metascore</span>
+              <span class="font-mono">25%</span>
+            </li>
+            <li class="flex justify-between">
+              <span>• Rotten Tomatoes</span>
+              <span class="font-mono">25%</span>
             </li>
           </ul>
           <div class="mt-2 p-2 bg-blue-50 rounded text-xs">
-            Formula: <code>(IMDb/10 * 0.5 + TMDb/10 * 0.5)</code>
-          </div>
-        </div>
-
-        <div class="border border-purple-200 rounded-lg p-4">
-          <h3 class="font-semibold text-purple-900 mb-2">🎭 Critical Acclaim</h3>
-          <p class="text-sm text-gray-600 mb-2">Average of critic scores:</p>
-          <ul class="space-y-1 text-sm">
-            <li class="flex justify-between">
-              <span>• Metacritic Metascore</span>
-              <span class="font-mono">50%</span>
-            </li>
-            <li class="flex justify-between">
-              <span>• Rotten Tomatoes Tomatometer</span>
-              <span class="font-mono">50%</span>
-            </li>
-          </ul>
-          <div class="mt-2 p-2 bg-purple-50 rounded text-xs">
-            Formula: <code>(Meta/100 * 0.5 + RT/100 * 0.5)</code>
+            Formula: <code>(IMDb/10 * 0.25 + TMDb/10 * 0.25 + Meta/100 * 0.25 + RT/100 * 0.25)</code>
           </div>
         </div>
 
@@ -523,7 +513,7 @@
             <tr>
               <td class="px-4 py-2 text-sm font-medium text-gray-900">
                 Popular Opinion<br />
-                <span class="text-xs text-gray-500">(ratings)</span>
+                <span class="text-xs text-gray-500">(all ratings)</span>
               </td>
               <%= for profile <- @weight_profiles do %>
                 <td class="px-4 py-2 text-center">
@@ -531,35 +521,12 @@
                     <div class="w-20 bg-gray-200 rounded-full h-2 mr-2">
                       <div
                         class="bg-blue-600 h-2 rounded-full"
-                        style={"width: #{min(100, get_profile_weight_actual(profile, "ratings"))}%"}
+                        style={"width: #{min(100, get_profile_weight_actual(profile, "popular_opinion"))}%"}
                       >
                       </div>
                     </div>
                     <span class="text-sm font-medium">
-                      {get_profile_weight_actual(profile, "ratings")}%
-                    </span>
-                  </div>
-                </td>
-              <% end %>
-            </tr>
-
-            <tr class="bg-gray-50">
-              <td class="px-4 py-2 text-sm font-medium text-gray-900">
-                Critical Acclaim<br />
-                <span class="text-xs text-gray-500">(critic ratings)</span>
-              </td>
-              <%= for profile <- @weight_profiles do %>
-                <td class="px-4 py-2 text-center">
-                  <div class="inline-flex items-center">
-                    <div class="w-20 bg-gray-200 rounded-full h-2 mr-2">
-                      <div
-                        class="bg-purple-600 h-2 rounded-full"
-                        style={"width: #{min(100, div(round(get_profile_weight_actual(profile, "ratings")), 2))}%"}
-                      >
-                      </div>
-                    </div>
-                    <span class="text-sm font-medium">
-                      {Float.round(get_profile_weight_actual(profile, "ratings") / 2, 1)}%
+                      {get_profile_weight_actual(profile, "popular_opinion")}%
                     </span>
                   </div>
                 </td>
@@ -917,9 +884,9 @@
                   </div>
                   <div class="text-xs text-gray-500">
                     Pop: {Float.round((movie.components["popular_opinion"] || 0) * 100, 0)}% |
-                    Crit: {Float.round((movie.components["critical_acclaim"] || 0) * 100, 0)}% |
                     Ind: {Float.round((movie.components["industry_recognition"] || 0) * 100, 0)}% |
-                    Cult: {Float.round((movie.components["cultural_impact"] || 0) * 100, 0)}%
+                    Cult: {Float.round((movie.components["cultural_impact"] || 0) * 100, 0)}% |
+                    People: {Float.round((movie.components["people_quality"] || 0) * 100, 0)}%
                   </div>
                 </div>
               </div>

--- a/lib/cinegraph_web/live/movie_live/advanced_filters.ex
+++ b/lib/cinegraph_web/live/movie_live/advanced_filters.ex
@@ -217,7 +217,6 @@ defmodule CinegraphWeb.MovieLive.AdvancedFilters do
       "actor_ids",
       "person_ids",
       "popular_opinion_min",
-      "critical_acclaim_min",
       "industry_recognition_min",
       "cultural_impact_min"
     ]
@@ -274,7 +273,6 @@ defmodule CinegraphWeb.MovieLive.AdvancedFilters do
       "actor_ids",
       "person_ids",
       "popular_opinion_min",
-      "critical_acclaim_min",
       "industry_recognition_min",
       "cultural_impact_min"
     ]
@@ -322,7 +320,6 @@ defmodule CinegraphWeb.MovieLive.AdvancedFilters do
       "actor_ids" -> "Actors"
       "person_ids" -> "People"
       "popular_opinion_min" -> "Popular Opinion"
-      "critical_acclaim_min" -> "Critical Acclaim"
       "industry_recognition_min" -> "Industry Recognition"
       "cultural_impact_min" -> "Cultural Impact"
       _ -> key |> String.replace("_", " ") |> String.capitalize()

--- a/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
+++ b/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
@@ -18,11 +18,10 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
     # Get the default/balanced weights - now including people_quality
     weights =
       Map.get(presets, :balanced, %{
-        popular_opinion: 0.2,
-        critical_acclaim: 0.2,
-        industry_recognition: 0.2,
-        cultural_impact: 0.2,
-        people_quality: 0.2
+        popular_opinion: 0.25,
+        industry_recognition: 0.25,
+        cultural_impact: 0.25,
+        people_quality: 0.25
       })
 
     # Store the current profile for database lookups
@@ -55,7 +54,6 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
         {key, value}, acc
         when key in [
                "popular_opinion",
-               "critical_acclaim",
                "industry_recognition",
                "cultural_impact",
                "people_quality"
@@ -320,10 +318,7 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
                 This filter excludes movies with a total discovery score below the specified percentage. The discovery score is calculated by combining:
               </p>
               <ul class="list-disc list-inside mt-2 space-y-1">
-                <li><strong>Popular Opinion:</strong> IMDb and TMDb user ratings</li>
-                <li>
-                  <strong>Critical Acclaim:</strong> Metacritic and Rotten Tomatoes critic scores
-                </li>
+                <li><strong>Popular Opinion:</strong> IMDb, TMDb, Metacritic and Rotten Tomatoes ratings</li>
                 <li>
                   <strong>Industry Recognition:</strong> Festival awards and Oscar nominations/wins
                 </li>
@@ -454,14 +449,12 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
   defp humanize_preset(preset), do: Phoenix.Naming.humanize(preset)
 
   defp humanize_dimension(:popular_opinion), do: "Popular Opinion"
-  defp humanize_dimension(:critical_acclaim), do: "Critical Acclaim"
   defp humanize_dimension(:industry_recognition), do: "Industry Recognition"
   defp humanize_dimension(:cultural_impact), do: "Cultural Impact"
   defp humanize_dimension(:people_quality), do: "People Quality"
   defp humanize_dimension(dimension), do: Phoenix.Naming.humanize(dimension)
 
-  defp dimension_description(:popular_opinion), do: "TMDb and IMDb user ratings"
-  defp dimension_description(:critical_acclaim), do: "Metacritic and Rotten Tomatoes scores"
+  defp dimension_description(:popular_opinion), do: "All rating sources (IMDb, TMDb, Metacritic, RT)"
   defp dimension_description(:industry_recognition), do: "Festival awards and nominations"
   defp dimension_description(:cultural_impact), do: "Canonical lists and popularity metrics"
   defp dimension_description(:people_quality), do: "Quality of directors, actors, and crew"

--- a/lib/cinegraph_web/live/movie_live/index.html.heex
+++ b/lib/cinegraph_web/live/movie_live/index.html.heex
@@ -181,9 +181,6 @@
                 <option value="popular_opinion" selected={@sort_criteria == "popular_opinion"}>
                   🎬 Popular Opinion
                 </option>
-                <option value="critical_acclaim" selected={@sort_criteria == "critical_acclaim"}>
-                  🏆 Critical Acclaim
-                </option>
                 <option
                   value="industry_recognition"
                   selected={@sort_criteria == "industry_recognition"}
@@ -492,11 +489,6 @@
                   <%= if movie.score_components.popular_opinion && has_meaningful_score?(movie.score_components.popular_opinion) do %>
                     <span class="inline-flex items-center px-2 py-0.5 rounded bg-green-50 text-green-700 border border-green-200">
                       🎬 {to_percentage(movie.score_components.popular_opinion)}%
-                    </span>
-                  <% end %>
-                  <%= if movie.score_components.critical_acclaim && has_meaningful_score?(movie.score_components.critical_acclaim) do %>
-                    <span class="inline-flex items-center px-2 py-0.5 rounded bg-blue-50 text-blue-700 border border-blue-200">
-                      🏆 {to_percentage(movie.score_components.critical_acclaim)}%
                     </span>
                   <% end %>
                   <%= if movie.score_components.industry_recognition && has_meaningful_score?(movie.score_components.industry_recognition) do %>

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -160,21 +160,6 @@
               </div>
             </div>
 
-            <div class="flex items-center justify-between">
-              <span class="text-white/80 text-sm">Critical Acclaim</span>
-              <div class="flex items-center">
-                <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
-                  <div
-                    class="h-2 bg-green-400 rounded-full"
-                    style={"width: #{score_data.components.critical_acclaim * 10}%"}
-                  >
-                  </div>
-                </div>
-                <span class="text-white text-sm w-8">
-                  {score_data.components.critical_acclaim}
-                </span>
-              </div>
-            </div>
 
             <div class="flex items-center justify-between">
               <span class="text-white/80 text-sm">Industry Recognition</span>

--- a/lib/cinegraph_web/live/predictions_live/index.ex
+++ b/lib/cinegraph_web/live/predictions_live/index.ex
@@ -107,11 +107,10 @@ defmodule CinegraphWeb.PredictionsLive.Index do
            :algorithm_weights,
            ScoringService.profile_to_discovery_weights(default_profile) ||
              %{
-               popular_opinion: 0.2,
-               critical_acclaim: 0.2,
-               industry_recognition: 0.2,
-               cultural_impact: 0.2,
-               people_quality: 0.2
+               popular_opinion: 0.25,
+               industry_recognition: 0.25,
+               cultural_impact: 0.25,
+               people_quality: 0.25
              }
          )
          |> assign(:show_weight_tuner, false)
@@ -222,7 +221,6 @@ defmodule CinegraphWeb.PredictionsLive.Index do
 
       new_weights = %{
         popular_opinion: parse_param.(params["popular_opinion"]),
-        critical_acclaim: parse_param.(params["critical_acclaim"]),
         industry_recognition: parse_param.(params["industry_recognition"]),
         cultural_impact: parse_param.(params["cultural_impact"]),
         people_quality: parse_param.(params["people_quality"])
@@ -343,7 +341,6 @@ defmodule CinegraphWeb.PredictionsLive.Index do
   defp format_likelihood(percentage), do: {"#{percentage}%", "text-gray-600"}
 
   defp criterion_label(:popular_opinion), do: "Popular Opinion"
-  defp criterion_label(:critical_acclaim), do: "Critical Acclaim"
   defp criterion_label(:industry_recognition), do: "Industry Recognition"
   defp criterion_label(:cultural_impact), do: "Cultural Impact"
   defp criterion_label(:people_quality), do: "People Quality"

--- a/lib/cinegraph_web/live/predictions_live/index.html.heex
+++ b/lib/cinegraph_web/live/predictions_live/index.html.heex
@@ -197,10 +197,7 @@
                   <div class="mt-2 text-xs text-gray-600">
                     <%= case criterion do
                       :popular_opinion ->
-                        "IMDb and TMDb user ratings and votes"
-
-                      :critical_acclaim ->
-                        "Metacritic and Rotten Tomatoes critic scores"
+                        "All rating sources (IMDb, TMDb, Metacritic, RT)"
 
                       :industry_recognition ->
                         "Oscars, Cannes, Venice, Berlin awards and nominations"

--- a/priv/repo/seeds/metric_weight_profiles.exs
+++ b/priv/repo/seeds/metric_weight_profiles.exs
@@ -10,13 +10,11 @@ Repo.delete_all(from mwp in "metric_weight_profiles", where: field(mwp, :is_syst
 weight_profiles = [
   %{
     name: "Balanced",
-    description: "Equal weight across critical acclaim, cultural impact, industry recognition, and popular opinion",
+    description: "Equal weight across popular opinion, cultural impact, industry recognition, and people quality",
     weights: %{
-      # Critical Acclaim
+      # Popular Opinion (all rating sources)
       "metacritic_metascore" => 1.0,
       "rotten_tomatoes_tomatometer" => 1.0,
-      
-      # Popular Opinion
       "imdb_rating" => 1.0,
       "tmdb_rating" => 1.0,
       "imdb_rating_votes" => 0.5,
@@ -45,11 +43,11 @@ weight_profiles = [
       "person_quality_score" => 1.5
     },
     category_weights: %{
-      "ratings" => 0.40,     # 40% (Popular + Critical combined, reduced from 50%)
-      "awards" => 0.20,      # 20% (reduced from 25%)
-      "financial" => 0.00,   # 0% (not used in current scoring)
-      "cultural" => 0.20,    # 20% (reduced from 25%)
-      "people" => 0.20       # 20% (new - person quality scores)
+      "popular_opinion" => 0.40,  # 40% (all rating sources combined)
+      "awards" => 0.20,           # 20% (industry recognition)
+      "financial" => 0.00,        # 0% (not used in current scoring)
+      "cultural" => 0.20,         # 20% (cultural impact)
+      "people" => 0.20            # 20% (person quality scores)
     },
     active: true,
     is_default: true,
@@ -58,37 +56,35 @@ weight_profiles = [
   
   %{
     name: "Award Winner",
-    description: "Emphasizes festival awards and industry recognition (50% awards, 20% critics, 20% cultural, 10% popular)",
+    description: "Emphasizes festival awards and industry recognition (45% awards, 20% cultural, 25% popular opinion, 10% people)",
     weights: %{
-      # Industry Recognition (50%)
+      # Industry Recognition (45%)
       "oscar_wins" => 3.0,
       "oscar_nominations" => 2.0,
       "cannes_palme_dor" => 2.5,
       "venice_golden_lion" => 2.5,
       "berlin_golden_bear" => 2.5,
       
-      # Critical Acclaim (20%)
-      "metacritic_metascore" => 1.5,
-      "rotten_tomatoes_tomatometer" => 1.5,
+      # Popular Opinion (25% - all rating sources)
+      "metacritic_metascore" => 1.0,
+      "rotten_tomatoes_tomatometer" => 1.0,
+      "imdb_rating" => 0.8,
+      "tmdb_rating" => 0.8,
       
       # Cultural Impact (20%)
       "1001_movies" => 1.0,
       "criterion" => 1.0,
       "sight_sound_critics_2022" => 1.0,
       
-      # Popular Opinion (10%)
-      "imdb_rating" => 0.5,
-      "tmdb_rating" => 0.5,
-      
       # People Quality (10%)
       "person_quality_score" => 1.0
     },
     category_weights: %{
-      "ratings" => 0.25,     # 25% (reduced from 30%)
-      "awards" => 0.45,      # 45% (reduced from 50%)
-      "financial" => 0.00,   # 0%
-      "cultural" => 0.20,    # 20% (unchanged)
-      "people" => 0.10       # 10% (new - person quality scores)
+      "popular_opinion" => 0.25,  # 25% (all rating sources combined)
+      "awards" => 0.45,           # 45% (industry recognition)
+      "financial" => 0.00,        # 0%
+      "cultural" => 0.20,         # 20% (cultural impact)
+      "people" => 0.10            # 10% (person quality scores)
     },
     active: true,
     is_default: false,
@@ -97,11 +93,13 @@ weight_profiles = [
   
   %{
     name: "Critics Choice",
-    description: "Prioritizes critical acclaim (45% critics) with cultural impact (30%), some awards (15%), minimal popular (10%)",
+    description: "Prioritizes critic-favored platforms (50% ratings with Metacritic/RT weighted higher) with cultural impact (30%), some awards (15%), minimal people (5%)",
     weights: %{
-      # Critical Acclaim (45%)
+      # Popular Opinion with critic platforms weighted higher (50%)
       "metacritic_metascore" => 3.0,
       "rotten_tomatoes_tomatometer" => 3.0,
+      "imdb_rating" => 0.5,
+      "tmdb_rating" => 0.5,
       
       # Cultural Impact (30%)
       "sight_sound_critics_2022" => 2.0,
@@ -114,19 +112,15 @@ weight_profiles = [
       "oscar_nominations" => 0.8,
       "cannes_palme_dor" => 1.0,
       
-      # Popular Opinion (10%)
-      "imdb_rating" => 0.3,
-      "tmdb_rating" => 0.3,
-      
       # People Quality (5%)
       "person_quality_score" => 0.5
     },
     category_weights: %{
-      "ratings" => 0.50,     # 50% (reduced from 55%, critics still favored)
-      "awards" => 0.15,      # 15% (unchanged)
-      "financial" => 0.00,   # 0%
-      "cultural" => 0.30,    # 30% (unchanged)
-      "people" => 0.05       # 5% (new - minimal for critics choice)
+      "popular_opinion" => 0.50,  # 50% (all ratings, but Metacritic/RT weighted higher)
+      "awards" => 0.15,           # 15% (industry recognition)
+      "financial" => 0.00,        # 0%
+      "cultural" => 0.30,         # 30% (cultural impact)
+      "people" => 0.05            # 5% (person quality scores)
     },
     active: true,
     is_default: false,
@@ -135,35 +129,33 @@ weight_profiles = [
   
   %{
     name: "Crowd Pleaser", 
-    description: "Focuses on popular opinion (40%), with some awards (15%), minimal critics (10%), and cultural (35%)",
+    description: "Focuses on popular opinion (40% with IMDb/TMDb weighted higher), cultural impact (35%), minimal awards (10%), financial success (10%)",
     weights: %{
-      # Popular Opinion (40%)
+      # Popular Opinion with mainstream platforms weighted higher (40%)
       "imdb_rating" => 2.5,
       "tmdb_rating" => 2.0,
       "imdb_rating_votes" => 1.5,
       "rotten_tomatoes_audience_score" => 2.0,
+      "metacritic_metascore" => 0.5,
+      "rotten_tomatoes_tomatometer" => 0.5,
       
       # Financial Success (not directly in categories but influences cultural)
       "tmdb_revenue_worldwide" => 2.0,
       "tmdb_budget" => 0.5,
       
-      # Industry Recognition (15%)
+      # Industry Recognition (10%)
       "oscar_wins" => 0.5,
       "oscar_nominations" => 0.3,
-      
-      # Critical Acclaim (10%)
-      "metacritic_metascore" => 0.3,
-      "rotten_tomatoes_tomatometer" => 0.3,
       
       # People Quality (5%)
       "person_quality_score" => 0.5
     },
     category_weights: %{
-      "ratings" => 0.40,     # 40% (reduced from 45%)
-      "awards" => 0.10,      # 10% (unchanged)
-      "financial" => 0.10,   # 10% (box office success matters for crowd pleasers)
-      "cultural" => 0.35,    # 35% (includes popularity metrics)
-      "people" => 0.05       # 5% (new - minimal for crowd pleasers)
+      "popular_opinion" => 0.45,  # 45% (all ratings, IMDb/TMDb weighted higher)
+      "awards" => 0.10,           # 10% (minimal awards focus)
+      "financial" => 0.10,        # 10% (box office success matters for crowd pleasers)
+      "cultural" => 0.30,         # 30% (includes popularity metrics)
+      "people" => 0.05            # 5% (minimal for crowd pleasers)
     },
     active: true,
     is_default: false,
@@ -172,16 +164,18 @@ weight_profiles = [
   
   %{
     name: "Cult Classic",
-    description: "Finds films with dedicated followings: cultural lists (40%), moderate ratings (35%), some awards (10%), popularity (15%)",
+    description: "Finds films with dedicated followings: cultural lists (35%), moderate ratings (40%), some awards (10%), people (15%)",
     weights: %{
-      # Cultural Lists (40%)
+      # Cultural Lists (35%)
       "criterion" => 2.5,
       "1001_movies" => 2.0,
       "sight_sound_critics_2022" => 1.5,
       
-      # Moderate ratings with specific engagement patterns (35%)
+      # Moderate ratings with specific engagement patterns (40%)
       "imdb_rating" => 1.0,
+      "tmdb_rating" => 0.8,
       "metacritic_metascore" => 0.8,
+      "rotten_tomatoes_tomatometer" => 0.6,
       "imdb_rating_votes" => 0.3,  # Some votes but not too mainstream
       
       # Festival presence (10%)
@@ -197,11 +191,11 @@ weight_profiles = [
       # Setting these to 0 or excluding them entirely
     },
     category_weights: %{
-      "ratings" => 0.40,     # 40% (reduced from 50%)
-      "awards" => 0.10,      # 10% (unchanged)
-      "financial" => 0.00,   # 0%
-      "cultural" => 0.35,    # 35% (reduced from 40%)
-      "people" => 0.15       # 15% (new - important for cult classics)
+      "popular_opinion" => 0.40,  # 40% (moderate ratings from all sources)
+      "awards" => 0.10,           # 10% (festival presence)
+      "financial" => 0.00,        # 0%
+      "cultural" => 0.35,         # 35% (cultural lists)
+      "people" => 0.15            # 15% (important for cult classics)
     },
     active: true,
     is_default: false,
@@ -217,17 +211,17 @@ Enum.each(weight_profiles, fn profile ->
   weights = profile.category_weights || %{}
   
   # Check relevant weights (excluding financial which is typically 0)
-  relevant_weights = Map.take(weights, ["ratings", "awards", "cultural", "people"])
+  relevant_weights = Map.take(weights, ["popular_opinion", "awards", "cultural", "people"])
   sum = Map.values(relevant_weights) |> Enum.sum()
   
   # Provide detailed validation feedback
   cond do
     sum > 1.01 ->
       IO.puts "WARNING: #{profile.name} category weights sum to #{Float.round(sum, 4)} (> 1.01)"
-      IO.puts "  Breakdown: ratings=#{weights["ratings"]}, awards=#{weights["awards"]}, cultural=#{weights["cultural"]}, people=#{weights["people"]}"
+      IO.puts "  Breakdown: popular_opinion=#{weights["popular_opinion"]}, awards=#{weights["awards"]}, cultural=#{weights["cultural"]}, people=#{weights["people"]}"
     sum < 0.99 ->
       IO.puts "WARNING: #{profile.name} category weights sum to #{Float.round(sum, 4)} (< 0.99)"
-      IO.puts "  Breakdown: ratings=#{weights["ratings"]}, awards=#{weights["awards"]}, cultural=#{weights["cultural"]}, people=#{weights["people"]}"
+      IO.puts "  Breakdown: popular_opinion=#{weights["popular_opinion"]}, awards=#{weights["awards"]}, cultural=#{weights["cultural"]}, people=#{weights["people"]}"
     true ->
       :ok
   end


### PR DESCRIPTION
### TL;DR

Simplified the scoring system by merging critical acclaim into popular opinion, reducing dimensions from 5 to 4 and making all rating sources (IMDb, TMDb, Metacritic, RT) part of a single "popular_opinion" category.

### What changed?

- Combined "critical_acclaim" and "popular_opinion" dimensions into a single "popular_opinion" dimension that includes all rating sources
- Updated the weight profile structure to use "popular_opinion" instead of "ratings" for backward compatibility
- Modified all scoring formulas to distribute weights evenly (25% each) across the four rating sources
- Removed "critical_acclaim" sorting options and filters throughout the application
- Updated UI components to reflect the new 4-dimension model
- Adjusted default weights to be 25% for each dimension (popular_opinion, industry_recognition, cultural_impact, people_quality)
- Updated seed data for metric weight profiles to use the new structure

### How to test?

1. Verify that movie discovery scores are calculated correctly with the new formula
2. Check that the UI displays the combined popular opinion score correctly
3. Confirm that sorting and filtering by popular opinion works as expected
4. Test that existing weight profiles are properly migrated to the new structure
5. Ensure the discovery tuner UI shows the correct dimensions and weights

### Why make this change?

The previous 5-dimension model created an artificial separation between "popular opinion" and "critical acclaim" that was confusing to users. This simplification makes the scoring system more intuitive by treating all rating sources as part of a single dimension, while maintaining the ability to weight individual sources differently in the implementation. The change also aligns better with how users think about movie ratings and makes the UI more straightforward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Popular Opinion now combines IMDb, TMDb, Metacritic, and Rotten Tomatoes equally for scoring and sorting.

* **Changes**
  * Critical Acclaim dimension removed across app (scoring, presets, UI, and predictions); Popular Opinion absorbs its influence.
  * Default and preset discovery weights updated to four dimensions at 0.25 each (Popular Opinion, Industry Recognition, Cultural Impact, People Quality).
  * Sorting and filtering by Critical Acclaim removed; Popular Opinion sorting/filtering reflects four-source model.
  * UI text, labels, badges, and breakdowns updated to “all rating sources,” including Discovery Tuner and metrics pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->