### PR TITLE
one more index

### DIFF
--- a/priv/repo/migrations/20251203100105_add_oban_jobs_queue_index.exs
+++ b/priv/repo/migrations/20251203100105_add_oban_jobs_queue_index.exs
@@ -1,0 +1,14 @@
+defmodule Cinegraph.Repo.Migrations.AddObanJobsQueueIndex do
+  use Ecto.Migration
+
+  @moduledoc """
+  Add standalone queue index on oban_jobs table.
+  PlanetScale recommendation #31.
+
+  Supports queries that filter by queue without state filtering.
+  """
+
+  def change do
+    create index(:oban_jobs, [:queue], name: :idx_oban_jobs_on_queue)
+  end
+end


### PR DESCRIPTION
### TL;DR

Added a standalone index on the `queue` column of the `oban_jobs` table.

### What changed?

Created a new migration file that adds an index named `idx_oban_jobs_on_queue` on the `queue` column of the `oban_jobs` table.

### How to test?

1. Run the migration with `mix ecto.migrate`
2. Verify the index was created by checking the database schema
3. Confirm that queries filtering by queue (without state filtering) perform better

### Why make this change?

This change follows PlanetScale recommendation #31 to improve query performance. The index supports queries that filter by queue without state filtering, which should enhance the performance of such operations.