### PR TITLE
small

### DIFF
--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -530,9 +530,9 @@
             <div class="mt-2 text-xs text-gray-400">
               <%= for org <- all_noms_overview do %>
                 <span class="inline-block mr-2">
-                  {get_organization_display_name(org.organization_name)
+                  {(get_organization_display_name(org.organization_name) || "")
                   |> String.split(" ")
-                  |> hd()}: {org.total_wins + org.total_nominations}
+                  |> List.first("Unknown")}: {org.total_wins + org.total_nominations}
                 </span>
               <% end %>
             </div>


### PR DESCRIPTION
### TL;DR

Fixed potential runtime errors in movie nominations display by adding fallback handling for organization names.

### What changed?

- Added a fallback empty string when `get_organization_display_name` returns nil
- Replaced `hd()` with `List.first("Unknown")` to safely handle empty lists when splitting organization names

### How to test?

1. Navigate to a movie details page that displays nominations
2. Verify that movies with missing or malformed organization names display properly without errors
3. Check that "Unknown" appears as expected for any organization names that can't be parsed

### Why make this change?

This change prevents runtime errors that could occur when:
1. `get_organization_display_name` returns nil for an organization
2. An organization name splits into an empty list, which would cause `hd()` to fail

The defensive programming approach ensures a more robust user experience by gracefully handling edge cases in the data.