### PR TITLE
fixes for rabbit

### DIFF
--- a/priv/repo/migrations/20251202203809_remove_redundant_indexes.exs
+++ b/priv/repo/migrations/20251202203809_remove_redundant_indexes.exs
@@ -6,7 +6,7 @@ defmodule Cinegraph.Repo.Migrations.RemoveRedundantIndexes do
   See GitHub Issue #401 for full documentation.
 
   Summary of removals:
-  - movie_credits: 6 redundant indexes (duplicates and covered indexes)
+  - movie_credits: 5 redundant indexes (duplicates and covered indexes)
   - external_metrics: 2 redundant indexes
   - movie_videos: 1 duplicate index
   - movie_recommendations: 1 covered index
@@ -15,12 +15,12 @@ defmodule Cinegraph.Repo.Migrations.RemoveRedundantIndexes do
   - metric_definitions: 1 covered index
   - movies: 1 covered index
 
-  Total: 17 indexes removed
+  Total: 16 indexes removed
   """
 
   def up do
     # ============================================
-    # movie_credits table (6 redundant indexes)
+    # movie_credits table (5 redundant indexes)
     # ============================================
 
     # Duplicate of movie_credits_movie_id_person_id_index
@@ -57,7 +57,7 @@ defmodule Cinegraph.Repo.Migrations.RemoveRedundantIndexes do
     # ============================================
 
     # Duplicate of movie_videos_tmdb_id_index (both are unique indexes on tmdb_id)
-    drop_if_exists index(:movie_videos, [:tmdb_id], name: :movie_videos_tmdb_id_constraint)
+    drop_if_exists unique_index(:movie_videos, [:tmdb_id], name: :movie_videos_tmdb_id_constraint)
 
     # ============================================
     # movie_recommendations table (1 redundant index)


### PR DESCRIPTION
### TL;DR

Fix incorrect index count and type in database migration for removing redundant indexes.

### What changed?

- Corrected the total count of redundant indexes from 17 to 16
- Updated the count for movie_credits table from 6 to 5 redundant indexes
- Fixed the `movie_videos_tmdb_id_constraint` index removal to use `unique_index` instead of regular `index`

### How to test?

1. Run the migration to ensure it executes without errors
2. Verify that the `movie_videos_tmdb_id_constraint` index is properly removed
3. Confirm database performance is maintained after index removals

### Why make this change?

This change ensures accuracy in the migration documentation and proper execution when removing the unique index on the movie_videos table. Using the correct function (`unique_index` vs `index`) is necessary for the migration to work properly, as these are different index types in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database schema by refining index definitions and removing redundant indexes to improve maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->