### PR TITLE
cache

### DIFF
--- a/lib/cinegraph_web/plugs/cache_control_plug.ex
+++ b/lib/cinegraph_web/plugs/cache_control_plug.ex
@@ -1,0 +1,46 @@
+defmodule CinegraphWeb.Plugs.CacheControlPlug do
+  @moduledoc """
+  Sets appropriate cache-control headers for different route types.
+
+  LiveView pages must not be cached by CDNs (like Cloudflare) because they contain
+  CSRF tokens that become stale. Cached pages with old CSRF tokens cause infinite
+  reload loops when the WebSocket connection fails validation.
+
+  Static assets can be cached aggressively since they have fingerprinted filenames.
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    # Register a before_send callback to set cache headers
+    # This runs after the response is built but before it's sent
+    register_before_send(conn, fn conn ->
+      set_cache_headers(conn)
+    end)
+  end
+
+  defp set_cache_headers(conn) do
+    # Only set headers for HTML responses (LiveView pages)
+    # Don't override headers for static assets, API responses, etc.
+    content_type = get_resp_header(conn, "content-type") |> List.first() || ""
+
+    cond do
+      # HTML pages (LiveView) - prevent CDN caching entirely
+      String.contains?(content_type, "text/html") ->
+        conn
+        |> put_resp_header("cache-control", "no-store, no-cache, must-revalidate, max-age=0")
+        |> put_resp_header("pragma", "no-cache")
+        |> put_resp_header("expires", "0")
+
+      # Already has cache-control set (e.g., redirects, static files)
+      get_resp_header(conn, "cache-control") != [] ->
+        conn
+
+      # Default - don't modify
+      true ->
+        conn
+    end
+  end
+end

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -8,6 +8,8 @@ defmodule CinegraphWeb.Router do
     plug :put_root_layout, html: {CinegraphWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    # Prevent CDN caching of LiveView pages (CSRF token staleness causes infinite loops)
+    plug CinegraphWeb.Plugs.CacheControlPlug
     # SEO: 301 redirects from numeric IDs to canonical slugs
     plug CinegraphWeb.Plugs.SEORedirectPlug
   end


### PR DESCRIPTION
### TL;DR

Added cache control headers to prevent CDN caching of LiveView pages while allowing static assets to be cached normally.

### What changed?

- Created a new `CacheControlPlug` module that sets appropriate cache-control headers
- Added the plug to the browser pipeline in the router
- Implemented logic to prevent caching of HTML/LiveView pages while preserving existing cache headers for static assets

### How to test?

1. Load any LiveView page and check the response headers
2. Verify that HTML pages have `cache-control: no-store, no-cache, must-revalidate, max-age=0`
3. Verify that static assets (JS, CSS, images) maintain their normal cache headers
4. If using a CDN like Cloudflare, verify that LiveView pages aren't being cached

### Why make this change?

LiveView pages contain CSRF tokens that become stale when cached by CDNs like Cloudflare. When these pages are served from cache with outdated tokens, they cause infinite reload loops when the WebSocket connection fails validation. This change ensures LiveView pages are always served fresh while still allowing static assets to be cached aggressively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP cache handling for web pages to ensure users always receive fresh content instead of potentially stale cached versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->