### PR TITLE
small env

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,21 +1,4 @@
 #!/bin/sh
 
-if [ -n "$FLY_APP_NAME" ]; then
-  export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
-  export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
-  # configure node for distributed erlang with IPV6 support
-  export ERL_AFLAGS="-proto_dist inet6_tcp"
-  # Don't force database connections to IPv6 - PlanetScale needs IPv4
-  # See: https://github.com/razrfly/cinegraph/issues/375
-  # export ECTO_IPV6="true"
-fi
-
 export RELEASE_DISTRIBUTION="name"
-
-# Uncomment to send crash dumps to stderr
-# This can be useful for debugging, but may log sensitive information
-# export ERL_CRASH_DUMP=/dev/stderr
-# export ERL_CRASH_DUMP_BYTES=4096
-
-# when not running on fly.io, use a sensible default
 export RELEASE_NODE=${RELEASE_NODE:-<%= @release.name %>@$(hostname)}


### PR DESCRIPTION
### TL;DR

Simplified the `rel/env.sh.eex` file by removing Fly.io specific configuration.

### What changed?

- Removed Fly.io specific environment variable configurations
- Removed distributed Erlang IPv6 configuration
- Removed commented out code for Ecto IPv6 settings
- Removed commented out crash dump configuration
- Kept only the essential RELEASE_DISTRIBUTION and RELEASE_NODE settings

### How to test?

1. Verify that the application can still be deployed and run properly without the Fly.io specific configurations
2. Ensure that distributed Erlang functionality works correctly with the simplified configuration
3. Test the application in both Fly.io and non-Fly.io environments to confirm it operates as expected

### Why make this change?

This change simplifies the release environment configuration by removing unnecessary Fly.io specific settings, making the configuration more portable and easier to maintain. The simplified script focuses only on the essential configuration needed for the release distribution, removing commented out code and platform-specific settings that may not be relevant for all deployment environments.