### PR TITLE
use of replicas

### DIFF
--- a/lib/cinegraph/collaborations.ex
+++ b/lib/cinegraph/collaborations.ex
@@ -286,8 +286,8 @@ defmodule Cinegraph.Collaborations do
       "Editor"
     ]
 
-    # First, get all movies
-    movie_ids = Repo.all(from m in Movie, select: m.id)
+    # First, get all movies (read-only query, use replica)
+    movie_ids = Repo.replica().all(from m in Movie, select: m.id)
     total_movies = length(movie_ids)
 
     # Process movies in batches

--- a/lib/cinegraph/cultural.ex
+++ b/lib/cinegraph/cultural.ex
@@ -745,7 +745,7 @@ defmodule Cinegraph.Cultural do
       |> where([j], j.worker == "Cinegraph.Workers.OscarImportWorker")
       |> group_by([j], j.state)
       |> select([j], {j.state, count(j.id)})
-      |> Repo.all()
+      |> Repo.replica().all()
       |> Enum.into(%{})
 
     %{
@@ -945,7 +945,7 @@ defmodule Cinegraph.Cultural do
       |> where([j], fragment("? ->> 'festival' = ?", j.args, "venice"))
       |> group_by([j], j.state)
       |> select([j], {j.state, count(j.id)})
-      |> Repo.all()
+      |> Repo.replica().all()
       |> Enum.into(%{})
 
     %{
@@ -1118,7 +1118,7 @@ defmodule Cinegraph.Cultural do
       query
       |> group_by([j], j.state)
       |> select([j], {j.state, count(j.id)})
-      |> Repo.all()
+      |> Repo.replica().all()
       |> Enum.into(%{})
 
     %{


### PR DESCRIPTION
### TL;DR

Added a replica database kill switch and improved query distribution metrics for database read replicas.

### What changed?

- Added a kill switch feature to disable read replicas via the `USE_REPLICA=false` environment variable
- Updated several read-only queries to use the replica database instead of the primary
- Enhanced the database metrics module with better error handling and logging
- Improved the calculation of distribution statistics between primary and replica databases
- Used persistent term for storing query counter references

### How to test?

1. Verify normal operation with replicas enabled (default)
2. Set `USE_REPLICA=false` and confirm all queries route to the primary database
3. Check the metrics dashboard to ensure query distribution statistics are accurate
4. Verify the logs for proper initialization of query counters

### Why make this change?

This change provides operational flexibility when dealing with database replication issues. The kill switch allows for quick failover to the primary database during emergencies without code changes. The improved metrics will help monitor read/write distribution and ensure we're effectively utilizing our database resources. Better error handling and logging will make troubleshooting easier in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized read operations to use read replicas for improved scalability and performance
  * Added configurable replica failover mechanism via environment variable
  * Enhanced monitoring and debugging with improved logging for infrastructure health

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->