### PR TITLE
fixes for stats

### DIFF
--- a/lib/cinegraph/cache/dashboard_stats.ex
+++ b/lib/cinegraph/cache/dashboard_stats.ex
@@ -262,7 +262,16 @@ defmodule Cinegraph.Cache.DashboardStats do
 
   defp default_stats do
     %{
-      progress: %{our_total: 0, tmdb_total: 0, remaining: 0},
+      # Progress keys must match ImportStateV2.get_progress_with_metrics/0 structure
+      # which the template expects (tmdb_total_movies, our_total_movies, etc.)
+      progress: %{
+        tmdb_total_movies: 0,
+        our_total_movies: 0,
+        movies_remaining: 0,
+        completion_percentage: 0.0,
+        last_page_processed: 0,
+        last_full_sync: nil
+      },
       db_stats: default_db_stats(),
       canonical_stats: [],
       oscar_stats: [],
@@ -273,7 +282,7 @@ defmodule Cinegraph.Cache.DashboardStats do
       fallback_stats: %{},
       strategy_breakdown: [],
       import_metrics: [],
-      year_progress: %{years: [], sync_health: %{}, current_year: nil, is_running: false},
+      year_progress: %{years: [], sync_health: %{status: :loading, message: "Loading...", color: "gray"}, current_year: nil, is_running: false},
       movie_lists: [],
       canonical_lists: [],
       loading: true
@@ -849,11 +858,14 @@ defmodule Cinegraph.Cache.DashboardStats do
           _ -> 0
         end
 
+      # expected_count is stored in metadata as "expected_movie_count", not as a schema field
+      expected_count = get_in(list.metadata, ["expected_movie_count"])
+
       %{
         name: list.name,
         source_key: list.source_key,
-        our_count: count,
-        expected_count: list.expected_count,
+        count: count,
+        expected_count: expected_count,
         category: list.category
       }
     end)


### PR DESCRIPTION
### TL;DR

Updated the dashboard stats structure to match the expected format in the UI templates.

### What changed?

- Expanded the `progress` structure in `default_stats` to match the keys expected by `ImportStateV2.get_progress_with_metrics/0`
- Added default values for completion percentage, last page processed, and last full sync
- Updated the default `sync_health` object with status, message, and color properties
- Modified the movie list mapping to use `count` instead of `our_count` and to extract the expected count from metadata instead of a schema field

### How to test?

1. Load the dashboard and verify that progress statistics display correctly
2. Check that movie lists show the correct counts and expected values
3. Verify that the sync health indicator shows the proper loading state initially

### Why make this change?

The dashboard was expecting a different data structure than what was being provided, causing display issues or errors. This change aligns the cache data structure with what the UI templates expect, ensuring consistent rendering of dashboard statistics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dashboard progress tracking with completion percentage, last sync timestamp, and sync health status indicators
  * Improved data structure for better visibility into synchronization metrics

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->