### PR TITLE
oban change

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -69,6 +69,9 @@ config :cinegraph, dev_routes: true
 # Enable debug logging in development
 config :cinegraph, dev_logging?: true
 
+# Disable admin authentication in development
+config :cinegraph, admin_auth_disabled: true
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -98,8 +98,10 @@ defmodule CinegraphWeb.Router do
   end
 
   # Basic auth for admin routes
+  @admin_auth_disabled Application.compile_env(:cinegraph, :admin_auth_disabled, false)
+
   defp admin_auth(conn, _opts) do
-    if Mix.env() == :dev do
+    if @admin_auth_disabled do
       conn
     else
       username = System.get_env("ADMIN_USERNAME") || "admin"


### PR DESCRIPTION
### TL;DR

Added a configuration option to disable admin authentication in development environment.

### What changed?

- Added a new configuration option `admin_auth_disabled` in `config/dev.exs` and set it to `true` for development
- Modified the `admin_auth` function in `router.ex` to check this configuration flag instead of directly checking the environment
- Introduced a module attribute `@admin_auth_disabled` that reads the configuration at compile time with a default value of `false`

### How to test?

1. Run the application in development mode
2. Access admin routes without authentication
3. Verify that admin routes are accessible without credentials
4. Change the config value to `false` in dev.exs and restart the application
5. Verify that admin routes now require authentication

### Why make this change?

This change improves the development workflow by making admin authentication configurable rather than tied directly to the environment. It allows developers to test admin authentication behavior in development when needed, while keeping the convenience of disabled authentication by default in development.