### PR TITLE
fixing subsearch

### DIFF
--- a/lib/cinegraph/movies/query/params.ex
+++ b/lib/cinegraph/movies/query/params.ex
@@ -383,10 +383,11 @@ defmodule Cinegraph.Movies.Query.Params do
     filters = []
 
     # Add search filter
+    # Note: Flop's :ilike operator automatically adds % wildcards,
+    # so we pass the raw search term without wrapping it in %
     filters =
       if params.search && params.search != "" do
-        pattern = "%#{params.search}%"
-        filters ++ [%{field: :title, op: :ilike, value: pattern}]
+        filters ++ [%{field: :title, op: :ilike, value: params.search}]
       else
         filters
       end

--- a/lib/cinegraph_web/live/awards_live/show.html.heex
+++ b/lib/cinegraph_web/live/awards_live/show.html.heex
@@ -39,13 +39,14 @@
         
 <!-- Search Bar -->
         <div class="w-full lg:w-96">
-          <form phx-change="search" class="relative">
+          <form phx-submit="search" class="relative">
             <input
               type="text"
               name="search"
               value={@search_term}
               placeholder="Search films..."
               class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              phx-change="search"
               phx-debounce="300"
             />
             <svg
@@ -111,8 +112,8 @@
       </nav>
     </div>
     
-<!-- Sort Options -->
-    <div class="mb-6 flex items-center gap-4">
+<!-- Sort Options and Filter Toggle -->
+    <div class="mb-6 flex flex-wrap items-center gap-4">
       <label class="text-sm font-medium text-gray-700">Sort by:</label>
       <select
         phx-change="change_sort"
@@ -147,7 +148,147 @@
           Rating (Highest)
         </option>
       </select>
+
+      <button
+        type="button"
+        phx-click="toggle_filters"
+        class={[
+          "inline-flex items-center px-3 py-2 border rounded-md text-sm font-medium",
+          if(@show_filters,
+            do: "border-blue-500 text-blue-600 bg-blue-50",
+            else: "border-gray-300 text-gray-700 bg-white hover:bg-gray-50"
+          )
+        ]}
+      >
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+          />
+        </svg>
+        Filters
+        <%= if has_active_filters(@filters) do %>
+          <span class="ml-1 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-blue-500 rounded-full">
+            {length(get_active_filters(@filters, assigns))}
+          </span>
+        <% end %>
+      </button>
     </div>
+    
+<!-- Filter Panel -->
+    <%= if @show_filters do %>
+      <div class="mb-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
+        <form phx-submit="apply_filters" class="space-y-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <!-- Genre Filter -->
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Genre</label>
+              <input type="hidden" name="filters[genres][]" value="" />
+              <select
+                name="filters[genres][]"
+                multiple
+                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                size="4"
+              >
+                <%= for genre <- @available_genres do %>
+                  <option
+                    value={genre.id}
+                    selected={to_string(genre.id) in (@filters[:genres] || [])}
+                  >
+                    {genre.name}
+                  </option>
+                <% end %>
+              </select>
+              <p class="mt-1 text-xs text-gray-500">Hold Ctrl/Cmd to select multiple</p>
+            </div>
+            
+<!-- Decade Filter -->
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Decade</label>
+              <select
+                name="filters[decade]"
+                class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              >
+                <option value="">All Decades</option>
+                <%= for decade <- @available_decades do %>
+                  <option
+                    value={decade.value}
+                    selected={@filters[:decade] == to_string(decade.value)}
+                  >
+                    {decade.label}
+                  </option>
+                <% end %>
+              </select>
+            </div>
+            
+<!-- Cast & Crew Filter -->
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Cast & Crew</label>
+              <.live_component
+                module={CinegraphWeb.Components.PersonAutocomplete}
+                id="awards-people-search"
+                field_name="filters[people_search]"
+                selected_people={@filters.people_ids || []}
+                search_term=""
+              />
+            </div>
+          </div>
+
+          <div class="flex items-center gap-3 pt-2">
+            <button
+              type="submit"
+              class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Apply Filters
+            </button>
+            <%= if has_active_filters(@filters) do %>
+              <button
+                type="button"
+                phx-click="clear_filters"
+                class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                Clear All
+              </button>
+            <% end %>
+          </div>
+        </form>
+      </div>
+    <% end %>
+    
+<!-- Active Filters Display -->
+    <%= if has_active_filters(@filters) and not @show_filters do %>
+      <div class="mb-4 flex flex-wrap items-center gap-2">
+        <span class="text-sm text-gray-600">Active filters:</span>
+        <%= for filter <- get_active_filters(@filters, assigns) do %>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+            {filter.label}: {filter.display_value}
+            <button
+              type="button"
+              phx-click="remove_filter"
+              phx-value-filter={filter.key}
+              class="ml-1 inline-flex items-center justify-center w-4 h-4 rounded-full text-blue-400 hover:bg-blue-200 hover:text-blue-600"
+            >
+              <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fill-rule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </button>
+          </span>
+        <% end %>
+        <button
+          type="button"
+          phx-click="clear_filters"
+          class="text-xs text-gray-500 hover:text-gray-700 underline"
+        >
+          Clear all
+        </button>
+      </div>
+    <% end %>
     
 <!-- Movies Grid -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">

--- a/lib/cinegraph_web/live/list_live/show.ex
+++ b/lib/cinegraph_web/live/list_live/show.ex
@@ -12,6 +12,9 @@ defmodule CinegraphWeb.ListLive.Show do
 
   @impl true
   def mount(_params, _session, socket) do
+    # Load filter options (same as MovieLive.Index)
+    filter_options = Search.get_filter_options()
+
     {:ok,
      socket
      |> assign(:movies, [])
@@ -19,7 +22,14 @@ defmodule CinegraphWeb.ListLive.Show do
      |> assign(:list_info, nil)
      |> assign(:search_term, "")
      |> assign(:sort_criteria, "release_date")
-     |> assign(:sort_direction, :desc)}
+     |> assign(:sort_direction, :desc)
+     |> assign(:show_filters, false)
+     |> assign(:filters, %{})
+     # Filter options for dropdowns
+     |> assign(:available_genres, filter_options.genres)
+     |> assign(:available_decades, filter_options.decades)
+     # Person search options
+     |> assign(:person_options, [])}
   end
 
   @impl true
@@ -41,6 +51,7 @@ defmodule CinegraphWeb.ListLive.Show do
              |> assign(:meta, meta)
              |> assign(:params, params)
              |> assign(:search_term, params["search"] || "")
+             |> assign(:filters, normalize_filters(params))
              |> assign(
                :sort_criteria,
                extract_sort_criteria(params["sort"] || "release_date_desc")
@@ -59,6 +70,7 @@ defmodule CinegraphWeb.ListLive.Show do
              |> assign(:movies, [])
              |> assign(:meta, %{})
              |> assign(:params, params)
+             |> assign(:filters, %{})
              |> put_flash(:error, "Unable to load movies")}
         end
 
@@ -85,6 +97,90 @@ defmodule CinegraphWeb.ListLive.Show do
   @impl true
   def handle_event("page", %{"page" => page}, socket) do
     params = build_params(socket, %{"page" => page})
+    {:noreply, push_patch(socket, to: ~p"/lists/#{socket.assigns.list_info.slug}?#{params}")}
+  end
+
+  @impl true
+  def handle_event("toggle_filters", _params, socket) do
+    {:noreply, assign(socket, :show_filters, !socket.assigns.show_filters)}
+  end
+
+  @impl true
+  def handle_event("apply_filters", %{"filters" => filters}, socket) do
+    # Clean up filters to handle empty arrays from hidden fields
+    cleaned_filters =
+      filters
+      |> Enum.map(fn
+        {key, [""]} -> {key, []}
+        {key, value} when is_list(value) -> {key, Enum.reject(value, &(&1 == "" || &1 == nil))}
+        other -> other
+      end)
+      |> Map.new()
+
+    params =
+      socket.assigns.params
+      |> Map.merge(cleaned_filters)
+      |> Map.put("page", "1")
+      |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" or v == [] end)
+      |> Map.new()
+
+    {:noreply, push_patch(socket, to: ~p"/lists/#{socket.assigns.list_info.slug}?#{params}")}
+  end
+
+  @impl true
+  def handle_event("clear_filters", _params, socket) do
+    # Keep only search and sort, reset filters
+    params =
+      socket.assigns.params
+      |> Map.take(["search", "sort"])
+      |> Map.put("page", "1")
+      |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
+      |> Map.new()
+
+    {:noreply, push_patch(socket, to: ~p"/lists/#{socket.assigns.list_info.slug}?#{params}")}
+  end
+
+  @impl true
+  def handle_event("remove_filter", %{"filter" => filter_key}, socket) do
+    params =
+      socket.assigns.params
+      |> Map.delete(filter_key)
+      |> Map.put("page", "1")
+
+    {:noreply, push_patch(socket, to: ~p"/lists/#{socket.assigns.list_info.slug}?#{params}")}
+  end
+
+  # Handle autocomplete search for people
+  @impl true
+  def handle_info({:search_people_autocomplete, component_id, query}, socket) do
+    results = Search.search_people(query, 10)
+
+    # Update component with results and cache them
+    send_update(CinegraphWeb.Components.PersonAutocomplete,
+      id: component_id,
+      search_results: results,
+      searching: false,
+      cache_query: query,
+      cache_timestamp: DateTime.utc_now()
+    )
+
+    {:noreply, socket}
+  end
+
+  # Handle people selection updates from autocomplete component
+  @impl true
+  def handle_info({:people_selected, _component_id, selected_people}, socket) do
+    # Update the filters with the new people selection
+    people_ids = Enum.map_join(selected_people, ",", & &1.id)
+
+    params =
+      if people_ids == "" do
+        Map.delete(socket.assigns.params, "people_ids")
+      else
+        Map.put(socket.assigns.params, "people_ids", people_ids)
+      end
+      |> Map.put("page", "1")
+
     {:noreply, push_patch(socket, to: ~p"/lists/#{socket.assigns.list_info.slug}?#{params}")}
   end
 
@@ -172,4 +268,69 @@ defmodule CinegraphWeb.ListLive.Show do
       text
     end
   end
+
+  # Filter helpers
+  defp normalize_filters(params) do
+    %{
+      genres: parse_array_param(params["genres"]),
+      decade: params["decade"],
+      people_ids: parse_array_param(params["people_ids"])
+    }
+  end
+
+  defp parse_array_param(nil), do: []
+  defp parse_array_param([]), do: []
+  defp parse_array_param(value) when is_list(value), do: value
+  defp parse_array_param(value) when is_binary(value), do: String.split(value, ",", trim: true)
+
+  # Check if any filters are active
+  def has_active_filters(filters) do
+    (filters.genres != [] and filters.genres != nil) or
+      (filters.decade != nil and filters.decade != "") or
+      (filters.people_ids != [] and filters.people_ids != nil)
+  end
+
+  # Get list of active filters for display
+  def get_active_filters(filters, assigns) do
+    []
+    |> maybe_add_genre_filter(filters, assigns)
+    |> maybe_add_decade_filter(filters)
+    |> maybe_add_people_filter(filters)
+  end
+
+  defp maybe_add_genre_filter(acc, %{genres: genres}, assigns)
+       when genres != [] and genres != nil do
+    genre_names =
+      genres
+      |> Enum.map(fn id ->
+        id_int = if is_binary(id), do: String.to_integer(id), else: id
+        genre = Enum.find(assigns.available_genres, &(&1.id == id_int))
+        if genre, do: genre.name, else: to_string(id)
+      end)
+      |> Enum.join(", ")
+
+    display =
+      if String.length(genre_names) > 25,
+        do: String.slice(genre_names, 0..22) <> "...",
+        else: genre_names
+
+    acc ++ [%{key: "genres", label: "Genres", display_value: display}]
+  end
+
+  defp maybe_add_genre_filter(acc, _, _), do: acc
+
+  defp maybe_add_decade_filter(acc, %{decade: decade}) when decade != nil and decade != "" do
+    acc ++ [%{key: "decade", label: "Decade", display_value: "#{decade}s"}]
+  end
+
+  defp maybe_add_decade_filter(acc, _), do: acc
+
+  defp maybe_add_people_filter(acc, %{people_ids: people_ids})
+       when people_ids != [] and people_ids != nil do
+    count = length(people_ids)
+    display = if count == 1, do: "1 person", else: "#{count} people"
+    acc ++ [%{key: "people_ids", label: "People", display_value: display}]
+  end
+
+  defp maybe_add_people_filter(acc, _), do: acc
 end

--- a/lib/cinegraph_web/live/list_live/show.html.heex
+++ b/lib/cinegraph_web/live/list_live/show.html.heex
@@ -34,13 +34,14 @@
         
 <!-- Search Bar -->
         <div class="w-full lg:w-96">
-          <form phx-change="search" class="relative">
+          <form phx-submit="search" class="relative">
             <input
               type="text"
               name="search"
               value={@search_term}
               placeholder="Search within this list..."
               class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              phx-change="search"
               phx-debounce="300"
             />
             <svg
@@ -61,48 +62,186 @@
       </div>
     </div>
     
-<!-- Sort Options -->
-    <div class="mb-6 flex items-center gap-4">
-      <label class="text-sm font-medium text-gray-700">Sort by:</label>
-      <select
-        phx-change="change_sort"
-        name="sort"
-        class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-      >
-        <option
-          value="release_date_desc"
-          selected={@sort_criteria == "release_date" && @sort_direction == :desc}
+<!-- Filter & Sort Controls -->
+    <div class="mb-6">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <!-- Filter Toggle -->
+        <button
+          type="button"
+          phx-click="toggle_filters"
+          class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
         >
-          Release Date (Newest)
-        </option>
-        <option
-          value="release_date_asc"
-          selected={@sort_criteria == "release_date" && @sort_direction == :asc}
-        >
-          Release Date (Oldest)
-        </option>
-        <option value="title_asc" selected={@sort_criteria == "title" && @sort_direction == :asc}>
-          Title (A-Z)
-        </option>
-        <option
-          value="title_desc"
-          selected={@sort_criteria == "title" && @sort_direction == :desc}
-        >
-          Title (Z-A)
-        </option>
-        <option
-          value="rating_desc"
-          selected={@sort_criteria == "rating" && @sort_direction == :desc}
-        >
-          Rating (Highest)
-        </option>
-        <option
-          value="rating_asc"
-          selected={@sort_criteria == "rating" && @sort_direction == :asc}
-        >
-          Rating (Lowest)
-        </option>
-      </select>
+          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+            />
+          </svg>
+          <%= if @show_filters do %>
+            Hide Filters
+          <% else %>
+            Show Filters
+          <% end %>
+          <%= if has_active_filters(@filters) do %>
+            <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+              Active
+            </span>
+          <% end %>
+        </button>
+        
+<!-- Sort Dropdown -->
+        <div class="flex items-center gap-2">
+          <label class="text-sm font-medium text-gray-700">Sort by:</label>
+          <select
+            phx-change="change_sort"
+            name="sort"
+            class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+          >
+            <option
+              value="release_date_desc"
+              selected={@sort_criteria == "release_date" && @sort_direction == :desc}
+            >
+              Release Date (Newest)
+            </option>
+            <option
+              value="release_date_asc"
+              selected={@sort_criteria == "release_date" && @sort_direction == :asc}
+            >
+              Release Date (Oldest)
+            </option>
+            <option
+              value="title_asc"
+              selected={@sort_criteria == "title" && @sort_direction == :asc}
+            >
+              Title (A-Z)
+            </option>
+            <option
+              value="title_desc"
+              selected={@sort_criteria == "title" && @sort_direction == :desc}
+            >
+              Title (Z-A)
+            </option>
+            <option
+              value="rating_desc"
+              selected={@sort_criteria == "rating" && @sort_direction == :desc}
+            >
+              Rating (Highest)
+            </option>
+            <option
+              value="rating_asc"
+              selected={@sort_criteria == "rating" && @sort_direction == :asc}
+            >
+              Rating (Lowest)
+            </option>
+          </select>
+        </div>
+      </div>
+      
+<!-- Filter Panel -->
+      <%= if @show_filters do %>
+        <div class="mt-4 bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+          <form phx-change="apply_filters">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <!-- Genre Filter -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  Genre
+                </label>
+                <input type="hidden" name="filters[genres][]" value="" />
+                <.multi_select_dropdown
+                  id="list-genres-select"
+                  name="filters[genres][]"
+                  options={@available_genres}
+                  selected={@filters.genres || []}
+                  placeholder="Select genres..."
+                  label_field={:name}
+                  value_field={:id}
+                />
+              </div>
+              
+<!-- Decade Filter -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  Decade
+                </label>
+                <select
+                  name="filters[decade]"
+                  class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                >
+                  <option value="">All Decades</option>
+                  <%= for decade <- @available_decades do %>
+                    <option
+                      value={decade.value}
+                      selected={to_string(decade.value) == @filters.decade}
+                    >
+                      {decade.label}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+              
+<!-- Cast & Crew Filter -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  Cast & Crew
+                </label>
+                <.live_component
+                  module={CinegraphWeb.Components.PersonAutocomplete}
+                  id="list-people-search"
+                  field_name="filters[people_search]"
+                  selected_people={@filters.people_ids || []}
+                  search_term=""
+                />
+              </div>
+            </div>
+            
+<!-- Filter Actions -->
+            <div class="mt-4 flex justify-end">
+              <button
+                type="button"
+                phx-click="clear_filters"
+                class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                Clear Filters
+              </button>
+            </div>
+          </form>
+        </div>
+      <% end %>
+      
+<!-- Active Filters Display -->
+      <%= if has_active_filters(@filters) do %>
+        <div class="mt-4 bg-white p-3 rounded-lg shadow-sm border border-gray-200">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm font-medium text-gray-700">Active Filters:</span>
+            <button
+              type="button"
+              phx-click="clear_filters"
+              class="text-sm text-red-600 hover:text-red-800"
+            >
+              Clear All
+            </button>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <%= for filter <- get_active_filters(@filters, assigns) do %>
+              <span class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800">
+                {filter.label}: {filter.display_value}
+                <button
+                  type="button"
+                  phx-click="remove_filter"
+                  phx-value-filter={filter.key}
+                  class="ml-2 inline-flex items-center justify-center w-4 h-4 text-blue-600 hover:text-blue-800"
+                  title="Remove this filter"
+                >
+                  ×
+                </button>
+              </span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
     
 <!-- Movies Grid -->

--- a/lib/cinegraph_web/plugs/cache_control_plug.ex
+++ b/lib/cinegraph_web/plugs/cache_control_plug.ex
@@ -30,7 +30,10 @@ defmodule CinegraphWeb.Plugs.CacheControlPlug do
       # HTML pages (LiveView) - prevent CDN caching entirely
       String.contains?(content_type, "text/html") ->
         conn
-        |> put_resp_header("cache-control", "private, no-store, no-cache, must-revalidate, max-age=0")
+        |> put_resp_header(
+          "cache-control",
+          "private, no-store, no-cache, must-revalidate, max-age=0"
+        )
         |> put_resp_header("pragma", "no-cache")
         |> put_resp_header("expires", "-1")
 


### PR DESCRIPTION
### TL;DR

Added advanced filtering capabilities to Awards and List pages, and fixed search functionality.

### What changed?

- Added filter panels to Awards and List pages with genre, decade, and cast/crew filters
- Implemented active filter display with ability to remove individual filters
- Fixed search functionality to use Flop's built-in wildcard handling
- Added toggle buttons to show/hide filter panels
- Implemented filter state management and URL parameter handling
- Added person autocomplete component integration for cast/crew filtering

### How to test?

1. Visit any Awards page (e.g., /awards/oscar) or List page
2. Click the "Filters" button to open the filter panel
3. Try filtering by genre, decade, or cast/crew members
4. Verify that active filters display correctly and can be removed
5. Test search functionality with and without filters applied
6. Confirm that filter state persists in URL parameters

### Why make this change?

This enhancement improves the user experience by providing more powerful search and filtering capabilities across the site. Users can now find specific movies more easily within awards and list pages by combining text search with structured filters. The implementation also maintains URL-based state, allowing for shareable filtered views and browser history navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added advanced filtering system: filter by genre, decade, and cast/crew members
  * Added filter toggle button with badge displaying active filter count
  * Added active filters summary with individual filter removal options
  * Enhanced search to support live updates as you type

* **Bug Fixes**
  * Improved search parameter handling for more accurate results

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->