### PR TITLE
small fixes

### DIFF
--- a/lib/cinegraph/movies/movie_lists.ex
+++ b/lib/cinegraph/movies/movie_lists.ex
@@ -220,6 +220,8 @@ defmodule Cinegraph.Movies.MovieLists do
       %{
         source_key: "1001_movies",
         name: "1001 Movies You Must See Before You Die",
+        description:
+          "The essential guide to cinema's greatest films, updated annually with new selections.",
         source_type: "imdb",
         source_url: "https://www.imdb.com/list/ls024863935/",
         source_id: "ls024863935",
@@ -235,6 +237,8 @@ defmodule Cinegraph.Movies.MovieLists do
       %{
         source_key: "criterion",
         name: "The Criterion Collection",
+        description:
+          "A continuing series of important classic and contemporary films from around the world.",
         source_type: "imdb",
         source_url: "https://www.imdb.com/list/ls087831830/",
         source_id: "ls087831830",
@@ -250,6 +254,8 @@ defmodule Cinegraph.Movies.MovieLists do
       %{
         source_key: "sight_sound_critics_2022",
         name: "BFI's Sight & Sound | Critics' Top 100 Movies (2022 Edition)",
+        description:
+          "BFI's once-a-decade poll of the world's greatest films as voted by critics (2022 edition).",
         source_type: "imdb",
         source_url: "https://www.imdb.com/list/ls566134733/",
         source_id: "ls566134733",
@@ -269,6 +275,8 @@ defmodule Cinegraph.Movies.MovieLists do
       %{
         source_key: "national_film_registry",
         name: "National Film Registry - The Full List of Films",
+        description:
+          "Films preserved by the Library of Congress for their cultural, historical, or aesthetic significance.",
         source_type: "imdb",
         source_url: "https://www.imdb.com/list/ls595303232/",
         source_id: "ls595303232",
@@ -301,7 +309,7 @@ defmodule Cinegraph.Movies.MovieLists do
             if is_nil(existing.slug) and not is_nil(attrs[:slug]) do
               update_movie_list(
                 existing,
-                Map.take(attrs, [:slug, :short_name, :icon, :display_order])
+                Map.take(attrs, [:slug, :short_name, :icon, :display_order, :description])
               )
             end
 

--- a/priv/repo/migrations/20260216173923_add_display_fields_to_movie_lists.exs
+++ b/priv/repo/migrations/20260216173923_add_display_fields_to_movie_lists.exs
@@ -15,22 +15,26 @@ defmodule Cinegraph.Repo.Migrations.AddDisplayFieldsToMovieLists do
     flush()
 
     execute """
-    UPDATE movie_lists SET slug = '1001-movies', short_name = '1001 Movies', icon = 'film', display_order = 1
+    UPDATE movie_lists SET slug = '1001-movies', short_name = '1001 Movies', icon = 'film', display_order = 1,
+      description = COALESCE(description, 'The essential guide to cinema''s greatest films, updated annually with new selections.')
     WHERE source_key = '1001_movies'
     """
 
     execute """
-    UPDATE movie_lists SET slug = 'criterion', short_name = 'Criterion', icon = 'sparkles', display_order = 2
+    UPDATE movie_lists SET slug = 'criterion', short_name = 'Criterion', icon = 'sparkles', display_order = 2,
+      description = COALESCE(description, 'A continuing series of important classic and contemporary films from around the world.')
     WHERE source_key = 'criterion'
     """
 
     execute """
-    UPDATE movie_lists SET slug = 'sight-sound-2022', short_name = 'Sight & Sound 2022', icon = 'eye', display_order = 3
+    UPDATE movie_lists SET slug = 'sight-sound-2022', short_name = 'Sight & Sound 2022', icon = 'eye', display_order = 3,
+      description = COALESCE(description, 'BFI''s once-a-decade poll of the world''s greatest films as voted by critics (2022 edition).')
     WHERE source_key = 'sight_sound_critics_2022'
     """
 
     execute """
-    UPDATE movie_lists SET slug = 'national-film-registry', short_name = 'Film Registry', icon = 'building-library', display_order = 4
+    UPDATE movie_lists SET slug = 'national-film-registry', short_name = 'Film Registry', icon = 'building-library', display_order = 4,
+      description = COALESCE(description, 'Films preserved by the Library of Congress for their cultural, historical, or aesthetic significance.')
     WHERE source_key = 'national_film_registry'
     """
   end


### PR DESCRIPTION
# Add descriptions to movie lists

### TL;DR

Added descriptive text to each curated movie list to provide context about their significance.

### What changed?

- Added a `description` field to each predefined movie list in `movie_lists.ex`
- Updated the migration file to include descriptions when setting up movie lists
- Modified the `update_movie_list` function to include the description field when updating existing lists

### How to test?

1. Run the migration
2. Check that movie lists have descriptions in the database
3. Verify that descriptions appear correctly in the UI where movie lists are displayed

### Why make this change?

This change provides users with helpful context about each curated list's significance and origin. The descriptions explain what makes each collection special (e.g., the Criterion Collection's focus on important films, the National Film Registry's cultural significance, etc.), enhancing the user's understanding of these important film collections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptions to movie lists including 1001 Movies, The Criterion Collection, BFI Sight & Sound 2022, and National Film Registry, providing enhanced context about each collection.

* **Chores**
  * Updated database to populate default descriptions for all existing movie lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->