### PR TITLE
final fixes ui

### DIFF
--- a/lib/cinegraph_web/live/festival_audit_live.ex
+++ b/lib/cinegraph_web/live/festival_audit_live.ex
@@ -238,11 +238,20 @@ defmodule CinegraphWeb.FestivalAuditLive do
       nil ->
         {:noreply, put_flash(socket, :error, "Nomination no longer exists.")}
 
+      %{movie: nil} ->
+        {:noreply, put_flash(socket, :error, "Nomination has no linked movie to switch.")}
+
+      %{movie: %{title: nil}} ->
+        {:noreply,
+         put_flash(socket, :error, "Nomination's movie has no title, so candidates can't be searched.")}
+
       nomination ->
+        title = nomination.movie.title
+
         # Pre-populate with candidates based on current movie title
         candidates =
           Festivals.find_candidate_movies(
-            nomination.movie.title,
+            title,
             socket.assigns.selected_ceremony.year,
             limit: 10
           )
@@ -252,7 +261,7 @@ defmodule CinegraphWeb.FestivalAuditLive do
          |> assign(:show_switch_modal, true)
          |> assign(:selected_nomination, nomination)
          |> assign(:movie_candidates, candidates)
-         |> assign(:search_query, nomination.movie.title)}
+         |> assign(:search_query, title)}
     end
   end
 


### PR DESCRIPTION
### TL;DR

Added error handling for nominations with missing movie data when attempting to switch movies.

### What changed?

- Added error handling for cases where a nomination has no linked movie (`%{movie: nil}`)
- Added error handling for cases where a nomination's movie has no title (`%{movie: %{title: nil}}`)
- Extracted `nomination.movie.title` to a variable to avoid repeated access
- Updated the code to use this variable in multiple places

### How to test?

1. Navigate to the Festival Audit page
2. Try to switch a nomination that has no linked movie
3. Verify you see the error message "Nomination has no linked movie to switch"
4. Try to switch a nomination where the movie has no title
5. Verify you see the error message "Nomination's movie has no title, so candidates can't be searched"

### Why make this change?

This change prevents potential runtime errors when trying to switch movies for nominations with incomplete data. Previously, the code would attempt to access `nomination.movie.title` without checking if `movie` or `title` existed, which could lead to crashes. The new error handling provides clear feedback to users about why the operation cannot be completed.