### PR TITLE
another

### DIFF
--- a/lib/cinegraph/movies/movie_lists.ex
+++ b/lib/cinegraph/movies/movie_lists.ex
@@ -308,14 +308,17 @@ defmodule Cinegraph.Movies.MovieLists do
             # Backfill any missing display fields on existing lists
             updates =
               [:slug, :short_name, :icon, :display_order, :description]
-              |> Enum.filter(fn field -> is_nil(Map.get(existing, field)) and not is_nil(attrs[field]) end)
+              |> Enum.filter(fn field ->
+                is_nil(Map.get(existing, field)) and not is_nil(attrs[field])
+              end)
               |> Map.new(fn field -> {field, attrs[field]} end)
 
             if map_size(updates) > 0 do
-              update_movie_list(existing, updates)
+              {:ok, updated} = update_movie_list(existing, updates)
+              {:exists, updated}
+            else
+              {:exists, existing}
             end
-
-            {:exists, existing}
         end
       end)
 


### PR DESCRIPTION
### TL;DR

Fixed a bug in the movie list creation logic to properly return updated movie lists.

### What changed?

Modified the `MovieLists` module to correctly return updated movie lists when backfilling missing display fields. Previously, the code would update a movie list but always return the original unmodified list. Now it returns the updated list with the backfilled fields.

### How to test?

1. Create a movie list with missing display fields
2. Try to create the same list again but with values for those missing fields
3. Verify that the returned list contains the backfilled values

### Why make this change?

This fixes a bug where backfilled display fields weren't being reflected in the returned data, causing inconsistencies between what was stored in the database and what was returned to the caller. The change ensures that when a movie list is updated during the backfill process, the updated version is properly returned.