### PR TITLE
rabbit fixes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,17 +16,15 @@ end
 # Use System.get_env since Dotenvy loads .env into system env in dev,
 # and Fly.io sets env vars directly in production
 # API key is optional at config time - the service will handle missing keys at runtime
-config :cinegraph, Cinegraph.Services.TMDb.Client,
-  api_key: System.get_env("TMDB_API_KEY")
+config :cinegraph, Cinegraph.Services.TMDb.Client, api_key: System.get_env("TMDB_API_KEY")
 
 # Configure OMDb (optional)
-config :cinegraph, Cinegraph.Services.OMDb.Client,
-  api_key: System.get_env("OMDB_API_KEY") || ""
+config :cinegraph, Cinegraph.Services.OMDb.Client, api_key: System.get_env("OMDB_API_KEY") || ""
 
 # Configure Zyte API (optional, for Oscar scraping)
 config :cinegraph,
-  :zyte_api_key,
-  System.get_env("ZYTE_API_KEY") || ""
+       :zyte_api_key,
+       System.get_env("ZYTE_API_KEY") || ""
 
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
@@ -58,12 +56,18 @@ end
 
 if config_env() == :prod do
   # Get database credentials from environment variables
-  username = System.get_env("DATABASE_USERNAME") ||
-    raise "environment variable DATABASE_USERNAME is missing"
-  password = System.get_env("DATABASE_PASSWORD") ||
-    raise "environment variable DATABASE_PASSWORD is missing"
-  hostname = System.get_env("DATABASE_HOST") ||
-    raise "environment variable DATABASE_HOST is missing"
+  username =
+    System.get_env("DATABASE_USERNAME") ||
+      raise "environment variable DATABASE_USERNAME is missing"
+
+  password =
+    System.get_env("DATABASE_PASSWORD") ||
+      raise "environment variable DATABASE_PASSWORD is missing"
+
+  hostname =
+    System.get_env("DATABASE_HOST") ||
+      raise "environment variable DATABASE_HOST is missing"
+
   port_num = String.to_integer(System.get_env("DATABASE_PORT") || "5432")
   database = System.get_env("DATABASE") || "postgres"
 
@@ -104,7 +108,10 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
+  host =
+    System.get_env("PHX_HOST") ||
+      raise "environment variable PHX_HOST is missing"
+
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :cinegraph, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
@@ -124,8 +131,7 @@ if config_env() == :prod do
       "https://cinegraph.org",
       "https://www.cinegraph.org",
       # Also allow Fly.io internal domain for health checks
-      "https://cinegraph.fly.dev",
-      "https://#{host}"
+      "https://cinegraph.fly.dev"
     ],
     secret_key_base: secret_key_base
 

--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ kill_signal = 'SIGTERM'
   release_command = '/app/bin/migrate'
 
 [env]
-  PHX_HOST = 'cinegraph.fly.dev'
+  PHX_HOST = 'cinegraph.org'
   PORT = '8080'
   DATABASE_HOST = 'eu-central-1.pg.psdb.cloud'
 


### PR DESCRIPTION
### TL;DR

Updated domain configuration to use cinegraph.org as the primary domain instead of the Fly.io subdomain.

### What changed?

- Changed `PHX_HOST` in fly.toml from 'cinegraph.fly.dev' to 'cinegraph.org'
- Made `PHX_HOST` a required environment variable in production by adding a raise statement
- Removed redundant `"https://#{host}"` from the CORS origins list since we now explicitly list the domains
- Reformatted configuration blocks for better readability

### How to test?

1. Deploy the application to production
2. Verify that the application is accessible at https://cinegraph.org
3. Confirm that CORS is working properly for requests from cinegraph.org and www.cinegraph.org
4. Ensure health checks from cinegraph.fly.dev still function correctly

### Why make this change?

This change prepares the application to use a custom domain (cinegraph.org) as the primary domain instead of relying on the default Fly.io subdomain. Using a custom domain provides a more professional appearance and better branding for the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated primary host configuration from cinegraph.fly.dev to cinegraph.org
  * Enhanced host validation to require explicit PHX_HOST configuration
  * Refined allowed origins to be more restrictive, now explicitly specifying permitted domains
  * Applied formatting refinements to runtime configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->