### PR TITLE
ready for production

### DIFF
--- a/lib/cinegraph_web/live/award_imports_live.html.heex
+++ b/lib/cinegraph_web/live/award_imports_live.html.heex
@@ -596,53 +596,47 @@
         This will queue import jobs regardless of current status.
       </p>
 
-      <div class="space-y-2">
-        <button
-          phx-click="resync_years"
-          phx-value-org-id={@resync_org.organization_id}
-          phx-value-count="10"
-          class="w-full px-4 py-2 text-left bg-gray-50 hover:bg-orange-50 rounded border border-gray-200 hover:border-orange-300"
-        >
-          <span class="font-medium">Last 10 years</span>
-          <span class="text-sm text-gray-500 ml-2">(Quick test)</span>
-        </button>
-        <button
-          phx-click="resync_years"
-          phx-value-org-id={@resync_org.organization_id}
-          phx-value-count="25"
-          class="w-full px-4 py-2 text-left bg-gray-50 hover:bg-orange-50 rounded border border-gray-200 hover:border-orange-300"
-        >
-          <span class="font-medium">Last 25 years</span>
-          <span class="text-sm text-gray-500 ml-2">(Recent history)</span>
-        </button>
-        <button
-          phx-click="resync_years"
-          phx-value-org-id={@resync_org.organization_id}
-          phx-value-count="50"
-          class="w-full px-4 py-2 text-left bg-gray-50 hover:bg-orange-50 rounded border border-gray-200 hover:border-orange-300"
-        >
-          <span class="font-medium">Last 50 years</span>
-          <span class="text-sm text-gray-500 ml-2">(Extended history)</span>
-        </button>
-        <button
-          phx-click="resync_years"
-          phx-value-org-id={@resync_org.organization_id}
-          phx-value-count="all"
-          class="w-full px-4 py-2 text-left bg-orange-50 hover:bg-orange-100 rounded border border-orange-300 hover:border-orange-400"
-        >
-          <span class="font-medium text-orange-800">All {@resync_org.total_years} years</span>
-          <span class="text-sm text-orange-600 ml-2">(Complete resync)</span>
-        </button>
-      </div>
+      <form phx-submit="resync_years" class="space-y-4">
+        <input type="hidden" name="org-id" value={@resync_org.organization_id} />
 
-      <div class="mt-4 flex justify-end">
-        <button
-          phx-click="close_resync_modal"
-          class="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
-        >
-          Cancel
-        </button>
-      </div>
+        <div>
+          <label for="resync-count" class="block text-sm font-medium text-gray-700 mb-1">
+            Number of Years
+          </label>
+          <select
+            id="resync-count"
+            name="count"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          >
+            <option value="1">1 year (Quick test)</option>
+            <option value="2">2 years</option>
+            <option value="3">3 years</option>
+            <option value="5">5 years</option>
+            <option value="10">10 years</option>
+            <option value="15">15 years</option>
+            <option value="20">20 years</option>
+            <option value="25">25 years</option>
+            <option value="50">50 years</option>
+            <option value="all">All {@resync_org.total_years} years</option>
+          </select>
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            phx-click="close_resync_modal"
+            class="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+          >
+            Start Resync
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
### TL;DR

Replaced the resync years button list with a dropdown select menu and submit form.

### What changed?

- Converted the multiple resync buttons into a proper form with a dropdown select
- Added more granular year options (1, 2, 3, 5, 15, 20 years) in addition to existing options
- Added a dedicated "Start Resync" submit button with improved styling
- Improved the UI layout with proper form elements and spacing

### How to test?

1. Navigate to the award imports page
2. Select an organization to resync
3. Verify the new dropdown interface appears with all year options
4. Test selecting different year options and submitting the form
5. Confirm the resync functionality works as expected

### Why make this change?

The dropdown approach provides a more compact and flexible UI that allows for more granular control over the number of years to resync. This improves usability by offering more options while taking up less screen space, and follows better form design patterns with a clear submit action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned the award resync interface with a form-based modal. Users can now select the number of years to resync from a dropdown menu instead of using preset quick-action buttons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->