### PR TITLE
fixes for the rabbit

### DIFF
--- a/lib/cinegraph/workers/data_repair_worker.ex
+++ b/lib/cinegraph/workers/data_repair_worker.ex
@@ -9,7 +9,8 @@ defmodule Cinegraph.Workers.DataRepairWorker do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [fields: [:args], keys: [:repair_type], period: 600]
+    # Compare full args for uniqueness - allows batched jobs with different last_id
+    unique: [period: 600]
 
   alias Cinegraph.{Repo, Movies, Repairs}
   alias Cinegraph.Services.TMDb

--- a/lib/cinegraph_web/live/import_dashboard_live.ex
+++ b/lib/cinegraph_web/live/import_dashboard_live.ex
@@ -965,10 +965,13 @@ defmodule CinegraphWeb.ImportDashboardLive do
           nil
 
         job ->
+          # Ensure meta is always a map to avoid crashes when it's nil
+          meta = job.meta || %{}
+
           %{
             type: "missing_director_credits",
-            status: format_repair_status(job),
-            last_id: get_in(job.meta, ["last_id"])
+            status: format_repair_status(%{job | meta: meta}),
+            last_id: Map.get(meta, "last_id")
           }
       end
 
@@ -978,7 +981,7 @@ defmodule CinegraphWeb.ImportDashboardLive do
   end
 
   defp format_repair_status(%{state: "executing", meta: meta}) do
-    batch_success = meta["batch_success"] || 0
+    batch_success = Map.get(meta || %{}, "batch_success", 0)
     "Processing... (#{batch_success} in current batch)"
   end
 


### PR DESCRIPTION
### TL;DR

Fix data repair worker uniqueness constraints and handle nil meta values to prevent crashes.

### What changed?

- Modified the `DataRepairWorker` uniqueness configuration to compare full args instead of specific fields, allowing batched jobs with different `last_id` values to run concurrently
- Added defensive handling for nil `meta` values in the import dashboard:
  - Ensuring `meta` is always a map when formatting repair status
  - Using `Map.get/3` with default values instead of `get_in` to safely access meta values

### How to test?

1. Run multiple data repair jobs with different `last_id` values and verify they execute concurrently
2. Check the import dashboard when jobs have nil meta values to confirm no crashes occur

### Why make this change?

The previous uniqueness constraint was too restrictive, preventing batched repair jobs with different `last_id` values from running concurrently. Additionally, the code was vulnerable to crashes when encountering nil meta values in job records, which this change prevents through proper defensive programming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes in data repair operations when handling missing or invalid job metadata.
  * Improved robustness of batch repair processing to gracefully handle edge cases.

* **Improvements**
  * Optimized concurrent batch repair job processing with enhanced scheduling capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->