### PR TITLE
fixes for lists

### DIFF
--- a/lib/cinegraph/movies/movie_list.ex
+++ b/lib/cinegraph/movies/movie_list.ex
@@ -36,6 +36,12 @@ defmodule Cinegraph.Movies.MovieList do
     # Metadata
     field :metadata, :map, default: %{}
 
+    # Display fields (for public-facing pages)
+    field :slug, :string
+    field :short_name, :string
+    field :icon, :string
+    field :display_order, :integer, default: 0
+
     timestamps()
   end
 
@@ -55,7 +61,11 @@ defmodule Cinegraph.Movies.MovieList do
       :last_import_at,
       :last_import_status,
       :total_imports,
-      :metadata
+      :metadata,
+      :slug,
+      :short_name,
+      :icon,
+      :display_order
     ])
     |> validate_required([:source_key, :name, :source_type, :source_url])
     |> validate_inclusion(:source_type, @source_types)
@@ -68,6 +78,7 @@ defmodule Cinegraph.Movies.MovieList do
     |> validate_url(:source_url)
     |> extract_source_id()
     |> unique_constraint(:source_key)
+    |> unique_constraint(:slug)
   end
 
   @doc """

--- a/lib/cinegraph_web/live/lists_manager_live.html.heex
+++ b/lib/cinegraph_web/live/lists_manager_live.html.heex
@@ -524,6 +524,11 @@
                       <div class="text-xs text-gray-500 font-mono">
                         {list.source_key}
                       </div>
+                      <%= if list.slug do %>
+                        <div class="text-xs text-indigo-500 font-mono">
+                          /{list.slug}
+                        </div>
+                      <% end %>
                     </div>
                   </div>
                 </td>
@@ -895,6 +900,64 @@
                   placeholder="Brief description of this list..."
                   class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                 ><%= if @editing_list, do: @editing_list.description, else: "" %></textarea>
+              </div>
+              
+<!-- Display Fields -->
+              <div class="border-t border-gray-200 pt-4 mt-4">
+                <p class="text-sm font-medium text-gray-700 mb-3">
+                  Display Settings (for public pages)
+                </p>
+
+                <div class="grid grid-cols-2 gap-4">
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">URL Slug</label>
+                    <input
+                      type="text"
+                      name="slug"
+                      value={if @editing_list, do: @editing_list.slug, else: ""}
+                      placeholder="my-list-name"
+                      pattern="[a-z0-9\-]+"
+                      class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p class="text-xs text-gray-500 mt-1">Auto-generated from name if blank</p>
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Short Name</label>
+                    <input
+                      type="text"
+                      name="short_name"
+                      value={if @editing_list, do: @editing_list.short_name, else: ""}
+                      placeholder="Short display name"
+                      class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Icon</label>
+                    <input
+                      type="text"
+                      name="icon"
+                      value={if @editing_list, do: @editing_list.icon, else: ""}
+                      placeholder="e.g. film, sparkles, eye"
+                      class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p class="text-xs text-gray-500 mt-1">Heroicon name</p>
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">
+                      Display Order
+                    </label>
+                    <input
+                      type="number"
+                      name="display_order"
+                      value={if @editing_list, do: @editing_list.display_order || 0, else: 0}
+                      min="0"
+                      class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                </div>
               </div>
 
               <div class="flex items-center">

--- a/lib/mix/tasks/import_canonical.ex
+++ b/lib/mix/tasks/import_canonical.ex
@@ -38,14 +38,9 @@ defmodule Mix.Tasks.ImportCanonical do
       
   """
 
-  # Get lists from database and hardcoded configuration
+  # Get lists from database (single source of truth)
   defp predefined_lists do
-    # Get from database first, fallback to hardcoded
-    db_lists = Cinegraph.Movies.MovieLists.all_as_config()
-    hardcoded_lists = Cinegraph.CanonicalLists.all()
-
-    # Merge with database taking precedence
-    Map.merge(hardcoded_lists, db_lists)
+    Cinegraph.Movies.MovieLists.all_as_config()
   end
 
   def run(args) do

--- a/lib/mix/tasks/seed_movie_lists.ex
+++ b/lib/mix/tasks/seed_movie_lists.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.SeedMovieLists do
   @moduledoc """
-  Seeds the database with default movie lists from canonical_lists.ex
+  Seeds the database with default movie lists.
 
   Usage:
       mix seed_movie_lists
@@ -9,14 +9,14 @@ defmodule Mix.Tasks.SeedMovieLists do
 
   require Logger
 
-  @shortdoc "Seeds movie lists from hardcoded canonical lists"
+  @shortdoc "Seeds default movie lists into the database"
 
   def run(_args) do
     Mix.Task.run("app.start")
 
-    Logger.info("Seeding movie lists from canonical lists...")
+    Logger.info("Seeding default movie lists...")
 
-    result = Cinegraph.Movies.MovieLists.migrate_hardcoded_lists()
+    result = Cinegraph.Movies.MovieLists.seed_default_lists()
 
     IO.puts("""
 

--- a/priv/repo/migrate_movie_lists.exs
+++ b/priv/repo/migrate_movie_lists.exs
@@ -1,11 +1,11 @@
-# Script to migrate hardcoded canonical lists to the database
+# Script to seed default movie lists into the database
 # Run with: mix run priv/repo/migrate_movie_lists.exs
 
 require Logger
 
-Logger.info("Starting migration of hardcoded lists to movie_lists table...")
+Logger.info("Seeding default movie lists...")
 
-result = Cinegraph.Movies.MovieLists.migrate_hardcoded_lists()
+result = Cinegraph.Movies.MovieLists.seed_default_lists()
 
 Logger.info("Migration complete!")
 Logger.info("Created: #{result.created} lists")

--- a/priv/repo/migrations/20260216173923_add_display_fields_to_movie_lists.exs
+++ b/priv/repo/migrations/20260216173923_add_display_fields_to_movie_lists.exs
@@ -1,0 +1,48 @@
+defmodule Cinegraph.Repo.Migrations.AddDisplayFieldsToMovieLists do
+  use Ecto.Migration
+
+  def up do
+    alter table(:movie_lists) do
+      add :slug, :string
+      add :short_name, :string
+      add :icon, :string
+      add :display_order, :integer, default: 0
+    end
+
+    create unique_index(:movie_lists, [:slug])
+
+    # Populate display fields for existing canonical lists
+    flush()
+
+    execute """
+    UPDATE movie_lists SET slug = '1001-movies', short_name = '1001 Movies', icon = 'film', display_order = 1
+    WHERE source_key = '1001_movies'
+    """
+
+    execute """
+    UPDATE movie_lists SET slug = 'criterion', short_name = 'Criterion', icon = 'sparkles', display_order = 2
+    WHERE source_key = 'criterion'
+    """
+
+    execute """
+    UPDATE movie_lists SET slug = 'sight-sound-2022', short_name = 'Sight & Sound 2022', icon = 'eye', display_order = 3
+    WHERE source_key = 'sight_sound_critics_2022'
+    """
+
+    execute """
+    UPDATE movie_lists SET slug = 'national-film-registry', short_name = 'Film Registry', icon = 'building-library', display_order = 4
+    WHERE source_key = 'national_film_registry'
+    """
+  end
+
+  def down do
+    drop index(:movie_lists, [:slug])
+
+    alter table(:movie_lists) do
+      remove :slug
+      remove :short_name
+      remove :icon
+      remove :display_order
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -14,9 +14,9 @@ require Logger
 
 Logger.info("Running seeds...")
 
-# Seed movie lists from hardcoded canonical lists
-Logger.info("Seeding movie lists from canonical lists...")
-result = Cinegraph.Movies.MovieLists.migrate_hardcoded_lists()
+# Seed movie lists (DB is the single source of truth)
+Logger.info("Seeding default movie lists...")
+result = Cinegraph.Movies.MovieLists.seed_default_lists()
 
 Logger.info("""
 Movie Lists Seeding Results:


### PR DESCRIPTION
### TL;DR

Refactored movie lists to use the database as the single source of truth instead of hardcoded configurations.

### What changed?

- Converted `CanonicalLists` module to be a thin compatibility wrapper over the database
- Updated `ListSlugs` to fetch data from the database instead of hardcoded maps
- Added display fields to `MovieList` schema (slug, short_name, icon, display_order)
- Created migration to add these new fields to the database
- Updated the Lists Manager UI to support editing the new display fields
- Renamed `migrate_hardcoded_lists` to `seed_default_lists` for clarity
- Updated mix tasks and seeds to use the database as the source of truth

### How to test?

1. Run the migration: `mix ecto.migrate`
2. Seed the default lists: `mix seed_movie_lists`
3. Verify existing canonical lists work in the UI
4. Test creating and editing lists with the new display fields
5. Confirm public-facing list pages still work correctly with the new slug system

### Why make this change?

This change eliminates duplication between hardcoded configurations and the database, making the system more maintainable. Having a single source of truth in the database allows for easier management of movie lists through the admin UI rather than requiring code changes. The compatibility wrapper ensures existing code continues to work without modifications while the system transitions to the new database-driven approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added display configuration fields for lists: URL slug, short name, icon, and display order
  - Lists now sourced from database configuration for improved flexibility

* **UI Improvements**
  - Introduced "Display Settings" section in list management modal
  - Display slugs in the lists table when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->