### PR TITLE
oban

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -65,8 +65,10 @@ config :logger, :console,
 config :phoenix, :json_library, Jason
 
 # Configure Oban
+# Uses dedicated Oban repo with direct connection (bypasses PgBouncer)
+# for reliable long-running background job execution
 config :cinegraph, Oban,
-  repo: Cinegraph.Repo,
+  repo: Cinegraph.Repo.Oban,
   queues: [
     # All TMDb API work (orchestration, discovery, details) - single rate limit
     tmdb: 15,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -22,6 +22,17 @@ config :cinegraph, Cinegraph.Repo.Replica,
   show_sensitive_data_on_connection_error: true,
   pool_size: 5
 
+# Oban repository for development
+# Points to same database as primary for simplicity
+config :cinegraph, Cinegraph.Repo.Oban,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "cinegraph_dev",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 5
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -101,6 +101,7 @@ if config_env() == :prod do
   ]
 
   # Primary database configuration
+  # May use PgBouncer (port 6432) for connection pooling on web requests
   config :cinegraph, Cinegraph.Repo,
     username: username,
     password: password,
@@ -112,6 +113,23 @@ if config_env() == :prod do
     connect_timeout: 30_000,
     timeout: 15_000,
     handshake_timeout: 15_000,
+    ssl: true,
+    ssl_opts: ssl_opts
+
+  # Oban repository - ALWAYS uses direct connection (port 5432)
+  # Required for long-running background jobs that exceed PgBouncer timeouts
+  # Uses smaller pool since Oban jobs are already concurrency-limited by queue config
+  config :cinegraph, Cinegraph.Repo.Oban,
+    username: username,
+    password: password,
+    hostname: hostname,
+    port: 5432,
+    database: database,
+    pool_size: String.to_integer(System.get_env("OBAN_POOL_SIZE") || "5"),
+    socket_options: socket_opts,
+    connect_timeout: 30_000,
+    timeout: 300_000,
+    handshake_timeout: 30_000,
     ssl: true,
     ssl_opts: ssl_opts
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,16 @@ config :cinegraph, Cinegraph.Repo.Replica,
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2
 
+# Oban repository for tests
+# Points to same database as primary - uses sandbox for isolation
+config :cinegraph, Cinegraph.Repo.Oban,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "cinegraph_test#{System.get_env("MIX_TEST_PARTITION")}",
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: System.schedulers_online() * 2
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :cinegraph, CinegraphWeb.Endpoint,

--- a/lib/cinegraph/application.ex
+++ b/lib/cinegraph/application.ex
@@ -10,6 +10,8 @@ defmodule Cinegraph.Application do
     children = [
       CinegraphWeb.Telemetry,
       Cinegraph.Repo,
+      # Oban repo - direct connection (bypasses PgBouncer) for long-running jobs
+      Cinegraph.Repo.Oban,
       # Read replica for PlanetScale - offloads read queries from primary
       # Only started if configured (production with DATABASE_REPLICA_ENABLED=true)
       replica_child_spec(),

--- a/lib/cinegraph/predictions/historical_validator.ex
+++ b/lib/cinegraph/predictions/historical_validator.ex
@@ -82,8 +82,9 @@ defmodule Cinegraph.Predictions.HistoricalValidator do
     all_decade_query = get_decade_movies_query(decade)
 
     # Apply scoring to all decade movies
+    # Use extended timeout (120s) for this complex query with many JOINs
     scored_query = ScoringService.apply_scoring(all_decade_query, profile, %{})
-    all_decade_movies = Repo.all(scored_query)
+    all_decade_movies = Repo.all(scored_query, timeout: :timer.seconds(120))
 
     # Sort by score and take top N where N = number of actual 1001 movies
     total_1001_in_decade = length(actual_1001_movies)

--- a/lib/cinegraph/predictions/movie_predictor.ex
+++ b/lib/cinegraph/predictions/movie_predictor.ex
@@ -42,8 +42,9 @@ defmodule Cinegraph.Predictions.MoviePredictor do
         limit: 300
 
     # Apply database-driven scoring to all movies
+    # Use extended timeout (120s) for this complex query with many JOINs
     scored_query = ScoringService.apply_scoring(all_movies_query, profile)
-    all_movies_with_scores = Repo.all(scored_query)
+    all_movies_with_scores = Repo.all(scored_query, timeout: :timer.seconds(120))
 
     # Format and sort all movies by score
     all_scored_movies =
@@ -123,7 +124,7 @@ defmodule Cinegraph.Predictions.MoviePredictor do
     # Apply scoring to see how well we predict actual additions
     scored_query = ScoringService.apply_scoring(query, profile)
 
-    Repo.all(scored_query)
+    Repo.all(scored_query, timeout: :timer.seconds(120))
     |> Enum.map(&format_prediction_result_from_scored(&1, weights))
   end
 
@@ -152,7 +153,7 @@ defmodule Cinegraph.Predictions.MoviePredictor do
     # Apply scoring with min score filter
     scored_query = ScoringService.apply_scoring(query, profile, %{min_score: normalized_min})
 
-    Repo.all(scored_query)
+    Repo.all(scored_query, timeout: :timer.seconds(120))
     |> Enum.map(&format_prediction_result_from_scored(&1, weights))
   end
 

--- a/lib/cinegraph/repo/oban.ex
+++ b/lib/cinegraph/repo/oban.ex
@@ -1,0 +1,19 @@
+defmodule Cinegraph.Repo.Oban do
+  @moduledoc """
+  Dedicated Ecto repository for Oban background jobs.
+
+  This repo uses a DIRECT connection to PlanetScale (port 5432) instead of
+  PgBouncer (port 6432). This is required because:
+
+  1. Oban uses long-running transactions for job locking
+  2. PgBouncer's transaction pooling mode terminates connections that exceed its timeout
+  3. Complex scoring queries can take 2+ minutes to complete
+
+  In development, this uses the same connection as the primary Repo.
+  In production, this bypasses PgBouncer for reliable long-running job execution.
+  """
+
+  use Ecto.Repo,
+    otp_app: :cinegraph,
+    adapter: Ecto.Adapters.Postgres
+end


### PR DESCRIPTION
### TL;DR

Created a dedicated Ecto repository for Oban background jobs with direct database connections, bypassing PgBouncer to prevent timeouts on long-running jobs.

### What changed?

- Added `Cinegraph.Repo.Oban` module for dedicated Oban database connections
- Updated Oban configuration to use the new repo instead of the primary repo
- Configured the Oban repo in all environments (dev, test, runtime)
- Added extended timeouts (120s) to complex scoring queries in `MoviePredictor` and `HistoricalValidator`
- Ensured the Oban repo uses direct connections (port 5432) in production, bypassing PgBouncer

### How to test?

1. Verify that the application starts correctly in development
2. Run the test suite to ensure all tests pass with the new Oban repo
3. Deploy to production and confirm that long-running background jobs complete successfully
4. Monitor for any timeout errors in complex scoring queries

### Why make this change?

Long-running background jobs were failing in production because:

1. Oban uses transactions for job locking that can exceed PgBouncer timeouts
2. Complex scoring queries can take 2+ minutes to complete
3. PgBouncer's transaction pooling mode terminates connections that exceed its timeout

By creating a dedicated repo with direct database connections for Oban, we ensure reliable execution of background jobs while maintaining the connection pooling benefits of PgBouncer for web requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended database query timeout to 120 seconds for complex prediction operations.
  * Added dedicated database repository configuration for background job processing with direct database connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->