### PR TITLE
re queue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -68,38 +68,18 @@ config :phoenix, :json_library, Jason
 config :cinegraph, Oban,
   repo: Cinegraph.Repo,
   queues: [
-    # Daily import orchestration (low concurrency - just coordinates)
-    tmdb_orchestration: 2,
-    # Movie discovery from TMDb
-    tmdb_discovery: 10,
-    # Movie details fetching
-    tmdb_details: 20,
-    # OMDb data enrichment
-    omdb_enrichment: 5,
-    # Keywords, videos, etc.
-    media_processing: 10,
+    # All TMDb API work (orchestration, discovery, details) - single rate limit
+    tmdb: 15,
+    # OMDb data enrichment (separate API rate limit)
+    omdb: 5,
     # Collaboration processing
     collaboration: 5,
-    # Movie enrichment from Oscar imports
-    movie_enrichment: 10,
-    # Oscar ceremony imports
-    oscar_imports: 3,
-    # Festival imports (Venice, Cannes, Berlin, etc.)
-    festival_import: 5,
-    # IMDb website scraping (canonical lists, user lists, etc.)
-    imdb_scraping: 5,
-    # Retry failed canonical source updates
-    canonical_retry: 3,
-    # CRI calculation jobs
-    cri_calculation: 5,
-    # Person Quality Score calculations
-    metrics: 15,
-    # Predictions calculation jobs
-    predictions: 3,
-    # Cache warming for movies page (Phase 2 optimization)
-    cache_warming: 1,
-    # Sitemap generation (runs once daily, long-running)
-    sitemap: 1
+    # Web scraping (IMDb, festivals, Oscars) - low concurrency for rate limiting
+    scraping: 5,
+    # All metrics/calculations (person quality scores, predictions, CRI)
+    metrics: 10,
+    # Background maintenance tasks (cache warming, sitemap, backfills)
+    maintenance: 2
   ],
   # Give jobs more time to complete during deployments/restarts
   shutdown_grace_period: :timer.seconds(60),

--- a/docs/OBAN_QUEUES.md
+++ b/docs/OBAN_QUEUES.md
@@ -1,0 +1,179 @@
+# Oban Queue System
+
+This document describes the Oban job queue architecture for Cinegraph. The system uses 6 consolidated queues to handle all background processing with clear separation of concerns and appropriate rate limiting.
+
+## Queue Overview
+
+| Queue | Concurrency | Purpose |
+|-------|-------------|---------|
+| `tmdb` | 15 | All TMDb API interactions |
+| `omdb` | 5 | OMDb API enrichment |
+| `collaboration` | 5 | Person collaboration processing |
+| `scraping` | 5 | Web scraping (IMDb, festivals, awards) |
+| `metrics` | 10 | Calculations and analytics |
+| `maintenance` | 2 | Background maintenance tasks |
+
+## Queue Details
+
+### `tmdb` (Concurrency: 15)
+
+**Purpose**: All interactions with the TMDb API. This queue handles movie discovery, detail fetching, and import orchestration.
+
+**Rate Limiting**: TMDb has a single API rate limit, so all TMDb work is consolidated here for coordinated throttling.
+
+**Current Workers**:
+- `DailyYearImportWorker` - Daily scheduled year-by-year imports
+- `YearImportCompletionWorker` - Completion handling for year imports
+- `TMDbDiscoveryWorker` - Movie discovery from TMDb
+- `TMDbDetailsWorker` - Fetching detailed movie information
+
+**Use this queue for**: Any new worker that calls the TMDb API.
+
+---
+
+### `omdb` (Concurrency: 5)
+
+**Purpose**: OMDb API data enrichment. Fetches additional movie data including awards, box office, and critic ratings.
+
+**Rate Limiting**: OMDb has its own separate rate limit (1000/day for free tier), so it has a dedicated queue.
+
+**Current Workers**:
+- `OMDbEnrichmentWorker` - Enriches movies with OMDb data
+
+**Use this queue for**: Any new worker that calls the OMDb API.
+
+---
+
+### `collaboration` (Concurrency: 5)
+
+**Purpose**: Processing collaboration relationships between people (actors, directors, etc.).
+
+**Current Workers**:
+- `CollaborationWorker` - Processes and updates collaboration data
+
+**Use this queue for**: Any work related to person-to-person collaboration analysis, relationship building, or collaboration graph updates.
+
+---
+
+### `scraping` (Concurrency: 5)
+
+**Purpose**: All web scraping operations including IMDb data extraction, festival information, and awards data.
+
+**Rate Limiting**: Low concurrency to be respectful to scraped sites and avoid rate limiting/blocking.
+
+**Current Workers**:
+- `UnifiedFestivalWorker` - Festival data import
+- `FestivalDiscoveryWorker` - Discovering festival nominations
+- `AwardImportWorker` - Importing award data
+- `AwardImportOrchestratorWorker` - Orchestrating award imports
+- `FestivalPersonInferenceWorker` - Inferring person data from festivals
+- `YearDiscoveryWorker` - Discovering movies by year
+- `OscarImportWorker` - Oscar-specific imports
+- `CanonicalImportOrchestrator` - Orchestrating canonical list imports
+- `CanonicalPageWorker` - Processing canonical list pages
+- `CanonicalImportWorker` - Importing canonical list items
+- `CanonicalImportCompletionWorker` - Completion handling
+- `CanonicalRetryWorker` - Retry logic for failed imports
+
+**Use this queue for**: Any worker that scrapes websites (IMDb, festival sites, etc.) or processes scraped data.
+
+---
+
+### `metrics` (Concurrency: 10)
+
+**Purpose**: All metric calculations, analytics, and prediction work. Higher concurrency since these are CPU-bound rather than I/O-bound.
+
+**Current Workers**:
+- `PersonQualityScoreWorker` - Calculating person quality scores
+- `PredictionsWorker` - Running predictions
+- `PredictionsOrchestrator` - Orchestrating prediction workflows
+- `PredictionCalculator` - Individual prediction calculations
+- `ComprehensivePredictionsCalculator` - Full prediction recalculations
+
+**Use this queue for**: Any computational work involving metrics, scores, predictions, rankings, or analytics.
+
+---
+
+### `maintenance` (Concurrency: 2)
+
+**Purpose**: Background maintenance tasks that run periodically. Low concurrency since these are non-urgent.
+
+**Current Workers**:
+- `MoviesCacheWarmer` - Warming the movies page cache
+- `SitemapWorker` - Generating sitemaps
+- `CacheWarmupWorker` - General cache warming
+- `SlugBackfillWorker` - Backfilling missing slugs
+
+**Use this queue for**: Any periodic/scheduled tasks, cache warming, cleanup jobs, backfills, or other maintenance work.
+
+---
+
+## Guidelines for Adding New Workers
+
+### Do NOT Create New Queues
+
+The current 6-queue system is intentionally consolidated. Before creating a new queue, consider:
+
+1. **Does it call TMDb?** → Use `tmdb`
+2. **Does it call OMDb?** → Use `omdb`
+3. **Does it scrape websites?** → Use `scraping`
+4. **Does it process collaborations?** → Use `collaboration`
+5. **Does it calculate metrics/scores?** → Use `metrics`
+6. **Is it a maintenance/background task?** → Use `maintenance`
+
+### When to Consider a New Queue
+
+Only create a new queue if:
+- You're integrating a **new external API** with its own rate limits
+- You have a **fundamentally different workload** that would conflict with existing queues
+- You have **specific isolation requirements** (e.g., critical path vs. batch processing)
+
+If you think you need a new queue, discuss with the team first.
+
+### Worker Configuration Example
+
+```elixir
+defmodule Cinegraph.Workers.MyNewWorker do
+  use Oban.Worker,
+    queue: :metrics,  # Choose appropriate queue
+    max_attempts: 3,
+    unique: [fields: [:args], keys: [:my_id], period: 3600]
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    # Worker implementation
+  end
+end
+```
+
+## Configuration
+
+Queue configuration is defined in `config/config.exs`:
+
+```elixir
+config :cinegraph, Oban,
+  repo: Cinegraph.Repo,
+  queues: [
+    tmdb: 15,
+    omdb: 5,
+    collaboration: 5,
+    scraping: 5,
+    metrics: 10,
+    maintenance: 2
+  ],
+  # ... plugins
+```
+
+## Monitoring
+
+Queue statistics are displayed in the Import Dashboard (`/import`) and tracked via:
+- `Cinegraph.Cache.DashboardStats` - Dashboard statistics
+- `Cinegraph.Imports.ImportStats` - Import-specific statistics
+
+## History
+
+This consolidated queue system was implemented in December 2024 (Issue #475), reducing the original 16 queues to 6 for:
+- Simpler mental model
+- Better rate limit management
+- Easier monitoring
+- Reduced configuration complexity

--- a/lib/cinegraph/cache/dashboard_stats.ex
+++ b/lib/cinegraph/cache/dashboard_stats.ex
@@ -315,14 +315,12 @@ defmodule Cinegraph.Cache.DashboardStats do
 
   defp default_oban_stats do
     queues = [
-      :tmdb_orchestration,
-      :tmdb_discovery,
-      :tmdb_details,
-      :omdb_enrichment,
+      :tmdb,
+      :omdb,
       :collaboration,
-      :imdb_scraping,
-      :oscar_imports,
-      :festival_import
+      :scraping,
+      :metrics,
+      :maintenance
     ]
 
     Enum.map(queues, fn queue ->
@@ -415,14 +413,12 @@ defmodule Cinegraph.Cache.DashboardStats do
 
   defp compute_oban_stats do
     queues = [
-      :tmdb_orchestration,
-      :tmdb_discovery,
-      :tmdb_details,
-      :omdb_enrichment,
+      :tmdb,
+      :omdb,
       :collaboration,
-      :imdb_scraping,
-      :oscar_imports,
-      :festival_import
+      :scraping,
+      :metrics,
+      :maintenance
     ]
 
     # Batch query - get all queue/state combinations in one query
@@ -975,15 +971,7 @@ defmodule Cinegraph.Cache.DashboardStats do
         eta: "Unknown"
       },
       queue_stats: [
-        %{
-          queue: :tmdb_orchestration,
-          name: "Orchestration",
-          available: 0,
-          executing: 0,
-          completed: 0
-        },
-        %{queue: :tmdb_discovery, name: "Discovery", available: 0, executing: 0, completed: 0},
-        %{queue: :tmdb_details, name: "Details", available: 0, executing: 0, completed: 0}
+        %{queue: :tmdb, name: "TMDb", available: 0, executing: 0, completed: 0}
       ],
       is_running: false,
       recent_activity: [],
@@ -1189,7 +1177,7 @@ defmodule Cinegraph.Cache.DashboardStats do
   end
 
   defp compute_year_queue_stats do
-    queues = [:tmdb_orchestration, :tmdb_discovery, :tmdb_details]
+    queues = [:tmdb]
 
     # Batch query - get all queue/state combinations in one query
     results =
@@ -1218,9 +1206,7 @@ defmodule Cinegraph.Cache.DashboardStats do
 
       queue_name =
         case queue do
-          :tmdb_orchestration -> "Orchestration"
-          :tmdb_discovery -> "Discovery"
-          :tmdb_details -> "Details"
+          :tmdb -> "TMDb"
           _ -> queue |> Atom.to_string() |> String.replace("_", " ")
         end
 

--- a/lib/cinegraph/imports/import_stats.ex
+++ b/lib/cinegraph/imports/import_stats.ex
@@ -114,10 +114,12 @@ defmodule Cinegraph.Imports.ImportStats do
     import Ecto.Query
 
     %{
-      discovery: count_jobs_in_queue("tmdb_discovery"),
-      details: count_jobs_in_queue("tmdb_details"),
-      omdb: count_jobs_in_queue("omdb_enrichment"),
-      collaboration: count_jobs_in_queue("collaboration")
+      tmdb: count_jobs_in_queue("tmdb"),
+      omdb: count_jobs_in_queue("omdb"),
+      collaboration: count_jobs_in_queue("collaboration"),
+      scraping: count_jobs_in_queue("scraping"),
+      metrics: count_jobs_in_queue("metrics"),
+      maintenance: count_jobs_in_queue("maintenance")
     }
   end
 
@@ -136,7 +138,7 @@ defmodule Cinegraph.Imports.ImportStats do
   defp calculate_queue_stats do
     import Ecto.Query
 
-    queues = ["tmdb_discovery", "tmdb_details", "omdb_enrichment", "collaboration"]
+    queues = ["tmdb", "omdb", "collaboration", "scraping", "metrics", "maintenance"]
 
     Enum.map(queues, fn queue ->
       available =

--- a/lib/cinegraph/workers/award_import_orchestrator_worker.ex
+++ b/lib/cinegraph/workers/award_import_orchestrator_worker.ex
@@ -11,7 +11,7 @@ defmodule Cinegraph.Workers.AwardImportOrchestratorWorker do
   """
 
   use Oban.Worker,
-    queue: :festival_import,
+    queue: :scraping,
     max_attempts: 1,
     priority: 0
 

--- a/lib/cinegraph/workers/award_import_worker.ex
+++ b/lib/cinegraph/workers/award_import_worker.ex
@@ -10,7 +10,7 @@ defmodule Cinegraph.Workers.AwardImportWorker do
   """
 
   use Oban.Worker,
-    queue: :festival_import,
+    queue: :scraping,
     max_attempts: 3,
     unique: [
       period: 300,

--- a/lib/cinegraph/workers/cache_warmup_worker.ex
+++ b/lib/cinegraph/workers/cache_warmup_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.CacheWarmupWorker do
   Runs periodically to ensure fast response times for common queries.
   """
 
-  use Oban.Worker, queue: :default, max_attempts: 3
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
 
   require Logger
   alias Cinegraph.Cache.PredictionsCache

--- a/lib/cinegraph/workers/canonical_import_completion_worker.ex
+++ b/lib/cinegraph/workers/canonical_import_completion_worker.ex
@@ -6,7 +6,7 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
   """
 
   use Oban.Worker,
-    queue: :imdb_scraping,
+    queue: :scraping,
     max_attempts: 5,
     unique: [
       keys: [:list_key],

--- a/lib/cinegraph/workers/canonical_import_orchestrator.ex
+++ b/lib/cinegraph/workers/canonical_import_orchestrator.ex
@@ -5,7 +5,7 @@ defmodule Cinegraph.Workers.CanonicalImportOrchestrator do
   """
 
   use Oban.Worker,
-    queue: :imdb_scraping,
+    queue: :scraping,
     max_attempts: 3,
     unique: [
       keys: [:list_key],

--- a/lib/cinegraph/workers/canonical_import_worker.ex
+++ b/lib/cinegraph/workers/canonical_import_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.CanonicalImportWorker do
   """
 
   use Oban.Worker,
-    queue: :imdb_scraping,
+    queue: :scraping,
     max_attempts: 3
 
   alias Cinegraph.Cultural.CanonicalImporter

--- a/lib/cinegraph/workers/canonical_page_worker.ex
+++ b/lib/cinegraph/workers/canonical_page_worker.ex
@@ -5,7 +5,7 @@ defmodule Cinegraph.Workers.CanonicalPageWorker do
   """
 
   use Oban.Worker,
-    queue: :imdb_scraping,
+    queue: :scraping,
     max_attempts: 3,
     unique: [
       keys: [:list_key, :page],

--- a/lib/cinegraph/workers/canonical_retry_worker.ex
+++ b/lib/cinegraph/workers/canonical_retry_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.CanonicalRetryWorker do
   """
 
   use Oban.Worker,
-    queue: :canonical_retry,
+    queue: :scraping,
     max_attempts: 3,
     unique: [
       fields: [:args],

--- a/lib/cinegraph/workers/comprehensive_predictions_calculator.ex
+++ b/lib/cinegraph/workers/comprehensive_predictions_calculator.ex
@@ -9,7 +9,7 @@ defmodule Cinegraph.Workers.ComprehensivePredictionsCalculator do
   but runs them in the background via Oban.
   """
 
-  use Oban.Worker, queue: :predictions, max_attempts: 3
+  use Oban.Worker, queue: :metrics, max_attempts: 3
 
   require Logger
 

--- a/lib/cinegraph/workers/daily_year_import_worker.ex
+++ b/lib/cinegraph/workers/daily_year_import_worker.ex
@@ -13,7 +13,7 @@ defmodule Cinegraph.Workers.DailyYearImportWorker do
   """
 
   use Oban.Worker,
-    queue: :tmdb_orchestration,
+    queue: :tmdb,
     max_attempts: 3
 
   alias Cinegraph.Imports.ImportStateV2

--- a/lib/cinegraph/workers/festival_discovery_worker.ex
+++ b/lib/cinegraph/workers/festival_discovery_worker.ex
@@ -14,7 +14,7 @@ defmodule Cinegraph.Workers.FestivalDiscoveryWorker do
   """
 
   use Oban.Worker,
-    queue: :festival_import,
+    queue: :scraping,
     max_attempts: 3,
     priority: 2
 

--- a/lib/cinegraph/workers/festival_person_inference_worker.ex
+++ b/lib/cinegraph/workers/festival_person_inference_worker.ex
@@ -11,7 +11,7 @@ defmodule Cinegraph.Workers.FestivalPersonInferenceWorker do
   """
 
   use Oban.Worker,
-    queue: :festival_import,
+    queue: :scraping,
     max_attempts: 3,
     unique: [fields: [:args], keys: [:ceremony_id], period: 300]
 

--- a/lib/cinegraph/workers/movies_cache_warmer.ex
+++ b/lib/cinegraph/workers/movies_cache_warmer.ex
@@ -21,7 +21,7 @@ defmodule Cinegraph.Workers.MoviesCacheWarmer do
   """
 
   use Oban.Worker,
-    queue: :cache_warming,
+    queue: :maintenance,
     max_attempts: 3,
     priority: 2
 

--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -7,7 +7,7 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
   """
 
   use Oban.Worker,
-    queue: :omdb_enrichment,
+    queue: :omdb,
     max_attempts: 3,
     # 1 hour uniqueness
     unique: [fields: [:args], keys: [:movie_id], period: 3600]

--- a/lib/cinegraph/workers/oscar_import_worker.ex
+++ b/lib/cinegraph/workers/oscar_import_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.OscarImportWorker do
   """
 
   use Oban.Worker,
-    queue: :oscar_imports,
+    queue: :scraping,
     max_attempts: 3
 
   alias Cinegraph.Cultural

--- a/lib/cinegraph/workers/prediction_calculator.ex
+++ b/lib/cinegraph/workers/prediction_calculator.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.PredictionCalculator do
   Uses the existing MoviePredictor logic to ensure correct scoring.
   """
 
-  use Oban.Worker, queue: :predictions, max_attempts: 3
+  use Oban.Worker, queue: :metrics, max_attempts: 3
 
   require Logger
 

--- a/lib/cinegraph/workers/predictions_orchestrator.ex
+++ b/lib/cinegraph/workers/predictions_orchestrator.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.PredictionsOrchestrator do
   This avoids timeout issues and allows partial progress to be saved.
   """
 
-  use Oban.Worker, queue: :predictions, max_attempts: 3
+  use Oban.Worker, queue: :metrics, max_attempts: 3
 
   require Logger
 

--- a/lib/cinegraph/workers/predictions_worker.ex
+++ b/lib/cinegraph/workers/predictions_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.PredictionsWorker do
   Each task is small enough to complete without timeout.
   """
 
-  use Oban.Worker, queue: :predictions, max_attempts: 3
+  use Oban.Worker, queue: :metrics, max_attempts: 3
 
   require Logger
 

--- a/lib/cinegraph/workers/sitemap_worker.ex
+++ b/lib/cinegraph/workers/sitemap_worker.ex
@@ -12,7 +12,7 @@ defmodule Cinegraph.Workers.SitemapWorker do
   """
 
   use Oban.Worker,
-    queue: :sitemap,
+    queue: :maintenance,
     max_attempts: 3,
     priority: 3
 

--- a/lib/cinegraph/workers/slug_backfill_worker.ex
+++ b/lib/cinegraph/workers/slug_backfill_worker.ex
@@ -10,7 +10,7 @@ defmodule Cinegraph.Workers.SlugBackfillWorker do
   memory issues and allow for graceful interruption.
   """
 
-  use Oban.Worker, queue: :default, max_attempts: 3
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
 
   require Logger
   import Ecto.Query

--- a/lib/cinegraph/workers/tmdb_details_worker.ex
+++ b/lib/cinegraph/workers/tmdb_details_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
   """
 
   use Oban.Worker,
-    queue: :tmdb_details,
+    queue: :tmdb,
     max_attempts: 5,
     unique: [fields: [:args], keys: [:tmdb_id, :imdb_id, :source_key], period: 300]
 

--- a/lib/cinegraph/workers/tmdb_discovery_worker.ex
+++ b/lib/cinegraph/workers/tmdb_discovery_worker.ex
@@ -4,7 +4,7 @@ defmodule Cinegraph.Workers.TMDbDiscoveryWorker do
   """
 
   use Oban.Worker,
-    queue: :tmdb_discovery,
+    queue: :tmdb,
     max_attempts: 3,
     unique: [period: 60]
 

--- a/lib/cinegraph/workers/unified_festival_worker.ex
+++ b/lib/cinegraph/workers/unified_festival_worker.ex
@@ -5,7 +5,7 @@ defmodule Cinegraph.Workers.UnifiedFestivalWorker do
   """
 
   use Oban.Worker,
-    queue: :festival_import,
+    queue: :scraping,
     max_attempts: 3,
     unique: [period: 60, fields: [:args], keys: [:festival, :year]]
 

--- a/lib/cinegraph/workers/year_discovery_worker.ex
+++ b/lib/cinegraph/workers/year_discovery_worker.ex
@@ -16,7 +16,7 @@ defmodule Cinegraph.Workers.YearDiscoveryWorker do
   """
 
   use Oban.Worker,
-    queue: :festival_import,
+    queue: :scraping,
     max_attempts: 3,
     unique: [
       period: 3600,

--- a/lib/cinegraph/workers/year_import_completion_worker.ex
+++ b/lib/cinegraph/workers/year_import_completion_worker.ex
@@ -8,7 +8,7 @@ defmodule Cinegraph.Workers.YearImportCompletionWorker do
   """
 
   use Oban.Worker,
-    queue: :tmdb_orchestration,
+    queue: :tmdb,
     max_attempts: 20
 
   alias Cinegraph.Imports.ImportStateV2

--- a/lib/cinegraph_web/live/import_dashboard_live.ex
+++ b/lib/cinegraph_web/live/import_dashboard_live.ex
@@ -988,14 +988,12 @@ defmodule CinegraphWeb.ImportDashboardLive do
   @doc """
   Formats queue names for display.
   """
-  def format_queue_name(:tmdb_orchestration), do: "TMDb Orchestration"
-  def format_queue_name(:tmdb_discovery), do: "TMDb Discovery"
-  def format_queue_name(:tmdb_details), do: "TMDb Details"
-  def format_queue_name(:omdb_enrichment), do: "OMDb Enrichment"
+  def format_queue_name(:tmdb), do: "TMDb"
+  def format_queue_name(:omdb), do: "OMDb"
   def format_queue_name(:collaboration), do: "Collaboration"
-  def format_queue_name(:imdb_scraping), do: "IMDb Scraping"
-  def format_queue_name(:oscar_imports), do: "Oscar Imports"
-  def format_queue_name(:festival_import), do: "Festival Imports"
+  def format_queue_name(:scraping), do: "Scraping"
+  def format_queue_name(:metrics), do: "Metrics"
+  def format_queue_name(:maintenance), do: "Maintenance"
 
   def format_queue_name(queue) when is_atom(queue),
     do: queue |> to_string() |> String.capitalize()


### PR DESCRIPTION
# Consolidate Oban Job Queues

### TL;DR

Reduced the number of Oban job queues from 16 to 6 consolidated queues with clear separation of concerns.

### What changed?

- Consolidated 16 specialized queues into 6 purpose-driven queues:
  - `tmdb`: All TMDb API interactions (15 workers)
  - `omdb`: OMDb API enrichment (5 workers)
  - `collaboration`: Person collaboration processing (5 workers)
  - `scraping`: Web scraping operations (5 workers)
  - `metrics`: Calculations and analytics (10 workers)
  - `maintenance`: Background tasks (2 workers)
- Updated all worker modules to use the new queue structure
- Updated dashboard stats and import stats to reflect the new queue names
- Added comprehensive documentation in `docs/OBAN_QUEUES.md` explaining the new system

### How to test?

1. Start the application and verify that all background jobs are running correctly
2. Check the Import Dashboard (`/import`) to ensure queue statistics are displayed properly
3. Trigger various import operations to verify jobs are properly routed to the correct queues
4. Monitor the Oban dashboard to ensure jobs are being processed as expected

### Why make this change?

- **Simpler mental model**: Easier to understand where jobs should be placed
- **Better rate limiting**: Consolidated queues for APIs with shared rate limits
- **Reduced configuration complexity**: Fewer queues to manage and monitor
- **Clearer separation of concerns**: Jobs are now grouped by their fundamental purpose rather than specific tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated background job queue system by reorganizing multiple specialized queues into broader functional categories (data fetching, scraping, metrics processing, and maintenance tasks).
  * Updated job routing and monitoring to reflect the new streamlined queue architecture.
  * Added comprehensive documentation for the redesigned job processing system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->