### PR TITLE
fixes for rabbit

### DIFF
--- a/lib/cinegraph/workers/year_import_completion_worker.ex
+++ b/lib/cinegraph/workers/year_import_completion_worker.ex
@@ -111,6 +111,9 @@ defmodule Cinegraph.Workers.YearImportCompletionWorker do
     scheduled =
       Repo.one(from(j in base_query, where: j.state == "scheduled", select: count(j.id))) || 0
 
+    retryable =
+      Repo.one(from(j in base_query, where: j.state == "retryable", select: count(j.id))) || 0
+
     executing =
       Repo.one(from(j in base_query, where: j.state == "executing", select: count(j.id))) || 0
 
@@ -122,6 +125,6 @@ defmodule Cinegraph.Workers.YearImportCompletionWorker do
         from(j in base_query, where: j.state in ["discarded", "cancelled"], select: count(j.id))
       ) || 0
 
-    {pending + scheduled, executing, completed, failed}
+    {pending + scheduled + retryable, executing, completed, failed}
   end
 end


### PR DESCRIPTION
### TL;DR

Improved job counting and cancellation logic for year imports.

### What changed?

- Added `retryable` jobs to the pending count in `YearImportCompletionWorker`
- Refactored the `cancel_jobs_for_year` function to use Oban's API for cancellation instead of direct database updates

### How to test?

1. Create a year import with multiple jobs
2. Verify that retryable jobs are now properly counted in the pending total
3. Cancel a year import and confirm that all associated jobs are properly cancelled with lifecycle callbacks triggered

### Why make this change?

The previous implementation had two issues:
1. It wasn't counting jobs in the "retryable" state as pending, which could lead to inaccurate progress tracking
2. It was directly updating the database to cancel jobs instead of using Oban's API, which meant that job lifecycle callbacks weren't being triggered properly