### PR TITLE
fixes for more rabbit

### DIFF
--- a/lib/cinegraph/sitemap.ex
+++ b/lib/cinegraph/sitemap.ex
@@ -286,6 +286,8 @@ defmodule Cinegraph.Sitemap do
   end
 
   # Calculate priority for people based on popularity
+  defp calculate_person_priority(nil), do: 0.5
+
   defp calculate_person_priority(popularity) do
     cond do
       popularity >= 50 -> 0.9

--- a/lib/cinegraph_web/controllers/sitemap_controller.ex
+++ b/lib/cinegraph_web/controllers/sitemap_controller.ex
@@ -41,23 +41,22 @@ defmodule CinegraphWeb.SitemapController do
     safe_filename = Path.basename(filename)
 
     # Only allow .xml files
-    unless String.ends_with?(safe_filename, ".xml") do
+    if not String.ends_with?(safe_filename, ".xml") do
       conn
       |> put_status(:bad_request)
       |> text("Invalid file type")
-      |> halt()
-    end
-
-    sitemap_path = Path.join(@sitemap_dir, safe_filename)
-
-    if File.exists?(sitemap_path) do
-      conn
-      |> put_resp_content_type("application/xml")
-      |> send_file(200, sitemap_path)
     else
-      conn
-      |> put_status(:not_found)
-      |> text("Sitemap file not found")
+      sitemap_path = Path.join(@sitemap_dir, safe_filename)
+
+      if File.exists?(sitemap_path) do
+        conn
+        |> put_resp_content_type("application/xml")
+        |> send_file(200, sitemap_path)
+      else
+        conn
+        |> put_status(:not_found)
+        |> text("Sitemap file not found")
+      end
     end
   end
 end


### PR DESCRIPTION
### TL;DR

Fixed sitemap handling for people with nil popularity and improved controller logic flow.

### What changed?

- Added a function clause to handle `nil` popularity values in `calculate_person_priority/1`, defaulting to 0.5 priority
- Refactored the sitemap file controller logic to use an if/else structure instead of an unless/halt pattern
- Improved code readability in the sitemap controller by nesting the file existence check within the file type validation

### How to test?

1. Test sitemap generation with people who have nil popularity values
2. Request sitemap files with both valid and invalid extensions
3. Request both existing and non-existing sitemap files to verify proper responses

### Why make this change?

The previous implementation would crash when encountering people with nil popularity values. This fix ensures the application gracefully handles these cases with a reasonable default priority. Additionally, the controller logic refactoring improves readability and maintains the same functionality without using halt(), making the control flow more straightforward.