### PR TITLE
small

### DIFF
--- a/lib/cinegraph/predictions/movie_predictor.ex
+++ b/lib/cinegraph/predictions/movie_predictor.ex
@@ -257,10 +257,11 @@ defmodule Cinegraph.Predictions.MoviePredictor do
     components = Map.get(movie, :score_components, %{})
     # Use provided weights or fallback to equal weights
     default_weights = %{
-      popular_opinion: 0.25,
-      industry_recognition: 0.25,
-      cultural_impact: 0.25,
-      people_quality: 0.25
+      popular_opinion: 0.30,
+      industry_recognition: 0.20,
+      financial_success: 0.20,
+      cultural_impact: 0.15,
+      people_quality: 0.15
     }
 
     actual_weights = weights || default_weights
@@ -269,44 +270,55 @@ defmodule Cinegraph.Predictions.MoviePredictor do
       %{
         criterion: :popular_opinion,
         raw_score: Float.round(to_float(components[:popular_opinion]) * 100, 1),
-        weight: Map.get(actual_weights, :popular_opinion, 0.25),
+        weight: Map.get(actual_weights, :popular_opinion, 0.30),
         weighted_points:
           Float.round(
             to_float(components[:popular_opinion]) *
-              Map.get(actual_weights, :popular_opinion, 0.25) * 100,
+              Map.get(actual_weights, :popular_opinion, 0.30) * 100,
             1
           )
       },
       %{
         criterion: :industry_recognition,
         raw_score: Float.round(to_float(components[:industry_recognition]) * 100, 1),
-        weight: Map.get(actual_weights, :industry_recognition, 0.2),
+        weight: Map.get(actual_weights, :industry_recognition, 0.20),
         weighted_points:
           Float.round(
             to_float(components[:industry_recognition]) *
-              Map.get(actual_weights, :industry_recognition, 0.2) * 100,
+              Map.get(actual_weights, :industry_recognition, 0.20) * 100,
             1
           )
       },
       %{
         criterion: :cultural_impact,
         raw_score: Float.round(to_float(components[:cultural_impact]) * 100, 1),
-        weight: Map.get(actual_weights, :cultural_impact, 0.2),
+        weight: Map.get(actual_weights, :cultural_impact, 0.15),
         weighted_points:
           Float.round(
             to_float(components[:cultural_impact]) *
-              Map.get(actual_weights, :cultural_impact, 0.2) * 100,
+              Map.get(actual_weights, :cultural_impact, 0.15) * 100,
             1
           )
       },
       %{
         criterion: :people_quality,
         raw_score: Float.round(to_float(components[:people_quality]) * 100, 1),
-        weight: Map.get(actual_weights, :people_quality, 0.2),
+        weight: Map.get(actual_weights, :people_quality, 0.15),
         weighted_points:
           Float.round(
-            to_float(components[:people_quality]) * Map.get(actual_weights, :people_quality, 0.2) *
+            to_float(components[:people_quality]) * Map.get(actual_weights, :people_quality, 0.15) *
               100,
+            1
+          )
+      },
+      %{
+        criterion: :financial_success,
+        raw_score: Float.round(to_float(components[:financial_success]) * 100, 1),
+        weight: Map.get(actual_weights, :financial_success, 0.20),
+        weighted_points:
+          Float.round(
+            to_float(components[:financial_success]) *
+              Map.get(actual_weights, :financial_success, 0.20) * 100,
             1
           )
       }


### PR DESCRIPTION
### TL;DR

Adjusted movie scoring weights and added financial success as a new scoring criterion.

### What changed?

- Modified the default weights for movie score components:
  - Increased popular opinion from 0.25 to 0.30
  - Decreased industry recognition from 0.25 to 0.20
  - Decreased cultural impact from 0.25 to 0.15
  - Decreased people quality from 0.25 to 0.15
  - Added a new criterion: financial success with weight 0.20
- Added a new score component for financial success in the breakdown list

### How to test?

1. Run the movie predictor on a sample movie
2. Verify that the score breakdown includes the new financial_success component
3. Check that the weighted calculations use the updated weights
4. Confirm that the total score reflects all five components with their proper weights

### Why make this change?

Financial success is an important indicator of a movie's overall performance and audience reach. This change provides a more balanced scoring system that better reflects industry standards by giving more weight to popular opinion while incorporating box office performance as a distinct factor in the evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Financial Success” metric to the score breakdown with adjustable weighting.
  * Rebalanced default weights: Popular Opinion 0.30, Industry Recognition 0.20, Cultural Impact 0.15, People Quality 0.15, Financial Success 0.20.
  * Updated overall and per-criterion scoring to reflect the new defaults.
  * UI weight inputs now include and map “Financial Success,” allowing users to tune its influence on profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->