### PR TITLE
finish cache

### DIFF
--- a/lib/cinegraph_web/plugs/cache_control_plug.ex
+++ b/lib/cinegraph_web/plugs/cache_control_plug.ex
@@ -30,9 +30,9 @@ defmodule CinegraphWeb.Plugs.CacheControlPlug do
       # HTML pages (LiveView) - prevent CDN caching entirely
       String.contains?(content_type, "text/html") ->
         conn
-        |> put_resp_header("cache-control", "no-store, no-cache, must-revalidate, max-age=0")
+        |> put_resp_header("cache-control", "private, no-store, no-cache, must-revalidate, max-age=0")
         |> put_resp_header("pragma", "no-cache")
-        |> put_resp_header("expires", "0")
+        |> put_resp_header("expires", "-1")
 
       # Already has cache-control set (e.g., redirects, static files)
       get_resp_header(conn, "cache-control") != [] ->


### PR DESCRIPTION
### TL;DR

Updated cache control headers for HTML pages to ensure proper browser and CDN behavior.

### What changed?

- Added the `private` directive to the `cache-control` header for HTML pages
- Changed the `expires` header value from `0` to `-1` for better compatibility

### How to test?

1. Load any HTML page in the application
2. Inspect the network response headers in browser dev tools
3. Verify that the `cache-control` header includes `private` and the `expires` header is set to `-1`
4. Test across different browsers to ensure consistent caching behavior

### Why make this change?

The `private` directive explicitly instructs CDNs and intermediate proxies not to cache the content, ensuring that only the end user's browser may store the response. The `expires: -1` value is more widely recognized as an immediate expiration indicator across different browsers and proxy servers, providing more consistent cache invalidation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined cache control settings for web pages to improve how dynamic content is managed across browsers and intermediate caches, ensuring better content freshness handling while maintaining existing performance characteristics and preventing unwanted caching of time-sensitive content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->