### PR TITLE
slowing it down

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -76,6 +76,9 @@ config :cinegraph, Oban,
     collaboration: 5,
     # Web scraping (IMDb, festivals, Oscars) - low concurrency for rate limiting
     scraping: 5,
+    # Festival discovery processing - very low concurrency to prevent overwhelming the system
+    # Each ceremony queues many child jobs, so limit to 2 concurrent ceremonies
+    festival_discovery: 2,
     # All metrics/calculations (person quality scores, predictions, CRI)
     metrics: 10,
     # Background maintenance tasks (cache warming, sitemap, backfills)


### PR DESCRIPTION
### TL;DR

Added throttling to award import and festival discovery processes to prevent system overload.

### What changed?

- Added a new `festival_discovery` Oban queue with a concurrency limit of 2
- Implemented spacing between organization sync jobs (10 minutes apart)
- Added spacing between year imports (5 minutes apart) for award ceremonies
- Added delays between category processing (1 second) and job insertions (100ms) in the festival discovery worker
- Enhanced logging to include information about job spacing and total estimated duration
- Updated progress broadcasts to include spacing information

### How to test?

1. Trigger a full award import via `AwardImportOrchestratorWorker.sync_all()`
2. Verify in logs that jobs are scheduled with appropriate spacing
3. Monitor the system during festival discovery processing to ensure it doesn't get overwhelmed
4. Check that the new `festival_discovery` queue is processing jobs with limited concurrency

### Why make this change?

The award import and festival discovery processes were previously overwhelming the system by queuing too many jobs simultaneously. Each ceremony import triggers many child jobs for film and person processing. This change implements rate limiting and job spacing to ensure the system remains stable and responsive during these intensive operations, preventing resource exhaustion and potential failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized background job scheduling with staggered processing to improve system stability and resource management.
  * Enhanced throttling mechanisms for data processing operations to prevent system overload.
  * Improved infrastructure configuration for better load distribution across background workers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->