### PR TITLE
upgrades

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -80,7 +80,8 @@ config :cinegraph, Oban,
     # Each ceremony queues many child jobs, so limit to 2 concurrent ceremonies
     festival_discovery: 2,
     # All metrics/calculations (person quality scores, predictions, CRI)
-    metrics: 10,
+    # Reduced from 10 to 5 to prevent resource contention during heavy scoring queries
+    metrics: 5,
     # Background maintenance tasks (cache warming, sitemap, backfills)
     maintenance: 2
   ],

--- a/lib/cinegraph/predictions/movie_predictor.ex
+++ b/lib/cinegraph/predictions/movie_predictor.ex
@@ -32,14 +32,14 @@ defmodule Cinegraph.Predictions.MoviePredictor do
     start_date = Date.new!(decade, 1, 1)
     end_date = Date.new!(decade + 9, 12, 31)
 
-    # Get ALL movies from the decade (both confirmed and unconfirmed) with scoring
+    # Get movies from the decade with scoring
+    # Reduced from 1000 to 300 to improve query performance in production
     all_movies_query =
       from m in Movie,
         where: m.release_date >= ^start_date,
         where: m.release_date <= ^end_date,
         where: m.import_status == "full",
-        # Get more candidates for better selection
-        limit: 1000
+        limit: 300
 
     # Apply database-driven scoring to all movies
     scored_query = ScoringService.apply_scoring(all_movies_query, profile)

--- a/lib/cinegraph/workers/predictions_worker.ex
+++ b/lib/cinegraph/workers/predictions_worker.ex
@@ -271,10 +271,10 @@ defmodule Cinegraph.Workers.PredictionsWorker do
   end
 
   @impl Oban.Worker
-  # 2 minutes for comparison
-  def timeout(%Oban.Job{args: %{"action" => "calculate_comparison"}}), do: :timer.seconds(120)
-  # 1 minute timeout for other pieces
-  def timeout(_job), do: :timer.seconds(60)
+  # 3 minutes for comparison (aggregates across all profiles)
+  def timeout(%Oban.Job{args: %{"action" => "calculate_comparison"}}), do: :timer.seconds(180)
+  # 3 minutes for predictions/validation (complex scoring queries)
+  def timeout(_job), do: :timer.seconds(180)
 
   # Helper functions
 


### PR DESCRIPTION
### TL;DR

Optimize prediction system performance by reducing resource usage and increasing timeouts for complex operations.

### What changed?

- Reduced Oban `metrics` queue concurrency from 10 to 5 workers to prevent resource contention
- Decreased movie candidate limit in decade predictions from 1000 to 300 to improve query performance
- Increased timeouts for prediction workers:
  - Comparison calculations: 120s → 180s
  - Other prediction operations: 60s → 180s

### How to test?

1. Run prediction generation for a profile and verify it completes successfully
2. Monitor server resource usage during prediction calculations
3. Check that decade predictions still return quality results with the reduced candidate pool
4. Verify that complex prediction jobs no longer time out

### Why make this change?

The prediction system was experiencing performance issues in production:
- Resource contention during heavy scoring queries
- Timeouts on complex prediction operations
- Excessive memory usage when processing large movie candidate pools

These changes balance performance needs with resource constraints while maintaining prediction quality.