### PR TITLE
cr changes

### DIFF
--- a/lib/cinegraph/predictions/movie_predictor.ex
+++ b/lib/cinegraph/predictions/movie_predictor.ex
@@ -192,7 +192,8 @@ defmodule Cinegraph.Predictions.MoviePredictor do
         ),
       cultural_impact: to_float(Map.get(weights, :cultural_impact, 0.0)),
       people_quality:
-        to_float(Map.get(weights, :people_quality, Map.get(weights, :auteur_recognition, 0.0)))
+        to_float(Map.get(weights, :people_quality, Map.get(weights, :auteur_recognition, 0.0))),
+      financial_success: to_float(Map.get(weights, :financial_success, 0.0))
     }
 
     ScoringService.discovery_weights_to_profile(sanitized).category_weights


### PR DESCRIPTION
# Fix SQL query weight handling for financial_success dimension

### TL;DR

Removed the financial_success dimension from SQL queries while preserving it in the weights model.

### What changed?

- Modified `ScoringService` to drop the `financial_success` dimension from query weights before executing SQL queries
- Added a comment explaining that SQL fragments can only handle 4 dimensions currently
- Added `financial_success` to the sanitized weights in `MoviePredictor.profile_to_discovery_weights/1`

### How to test?

1. Run discovery queries with profiles that include financial_success weights
2. Verify that queries execute without errors
3. Confirm that financial_success is still included in the normalized weights model

### Why make this change?

The SQL fragments in our database queries can only handle 4 dimensions currently, but we need to support the financial_success dimension in our data model. This change allows us to maintain the dimension in our weights model while preventing SQL query errors, with a TODO to properly integrate financial data in the future.