### PR TITLE
again

### DIFF
--- a/lib/cinegraph/movies/movie_lists.ex
+++ b/lib/cinegraph/movies/movie_lists.ex
@@ -7,6 +7,7 @@ defmodule Cinegraph.Movies.MovieLists do
   import Ecto.Query, warn: false
   alias Cinegraph.Repo
   alias Cinegraph.Movies.MovieList
+  require Logger
 
   @doc """
   Returns all active movie lists.
@@ -315,8 +316,15 @@ defmodule Cinegraph.Movies.MovieLists do
 
             if map_size(updates) > 0 do
               case update_movie_list(existing, updates) do
-                {:ok, updated} -> {:exists, updated}
-                {:error, _changeset} -> {:exists, existing}
+                {:ok, updated} ->
+                  {:exists, updated}
+
+                {:error, changeset} ->
+                  Logger.warning(
+                    "Failed to backfill display fields for #{existing.source_key}: #{inspect(changeset.errors)}"
+                  )
+
+                  {:exists, existing}
               end
             else
               {:exists, existing}


### PR DESCRIPTION
### TL;DR

Added error logging for failed movie list display field backfills.

### What changed?

Enhanced the error handling in the `upsert_movie_list_by_source` function by adding proper logging when backfilling display fields fails. Now, when an update to an existing movie list fails, a warning log is generated that includes the source key and the specific errors from the changeset.

### How to test?

1. Trigger a scenario where movie list display fields need to be backfilled but the update fails
2. Check the logs for a warning message that includes the source key and detailed error information
3. Verify that the function still returns `{:exists, existing}` as before

### Why make this change?

This change improves observability by adding detailed logging when movie list updates fail during the backfill process. Previously, errors were silently ignored, making it difficult to diagnose issues with movie list updates. The added logging will help identify and troubleshoot problems with display field backfilling.