### PR TITLE
cinegraph

### DIFF
--- a/lib/cinegraph_web/components/rating_components.ex
+++ b/lib/cinegraph_web/components/rating_components.ex
@@ -401,16 +401,6 @@ defmodule CinegraphWeb.RatingComponents do
   attr :url, :string, default: nil
   attr :class, :string, default: ""
 
-  # Brand-specific pill styling
-  @pill_styles %{
-    "imdb" => "bg-[#F5C518] text-black",
-    "tmdb" => "bg-[#01D277] text-white",
-    "rotten_tomatoes" => "bg-[#FA320A] text-white",
-    "rotten_tomatoes_audience" => "bg-[#FA320A] text-white",
-    "metacritic" => "bg-[#FFCC34] text-black",
-    "letterboxd" => "bg-[#00D735] text-white"
-  }
-
   def inline_rating_badge(assigns) do
     config =
       Map.get(@icon_config, assigns.source, %{
@@ -420,16 +410,7 @@ defmodule CinegraphWeb.RatingComponents do
         scale: nil
       })
 
-    pill_style = Map.get(@pill_styles, assigns.source, "bg-gray-700 text-white")
-    # Use black icons for light backgrounds, white for dark
-    icon_color = if assigns.source in ["imdb", "metacritic"], do: "000000", else: "ffffff"
-
-    assigns =
-      assign(assigns,
-        config: config,
-        pill_style: pill_style,
-        icon_color: icon_color
-      )
+    assigns = assign(assigns, config: config)
 
     # Compact horizontal with dark glass background + colored icon + hover popover
     ~H"""


### PR DESCRIPTION
### TL;DR

Removed unused styling code from the `inline_rating_badge` function in rating components.

### What changed?

- Removed the `@pill_styles` map that contained brand-specific styling for different rating sources
- Removed the code that determined `pill_style` and `icon_color` based on the rating source
- Simplified the assigns by only passing the `config` to the template

### How to test?

1. Verify that rating badges still display correctly throughout the application
2. Check that the styling of rating badges is consistent with the expected design
3. Confirm that no visual regressions have been introduced by this change

### Why make this change?

This change removes unused styling code that was no longer needed in the component. The styling variables (`pill_style` and `icon_color`) were being assigned but not used in the template, making them redundant. This cleanup improves code maintainability by removing dead code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal styling logic for rating components with no impact to user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->