### PR TITLE
move fixes for movies

### DIFF
--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -237,11 +237,12 @@ defmodule Cinegraph.Movies do
   def quick_search(query, opts \\ []) do
     limit = Elixir.Keyword.get(opts, :limit, 20)
     clean_query = String.trim(query)
+    escaped_query = escape_like_wildcards(clean_query)
 
     from(m in Movie,
       where:
-        fragment("LOWER(?) LIKE LOWER(?)", m.title, ^"%#{clean_query}%") or
-          fragment("LOWER(?) LIKE LOWER(?)", m.original_title, ^"%#{clean_query}%") or
+        fragment("LOWER(?) LIKE LOWER(?)", m.title, ^"%#{escaped_query}%") or
+          fragment("LOWER(?) LIKE LOWER(?)", m.original_title, ^"%#{escaped_query}%") or
           fragment("CAST(? AS TEXT) = ?", m.tmdb_id, ^clean_query) or
           fragment("LOWER(?) = LOWER(?)", m.imdb_id, ^clean_query),
       select: %{
@@ -1075,5 +1076,13 @@ defmodule Cinegraph.Movies do
     end)
 
     :ok
+  end
+
+  # Helper to escape SQL LIKE wildcards
+  defp escape_like_wildcards(str) do
+    str
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
   end
 end


### PR DESCRIPTION
### TL;DR

Fixed SQL injection vulnerability in search functions and improved error handling for nominations.

### What changed?

- Added proper escaping for SQL LIKE wildcards (`%` and `_`) in search queries to prevent SQL injection
- Improved error handling in `get_nomination/1` function to properly handle nil cases
- Enhanced the nomination modal flows in the Festival Audit interface to handle cases where nominations no longer exist
- Fixed the event handler for movie search to use the correct parameter name (`value` instead of `query`)
- Updated documentation to clarify that `get_nomination/1` returns nil when not found

### How to test?

1. Try searching for movies with special characters like `%` or `_` in their titles
2. Test the nomination deletion and movie switching flows in the Festival Audit interface
3. Verify that appropriate error messages appear when attempting to access non-existent nominations

### Why make this change?

This change addresses a security vulnerability where special SQL characters in search queries could potentially lead to SQL injection attacks. It also improves the robustness of the application by properly handling cases where nominations might have been deleted while a user has the interface open, preventing potential crashes or unexpected behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved search functionality to correctly handle special characters in queries
  * Enhanced error handling for missing nominations—users now receive clear error messages instead of crashes
  * Strengthened robustness of the festival audit interface with better validation and state management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->