### PR TITLE
fixes

### DIFF
--- a/lib/cinegraph_web/plugs/etag_plug.ex
+++ b/lib/cinegraph_web/plugs/etag_plug.ex
@@ -248,10 +248,11 @@ defmodule CinegraphWeb.Plugs.ETagPlug do
         {etag, updated_at}
 
       _ ->
-        # Fallback: use current day as cache key (refreshes daily)
+        # Fallback: use start of current day as cache key (refreshes daily)
         today = Date.utc_today()
+        midnight = DateTime.new!(today, ~T[00:00:00], "Etc/UTC")
         etag = ~s(W/"award-#{slug}-#{Date.to_iso8601(today)}")
-        {etag, DateTime.utc_now()}
+        {etag, midnight}
     end
   end
 


### PR DESCRIPTION
### TL;DR

Fix award page ETag generation to use consistent timestamps

### What changed?

Modified the fallback ETag generation for award pages to use midnight UTC as the timestamp instead of the current time. This ensures that the same ETag is generated throughout the day, improving caching behavior.

### How to test?

1. Visit an award page that uses the fallback ETag generation
2. Refresh the page multiple times throughout the day
3. Verify that the ETag remains consistent until the next day
4. Check server logs to confirm 304 Not Modified responses are being returned for repeat visits

### Why make this change?

The previous implementation used `DateTime.utc_now()` as the timestamp for the fallback ETag, which meant that each request generated a different ETag even on the same day. By using midnight UTC as a fixed reference point, we ensure consistent ETags throughout the day, allowing browsers to properly cache responses and reducing unnecessary data transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized application caching behavior to refresh daily at midnight UTC instead of continuously throughout the day. This improvement reduces unnecessary cache invalidations, delivering better performance and improved responsiveness across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->