### PR TITLE
small more grep

### DIFF
--- a/lib/cinegraph/movies/movie_lists.ex
+++ b/lib/cinegraph/movies/movie_lists.ex
@@ -305,12 +305,14 @@ defmodule Cinegraph.Movies.MovieLists do
             end
 
           existing ->
-            # Update existing lists with display fields if missing
-            if is_nil(existing.slug) and not is_nil(attrs[:slug]) do
-              update_movie_list(
-                existing,
-                Map.take(attrs, [:slug, :short_name, :icon, :display_order, :description])
-              )
+            # Backfill any missing display fields on existing lists
+            updates =
+              [:slug, :short_name, :icon, :display_order, :description]
+              |> Enum.filter(fn field -> is_nil(Map.get(existing, field)) and not is_nil(attrs[field]) end)
+              |> Map.new(fn field -> {field, attrs[field]} end)
+
+            if map_size(updates) > 0 do
+              update_movie_list(existing, updates)
             end
 
             {:exists, existing}


### PR DESCRIPTION
### TL;DR

Improved the backfill logic for movie list display fields.

### What changed?

Enhanced the movie list update logic to more efficiently handle backfilling missing display fields. Instead of only checking for a missing slug, the code now:

1. Dynamically checks all display fields (slug, short_name, icon, display_order, description)
2. Creates an updates map containing only the fields that need to be backfilled
3. Only performs an update if there are actual fields to update

### How to test?

1. Create a movie list with some missing display fields
2. Call the function that contains this backfill logic
3. Verify that only the previously missing fields are updated while existing values remain unchanged
4. Check that no update is performed when all fields are already populated

### Why make this change?

This change makes the backfill process more comprehensive and efficient by:
- Checking all display fields instead of just the slug
- Only updating fields that are actually missing
- Avoiding unnecessary database updates when no fields need to be backfilled