### PR TITLE
working changes

### DIFF
--- a/lib/cinegraph/festivals.ex
+++ b/lib/cinegraph/festivals.ex
@@ -320,6 +320,7 @@ defmodule Cinegraph.Festivals do
     Repo.one(
       from(s in AwardImportStatus,
         where: s.organization_id == ^organization_id,
+        order_by: [desc: s.year],
         limit: 1
       )
     )
@@ -505,6 +506,10 @@ defmodule Cinegraph.Festivals do
       {k, v} when is_atom(k) -> {Atom.to_string(k), stringify_keys(v)}
       {k, v} -> {k, stringify_keys(v)}
     end)
+  end
+
+  defp stringify_keys(list) when is_list(list) do
+    Enum.map(list, &stringify_keys/1)
   end
 
   defp stringify_keys(value), do: value

--- a/lib/cinegraph/workers/award_import_orchestrator_worker.ex
+++ b/lib/cinegraph/workers/award_import_orchestrator_worker.ex
@@ -165,9 +165,12 @@ defmodule Cinegraph.Workers.AwardImportOrchestratorWorker do
       "AwardImportOrchestratorWorker: Retrying failed imports for organization #{org_id}"
     )
 
-    # Find years with failed status
+    # Find years with any failure status (failed, no_matches, low_match, empty)
     failed_statuses =
-      Festivals.list_award_import_statuses(organization_id: org_id, status: "failed")
+      Festivals.list_award_import_statuses(organization_id: org_id)
+      |> Enum.filter(fn status ->
+        status.status in ["failed", "no_matches", "low_match", "empty"]
+      end)
 
     if length(failed_statuses) == 0 do
       Logger.info(

--- a/lib/cinegraph_web/live/award_imports_live.html.heex
+++ b/lib/cinegraph_web/live/award_imports_live.html.heex
@@ -202,12 +202,12 @@
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
             <%= for org <- @organizations do %>
-              <tr
-                class="hover:bg-gray-50 cursor-pointer"
-                phx-click="show_organization_detail"
-                phx-value-org-id={org.organization_id}
-              >
-                <td class="px-4 py-4 whitespace-nowrap">
+              <tr class="hover:bg-gray-50">
+                <td
+                  class="px-4 py-4 whitespace-nowrap cursor-pointer"
+                  phx-click="show_organization_detail"
+                  phx-value-org-id={org.organization_id}
+                >
                   <div class="flex items-center">
                     <div>
                       <div class="text-sm font-medium text-gray-900">
@@ -386,10 +386,7 @@
 
 <!-- Organization Detail Modal -->
 <%= if @show_detail_modal && @selected_organization do %>
-  <div
-    class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50"
-    phx-click="close_modal"
-  >
+  <div class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
     <div
       class="relative top-10 mx-auto p-5 border w-11/12 max-w-4xl shadow-lg rounded-md bg-white"
       phx-click-away="close_modal"

--- a/lib/cinegraph_web/live/movie_live/index.ex
+++ b/lib/cinegraph_web/live/movie_live/index.ex
@@ -144,6 +144,12 @@ defmodule CinegraphWeb.MovieLive.Index do
     {:noreply, push_patch(socket, to: path)}
   end
 
+  # Delegate all other events to the SearchEventHandlers macro
+  @impl true
+  def handle_event(event, params, socket) do
+    super(event, params, socket)
+  end
+
   # Ensure filter options are always present in socket assigns
   defp ensure_filter_options(socket) do
     # Check if filter options are already loaded


### PR DESCRIPTION
### TL;DR

Fixed award import functionality with improved error handling, sorting, and UI enhancements.

### What changed?

- Added proper ordering to award import status queries to ensure the most recent year is returned first
- Implemented `stringify_keys` for lists to properly handle nested data structures
- Enhanced retry logic in `AwardImportOrchestratorWorker` to include all failure states ("failed", "no_matches", "low_match", "empty")
- Added error handling for empty year lists in `YearDiscoveryWorker` with appropriate logging
- Refactored year calculation in `YearDiscoveryWorker` to avoid redundant calls to `Enum.min/max`
- Added robust error handling for user inputs in `AwardImportsLive` with proper Integer parsing
- Improved UI in award imports page by making only the organization name clickable instead of the entire row
- Fixed modal behavior to prevent accidental closing when clicking inside the modal
- Added event delegation for unhandled events in `MovieLive.Index`

### How to test?

1. Test award import functionality with organizations that have various failure states
2. Verify that the most recent year appears first in award import status lists
3. Try importing years for organizations and check that error handling works correctly
4. Verify that the UI improvements work as expected - only organization names should be clickable
5. Test the modal behavior to ensure it doesn't close when clicking inside it
6. Check that the year discovery process handles empty year lists gracefully

### Why make this change?

These changes improve the reliability and user experience of the award import system. The enhanced error handling prevents crashes when dealing with invalid inputs, while the UI improvements make the interface more intuitive. The sorting fix ensures users see the most relevant (recent) data first, and the expanded retry logic ensures all types of failures are properly addressed during import retries.