### PR TITLE
code rabbit audit

### DIFF
--- a/lib/cinegraph/movies/filters.ex
+++ b/lib/cinegraph/movies/filters.ex
@@ -146,10 +146,10 @@ defmodule Cinegraph.Movies.Filters do
                         COALESCE(ir.value, 0) / 10.0 * 0.25 +
                         COALESCE(mc.value, 0) / 100.0 * 0.25 + 
                         COALESCE(rt.value, 0) / 100.0 * 0.25)
-                FROM (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average' LIMIT 1) tr,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average' LIMIT 1) ir,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore' LIMIT 1) mc,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer' LIMIT 1) rt
+                FROM (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average' ORDER BY fetched_at DESC LIMIT 1) tr,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average' ORDER BY fetched_at DESC LIMIT 1) ir,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore' ORDER BY fetched_at DESC LIMIT 1) mc,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer' ORDER BY fetched_at DESC LIMIT 1) rt
               ), 0)
               """,
               m.id,
@@ -169,10 +169,10 @@ defmodule Cinegraph.Movies.Filters do
                         COALESCE(ir.value, 0) / 10.0 * 0.25 +
                         COALESCE(mc.value, 0) / 100.0 * 0.25 + 
                         COALESCE(rt.value, 0) / 100.0 * 0.25)
-                FROM (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average' LIMIT 1) tr,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average' LIMIT 1) ir,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore' LIMIT 1) mc,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer' LIMIT 1) rt
+                FROM (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average' ORDER BY fetched_at DESC LIMIT 1) tr,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average' ORDER BY fetched_at DESC LIMIT 1) ir,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore' ORDER BY fetched_at DESC LIMIT 1) mc,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer' ORDER BY fetched_at DESC LIMIT 1) rt
               ), 0)
               """,
               m.id,
@@ -1219,10 +1219,10 @@ defmodule Cinegraph.Movies.Filters do
                         COALESCE(ir.value, 0) / 10.0 * 0.25 +
                         COALESCE(mc.value, 0) / 100.0 * 0.25 + 
                         COALESCE(rt.value, 0) / 100.0 * 0.25)
-                FROM (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average' LIMIT 1) tr,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average' LIMIT 1) ir,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore' LIMIT 1) mc,
-                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer' LIMIT 1) rt
+                FROM (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average' ORDER BY fetched_at DESC LIMIT 1) tr,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average' ORDER BY fetched_at DESC LIMIT 1) ir,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore' ORDER BY fetched_at DESC LIMIT 1) mc,
+                     (SELECT value FROM external_metrics WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer' ORDER BY fetched_at DESC LIMIT 1) rt
               ), 0) >= ?
               """,
               m.id,

--- a/lib/cinegraph/predictions/historical_validator.ex
+++ b/lib/cinegraph/predictions/historical_validator.ex
@@ -286,9 +286,18 @@ defmodule Cinegraph.Predictions.HistoricalValidator do
 
   defp convert_weights_to_categories(weights) do
     # Map validation weights to database categories
-    # Popular opinion now includes all rating sources (critical_acclaim merged in)
+    # If both popular_opinion and critical_acclaim are present (legacy data),
+    # only use popular_opinion since it now includes all rating sources
+    ratings_weight = if Map.has_key?(weights, :critical_acclaim) do
+      # Legacy case: ignore critical_acclaim, use only popular_opinion
+      Map.get(weights, :popular_opinion, 0.25)
+    else
+      # Modern case: popular_opinion includes all rating sources
+      Map.get(weights, :popular_opinion, 0.25)
+    end
+
     %{
-      "ratings" => Map.get(weights, :popular_opinion, 0.25) + Map.get(weights, :critical_acclaim, 0.0),
+      "ratings" => ratings_weight,
       "awards" => Map.get(weights, :industry_recognition, 0.25),
       "cultural" => Map.get(weights, :cultural_impact, 0.25),
       "people" => Map.get(weights, :people_quality, 0.25),

--- a/priv/repo/migrations/20250819000001_fix_metric_weight_profiles.exs
+++ b/priv/repo/migrations/20250819000001_fix_metric_weight_profiles.exs
@@ -1,0 +1,92 @@
+defmodule Cinegraph.Repo.Migrations.FixMetricWeightProfiles do
+  use Ecto.Migration
+
+  def up do
+    # Fix Balanced profile to use true 25% for each of the 4 categories
+    # Since popular_opinion now includes all rating sources (merged with critical_acclaim)
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        category_weights = jsonb_build_object(
+          'popular_opinion', 0.25,
+          'awards', 0.25,
+          'cultural', 0.25,
+          'people', 0.25,
+          'financial', 0.0
+        ),
+        description = 'Equal weight across all four dimensions: popular opinion (25%), industry recognition (25%), cultural impact (25%), and people quality (25%)',
+        updated_at = NOW()
+      WHERE name = 'Balanced'
+    """
+
+    # Fix Crowd Pleaser profile - align description with actual weights (45%)
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        description = 'Focuses on popular opinion (45%), cultural impact (30%), minimal awards (10%), financial success (10%), people quality (5%)',
+        updated_at = NOW()
+      WHERE name = 'Crowd Pleaser'
+    """
+
+    # Update Award Winner profile to maintain balance after critical_acclaim removal
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        category_weights = jsonb_build_object(
+          'popular_opinion', 0.25,
+          'awards', 0.45,
+          'cultural', 0.2,
+          'people', 0.1,
+          'financial', 0.0
+        ),
+        updated_at = NOW()
+      WHERE name = 'Award Winner'
+    """
+
+    # Update Critics Choice profile - now focuses on all rating sources equally
+    # Since we no longer distinguish between "critic" and "audience" ratings
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        description = 'Prioritizes rating platforms (50% across IMDb, TMDb, Metacritic, RT) with cultural impact (30%), some awards (15%), minimal people (5%)',
+        updated_at = NOW()
+      WHERE name = 'Critics Choice'
+    """
+  end
+
+  def down do
+    # Revert Balanced profile
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        category_weights = jsonb_build_object(
+          'popular_opinion', 0.4,
+          'awards', 0.2,
+          'cultural', 0.2,
+          'people', 0.2,
+          'financial', 0.0
+        ),
+        description = 'Equal weight across popular opinion, cultural impact, industry recognition, and people quality',
+        updated_at = NOW()
+      WHERE name = 'Balanced'
+    """
+
+    # Revert Crowd Pleaser description
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        description = 'Focuses on popular opinion (40% with IMDb/TMDb weighted higher), cultural impact (35%), minimal awards (10%), financial success (10%)',
+        updated_at = NOW()
+      WHERE name = 'Crowd Pleaser'
+    """
+
+    # Revert Critics Choice description
+    execute """
+      UPDATE metric_weight_profiles
+      SET 
+        description = 'Prioritizes critic-favored platforms (50% ratings with Metacritic/RT weighted higher) with cultural impact (30%), some awards (15%), minimal people (5%)',
+        updated_at = NOW()
+      WHERE name = 'Critics Choice'
+    """
+  end
+end


### PR DESCRIPTION
### TL;DR

Improved movie rating calculations by using the most recent metrics and updated weight profiles to reflect the merged rating sources.

### What changed?

- Modified SQL queries in `filters.ex` to use the most recent metrics by adding `ORDER BY fetched_at DESC` to all external metric queries
- Updated `HistoricalValidator.convert_weights_to_categories/1` to handle both legacy and modern weight profiles
- Added a migration (`20250819000001_fix_metric_weight_profiles.exs`) that:
    - Updates the "Balanced" profile to use true 25% weights across all categories
    - Aligns the "Crowd Pleaser" description with actual weights
    - Adjusts the "Award Winner" profile to maintain balance after critical acclaim removal
    - Updates the "Critics Choice" profile description to reflect that all rating sources are now treated equally

### How to test?

1. Run the migration to update the weight profiles
2. Verify that movie ratings now use the most recent metrics by checking a movie with multiple metric entries
3. Test both legacy and modern weight profiles to ensure they calculate scores correctly
4. Confirm that the updated profile descriptions match their actual weights

### Why make this change?

Previously, the system wasn't consistently using the most recent metrics when calculating movie ratings. Additionally, the weight profiles needed updating after merging critical acclaim into popular opinion. These changes ensure that ratings are calculated using the freshest data and that weight profiles accurately reflect the current rating system architecture.