### PR TITLE
small potatos

### DIFF
--- a/lib/cinegraph/services/tmdb/daily_export.ex
+++ b/lib/cinegraph/services/tmdb/daily_export.ex
@@ -55,9 +55,10 @@ defmodule Cinegraph.Services.TMDb.DailyExport do
     date = Keyword.get(opts, :date, Date.utc_today())
     dest_dir = Keyword.get(opts, :dest_dir, System.tmp_dir!())
     # Allow fallback to previous days if today's file isn't available yet
+    # fallback_days means "try N previous days" so we add 1 to include today's attempt
     fallback_days = Keyword.get(opts, :fallback_days, 3)
 
-    try_download_with_fallback(date, dest_dir, fallback_days)
+    try_download_with_fallback(date, dest_dir, fallback_days + 1)
   end
 
   defp try_download_with_fallback(date, dest_dir, days_remaining) when days_remaining > 0 do


### PR DESCRIPTION
### TL;DR

Fixed the fallback logic in TMDb daily export downloads to correctly include the current day.

### What changed?

Modified the `download/1` function in the `Cinegraph.Services.TMDb.DailyExport` module to add 1 to the `fallback_days` parameter when calling `try_download_with_fallback/3`. This ensures that the specified number of fallback days is correctly honored, as the original implementation was effectively trying one fewer day than intended.

### How to test?

1. Set a specific `fallback_days` value (e.g., 3) when calling `download/1`
2. Verify that the function attempts to download from the current day plus 3 previous days (4 attempts total)
3. Test with various `fallback_days` values to ensure the correct number of attempts are made

### Why make this change?

The original implementation had a logical error where the `fallback_days` parameter represented "try N previous days" but didn't account for the current day in the total count. This meant that when users specified 3 fallback days, they were only getting 3 total attempts (today + 2 previous days) instead of the expected 4 attempts (today + 3 previous days). The fix ensures the function behaves as documented in the code comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download retry logic for daily data exports. The service now attempts to retrieve data from an additional day when initial attempts fail, expanding the fallback window to enhance data synchronization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->