### PR TITLE
movie lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,23 @@ priv/
 │   └── seeds.exs     # Seed data
 ```
 
+## Adding Festivals & Awards Ceremonies
+The `festival_events` table is the single source of truth. Add new festivals/ceremonies via:
+1. **Seeds** (`priv/repo/seeds.exs`) or **Admin UI** (`/admin/festival-events`)
+2. Discover available years: `YearDiscoveryWorker.queue_discovery("source_key")`
+3. Import a year: `Cultural.import_festival_year("source_key", 2024)`
+4. Bulk import: `AwardImportWorker.queue_sync_missing(org_id)`
+
+No code changes needed — `Events.list_active_events()` drives all festival discovery dynamically.
+
+## Adding Canonical Movie Lists
+The `movie_lists` table is the single source of truth. Add new lists via:
+1. **Seeds** (`MovieLists.seed_default_lists/0`) or **Admin UI** (`/admin/lists-manager`)
+2. Fill: name, source_url (IMDb list URL), source_id, category, slug
+3. Trigger import: `CanonicalImporter.import_list_by_key("source_key")`
+
+Legacy modules (`canonical_lists.ex`, `list_slugs.ex`) are thin wrappers that delegate to the DB.
+
 ## Development Notes
 - Always run `mix format` before committing
 - Use Oban for background jobs, not manual async tasks

--- a/lib/cinegraph/cultural.ex
+++ b/lib/cinegraph/cultural.ex
@@ -1031,16 +1031,19 @@ defmodule Cinegraph.Cultural do
   end
 
   @doc """
-  Import all supported festivals for a specific year.
+  Import all active festivals/ceremonies for a specific year.
+  Queries the database for all active festival events rather than using a hardcoded list.
 
   ## Examples
 
       iex> Cinegraph.Cultural.import_all_festivals_for_year(2024)
-      {:ok, %{year: 2024, festivals: ["cannes", "bafta", "berlin", "venice"], jobs: 4}}
-      
+      {:ok, %{year: 2024, festivals: [...], jobs: 11}}
+
   """
   def import_all_festivals_for_year(year, options \\ []) do
-    festivals = ["cannes", "bafta", "berlin", "venice"]
+    festivals =
+      Events.list_active_events()
+      |> Enum.map(& &1.source_key)
 
     jobs =
       Enum.map(festivals, fn festival ->

--- a/lib/cinegraph/movies/movie_lists.ex
+++ b/lib/cinegraph/movies/movie_lists.ex
@@ -293,6 +293,107 @@ defmodule Cinegraph.Movies.MovieLists do
         short_name: "Film Registry",
         icon: "building-library",
         display_order: 4
+      },
+      %{
+        source_key: "sight_sound_directors_2022",
+        name: "BFI's Sight & Sound | Directors' Top 100 Movies (2022 Edition)",
+        description:
+          "BFI's once-a-decade poll of the greatest films as voted by 480 directors worldwide (2022 edition).",
+        source_type: "imdb",
+        source_url: "https://www.imdb.com/list/ls562044484/",
+        source_id: "ls562044484",
+        category: "critics",
+        active: true,
+        tracks_awards: false,
+        metadata: %{
+          "edition" => "2022",
+          "poll_type" => "directors",
+          "source" => "BFI Sight & Sound"
+        },
+        slug: "sight-sound-directors-2022",
+        short_name: "S&S Directors 2022",
+        icon: "eye",
+        display_order: 5
+      },
+      %{
+        source_key: "ebert_great_movies",
+        name: "Roger Ebert's Great Movies",
+        description:
+          "Roger Ebert's personal selection of the greatest films ever made, spanning his career from 1997 to 2013.",
+        source_type: "imdb",
+        source_url: "https://www.imdb.com/list/ls064094320/",
+        source_id: "ls064094320",
+        category: "critics",
+        active: true,
+        tracks_awards: false,
+        metadata: %{
+          "critic" => "Roger Ebert",
+          "source" => "rogerebert.com"
+        },
+        slug: "ebert-great-movies",
+        short_name: "Ebert's Great",
+        icon: "star",
+        display_order: 6
+      },
+      %{
+        source_key: "tspdt_1000",
+        name: "They Shoot Pictures, Don't They? - 1000 Greatest Films",
+        description:
+          "Aggregated meta-list of the 1,000 greatest films, compiled from thousands of critics' and filmmakers' polls.",
+        source_type: "imdb",
+        source_url: "https://www.imdb.com/list/ls597166073/",
+        source_id: "ls597166073",
+        category: "critics",
+        active: true,
+        tracks_awards: false,
+        metadata: %{
+          "edition" => "2025",
+          "source" => "theyshootpictures.com"
+        },
+        slug: "tspdt-1000",
+        short_name: "TSPDT 1000",
+        icon: "chart-bar",
+        display_order: 7
+      },
+      %{
+        source_key: "letterboxd_top_250",
+        name: "Letterboxd Top 250 Narrative Feature Films",
+        description:
+          "Community-driven ranking based on the average weighted rating of all Letterboxd users.",
+        source_type: "imdb",
+        source_url: "https://www.imdb.com/list/ls567401607/",
+        source_id: "ls567401607",
+        category: "curated",
+        active: true,
+        tracks_awards: false,
+        metadata: %{
+          "source" => "letterboxd.com",
+          "note" => "Excludes documentaries, shorts, and stand-up specials"
+        },
+        slug: "letterboxd-top-250",
+        short_name: "Letterboxd 250",
+        icon: "heart",
+        display_order: 8
+      },
+      %{
+        source_key: "afi_100",
+        name: "AFI's 100 Years...100 Movies",
+        description:
+          "The American Film Institute's definitive list of the 100 greatest American films of all time.",
+        source_type: "imdb",
+        source_url: "https://www.imdb.com/list/ls076768590/",
+        source_id: "ls076768590",
+        category: "critics",
+        active: true,
+        tracks_awards: false,
+        metadata: %{
+          "organization" => "American Film Institute",
+          "edition" => "1998"
+        },
+        slug: "afi-100",
+        short_name: "AFI 100",
+        icon: "trophy",
+        display_order: 9
       }
     ]
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -402,6 +402,428 @@ case Events.get_by_source_key("sxsw") do
     Logger.info("  ⏭️  SXSW events already exists")
 end
 
+# Golden Globe Awards - IMDb source
+case Events.get_by_source_key("golden_globes") do
+  nil ->
+    {:ok, _golden_globes_event} =
+      Events.create_festival_event(%{
+        source_key: "golden_globes",
+        name: "Golden Globe Awards",
+        abbreviation: "HFPA",
+        country: "USA",
+        founded_year: 1944,
+        website: "https://www.goldenglobes.com",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000292",
+          "imdb_event_id" => "ev0000292",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.goldenglobes.com"}
+        ],
+        typical_start_month: 1,
+        typical_start_day: 5,
+        typical_duration_days: 1,
+        ceremony_vs_festival: "ceremony",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1944,
+        max_available_year: 2025,
+        import_priority: 95,
+        reliability_score: 0.90,
+        metadata: %{
+          "organization" => "Hollywood Foreign Press Association",
+          "category_mappings" => %{
+            "best_motion_picture_drama" => "best_picture_drama",
+            "best_motion_picture_musical_or_comedy" => "best_picture_comedy",
+            "best_director" => "best_director",
+            "best_actor_drama" => "best_actor_drama",
+            "best_actress_drama" => "best_actress_drama"
+          },
+          "default_category" => "golden_globe_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created Golden Globes events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  Golden Globes events already exists")
+end
+
+# BAFTA Film Awards - IMDb source
+case Events.get_by_source_key("bafta") do
+  nil ->
+    {:ok, _bafta_event} =
+      Events.create_festival_event(%{
+        source_key: "bafta",
+        name: "BAFTA Film Awards",
+        abbreviation: "BAFTA",
+        country: "UK",
+        founded_year: 1949,
+        website: "https://www.bafta.org",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000123",
+          "imdb_event_id" => "ev0000123",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.bafta.org/film/awards"}
+        ],
+        typical_start_month: 2,
+        typical_start_day: 16,
+        typical_duration_days: 1,
+        ceremony_vs_festival: "ceremony",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1949,
+        max_available_year: 2025,
+        import_priority: 95,
+        reliability_score: 0.90,
+        metadata: %{
+          "organization" => "British Academy of Film and Television Arts",
+          "category_mappings" => %{
+            "best_film" => "best_film",
+            "best_director" => "best_director",
+            "best_leading_actor" => "best_actor",
+            "best_leading_actress" => "best_actress"
+          },
+          "default_category" => "bafta_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created BAFTA events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  BAFTA events already exists")
+end
+
+# SAG Awards - IMDb source
+case Events.get_by_source_key("sag") do
+  nil ->
+    {:ok, _sag_event} =
+      Events.create_festival_event(%{
+        source_key: "sag",
+        name: "Screen Actors Guild Awards",
+        abbreviation: "SAG",
+        country: "USA",
+        founded_year: 1995,
+        website: "https://www.sagawards.org",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000598",
+          "imdb_event_id" => "ev0000598",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.sagawards.org"}
+        ],
+        typical_start_month: 2,
+        typical_start_day: 23,
+        typical_duration_days: 1,
+        ceremony_vs_festival: "ceremony",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1995,
+        max_available_year: 2025,
+        import_priority: 90,
+        reliability_score: 0.90,
+        metadata: %{
+          "organization" =>
+            "Screen Actors Guild - American Federation of Television and Radio Artists",
+          "category_mappings" => %{
+            "outstanding_cast" => "outstanding_cast",
+            "outstanding_male_actor_leading" => "best_actor",
+            "outstanding_female_actor_leading" => "best_actress"
+          },
+          "default_category" => "sag_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created SAG Awards events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  SAG Awards events already exists")
+end
+
+# Critics Choice Awards - IMDb source
+case Events.get_by_source_key("critics_choice") do
+  nil ->
+    {:ok, _critics_choice_event} =
+      Events.create_festival_event(%{
+        source_key: "critics_choice",
+        name: "Critics Choice Awards",
+        abbreviation: "CCA",
+        country: "USA",
+        founded_year: 1996,
+        website: "https://www.criticschoice.com",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000133",
+          "imdb_event_id" => "ev0000133",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.criticschoice.com"}
+        ],
+        typical_start_month: 1,
+        typical_start_day: 12,
+        typical_duration_days: 1,
+        ceremony_vs_festival: "ceremony",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1996,
+        max_available_year: 2025,
+        import_priority: 85,
+        reliability_score: 0.85,
+        metadata: %{
+          "organization" => "Critics Choice Association",
+          "category_mappings" => %{
+            "best_picture" => "best_picture",
+            "best_director" => "best_director",
+            "best_actor" => "best_actor",
+            "best_actress" => "best_actress"
+          },
+          "default_category" => "critics_choice_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created Critics Choice Awards events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  Critics Choice Awards events already exists")
+end
+
+# Toronto International Film Festival (TIFF) - IMDb source
+case Events.get_by_source_key("toronto") do
+  nil ->
+    {:ok, _toronto_event} =
+      Events.create_festival_event(%{
+        source_key: "toronto",
+        name: "Toronto International Film Festival",
+        abbreviation: "TIFF",
+        country: "Canada",
+        founded_year: 1976,
+        website: "https://www.tiff.net",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000659",
+          "imdb_event_id" => "ev0000659",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.tiff.net"}
+        ],
+        typical_start_month: 9,
+        typical_start_day: 5,
+        typical_duration_days: 11,
+        ceremony_vs_festival: "festival",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1976,
+        max_available_year: 2025,
+        import_priority: 90,
+        reliability_score: 0.90,
+        metadata: %{
+          "festival" => "Toronto International Film Festival",
+          "location" => "Toronto, Ontario, Canada",
+          "specialization" => "premiere platform, Oscar bellwether",
+          "category_mappings" => %{
+            "peoples_choice_award" => "peoples_choice",
+            "platform_prize" => "platform_prize"
+          },
+          "default_category" => "tiff_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created TIFF events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  TIFF events already exists")
+end
+
+# Telluride Film Festival - IMDb source
+case Events.get_by_source_key("telluride") do
+  nil ->
+    {:ok, _telluride_event} =
+      Events.create_festival_event(%{
+        source_key: "telluride",
+        name: "Telluride Film Festival",
+        abbreviation: "TFF",
+        country: "USA",
+        founded_year: 1974,
+        website: "https://www.telluridefilmfestival.org",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000645",
+          "imdb_event_id" => "ev0000645",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.telluridefilmfestival.org"}
+        ],
+        typical_start_month: 8,
+        typical_start_day: 30,
+        typical_duration_days: 4,
+        ceremony_vs_festival: "festival",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1974,
+        max_available_year: 2025,
+        import_priority: 80,
+        reliability_score: 0.85,
+        metadata: %{
+          "festival" => "Telluride Film Festival",
+          "location" => "Telluride, Colorado",
+          "specialization" => "curated premieres, no advance program announcement",
+          "category_mappings" => %{
+            "silver_medallion" => "silver_medallion"
+          },
+          "default_category" => "telluride_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created Telluride events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  Telluride events already exists")
+end
+
+# New York Film Festival - IMDb source
+case Events.get_by_source_key("nyff") do
+  nil ->
+    {:ok, _nyff_event} =
+      Events.create_festival_event(%{
+        source_key: "nyff",
+        name: "New York Film Festival",
+        abbreviation: "NYFF",
+        country: "USA",
+        founded_year: 1963,
+        website: "https://www.filmlinc.org/nyff",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000484",
+          "imdb_event_id" => "ev0000484",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.filmlinc.org/nyff"}
+        ],
+        typical_start_month: 9,
+        typical_start_day: 27,
+        typical_duration_days: 17,
+        ceremony_vs_festival: "festival",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1963,
+        max_available_year: 2025,
+        import_priority: 80,
+        reliability_score: 0.85,
+        metadata: %{
+          "festival" => "New York Film Festival",
+          "location" => "New York City, New York",
+          "organization" => "Film at Lincoln Center",
+          "specialization" => "curated selection, no competitive awards",
+          "default_category" => "nyff_selection",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created NYFF events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  NYFF events already exists")
+end
+
+# Locarno Film Festival - IMDb source
+case Events.get_by_source_key("locarno") do
+  nil ->
+    {:ok, _locarno_event} =
+      Events.create_festival_event(%{
+        source_key: "locarno",
+        name: "Locarno Film Festival",
+        abbreviation: "LFF",
+        country: "Switzerland",
+        founded_year: 1946,
+        website: "https://www.locarnofestival.ch",
+        primary_source: "imdb",
+        source_config: %{
+          "event_id" => "ev0000400",
+          "imdb_event_id" => "ev0000400",
+          "url_template" => "https://www.imdb.com/event/{event_id}/{year}/1/",
+          "parser_type" => "next_data_json"
+        },
+        fallback_sources: [
+          %{"source" => "official", "url" => "https://www.locarnofestival.ch"}
+        ],
+        typical_start_month: 8,
+        typical_start_day: 7,
+        typical_duration_days: 10,
+        ceremony_vs_festival: "festival",
+        tracks_nominations: true,
+        tracks_winners_only: false,
+        min_available_year: 1946,
+        max_available_year: 2025,
+        import_priority: 75,
+        reliability_score: 0.85,
+        metadata: %{
+          "festival" => "Locarno Film Festival",
+          "location" => "Locarno, Switzerland",
+          "specialization" => "arthouse and independent cinema",
+          "category_mappings" => %{
+            "golden_leopard" => "golden_leopard",
+            "special_jury_prize" => "special_jury_prize",
+            "best_director" => "best_director"
+          },
+          "default_category" => "locarno_award",
+          "parser_hints" => %{
+            "expected_format" => "key_value_awards",
+            "category_path" => "awards"
+          }
+        }
+      })
+
+    Logger.info("  ✅ Created Locarno events configuration")
+
+  _ ->
+    Logger.info("  ⏭️  Locarno events already exists")
+end
+
 # Add some festival dates for 2024 (completed) and 2025 (upcoming where known)
 Logger.info("Seeding festival dates for 2024/2025...")
 
@@ -415,6 +837,14 @@ create_festival_dates = fn ->
   new_horizons_event = Events.get_by_source_key("new_horizons")
   sundance_event = Events.get_by_source_key("sundance")
   sxsw_event = Events.get_by_source_key("sxsw")
+  golden_globes_event = Events.get_by_source_key("golden_globes")
+  bafta_event = Events.get_by_source_key("bafta")
+  sag_event = Events.get_by_source_key("sag")
+  critics_choice_event = Events.get_by_source_key("critics_choice")
+  toronto_event = Events.get_by_source_key("toronto")
+  telluride_event = Events.get_by_source_key("telluride")
+  nyff_event = Events.get_by_source_key("nyff")
+  locarno_event = Events.get_by_source_key("locarno")
 
   # 2024 dates (completed)
   if oscar_event do
@@ -489,6 +919,94 @@ create_festival_dates = fn ->
       year: 2024,
       start_date: ~D[2024-03-08],
       end_date: ~D[2024-03-16],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if golden_globes_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: golden_globes_event.id,
+      year: 2024,
+      start_date: ~D[2024-01-07],
+      end_date: ~D[2024-01-07],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if bafta_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: bafta_event.id,
+      year: 2024,
+      start_date: ~D[2024-02-18],
+      end_date: ~D[2024-02-18],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if sag_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: sag_event.id,
+      year: 2024,
+      start_date: ~D[2024-02-24],
+      end_date: ~D[2024-02-24],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if critics_choice_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: critics_choice_event.id,
+      year: 2024,
+      start_date: ~D[2024-01-14],
+      end_date: ~D[2024-01-14],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if toronto_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: toronto_event.id,
+      year: 2024,
+      start_date: ~D[2024-09-05],
+      end_date: ~D[2024-09-15],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if telluride_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: telluride_event.id,
+      year: 2024,
+      start_date: ~D[2024-08-30],
+      end_date: ~D[2024-09-02],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if nyff_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: nyff_event.id,
+      year: 2024,
+      start_date: ~D[2024-09-27],
+      end_date: ~D[2024-10-13],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if locarno_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: locarno_event.id,
+      year: 2024,
+      start_date: ~D[2024-08-07],
+      end_date: ~D[2024-08-17],
       status: "completed",
       source: "official"
     })
@@ -569,6 +1087,94 @@ create_festival_dates = fn ->
       end_date: ~D[2025-03-15],
       status: "upcoming",
       source: "official"
+    })
+  end
+
+  if golden_globes_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: golden_globes_event.id,
+      year: 2025,
+      start_date: ~D[2025-01-05],
+      end_date: ~D[2025-01-05],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if bafta_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: bafta_event.id,
+      year: 2025,
+      start_date: ~D[2025-02-16],
+      end_date: ~D[2025-02-16],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if sag_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: sag_event.id,
+      year: 2025,
+      start_date: ~D[2025-02-23],
+      end_date: ~D[2025-02-23],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if critics_choice_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: critics_choice_event.id,
+      year: 2025,
+      start_date: ~D[2025-01-12],
+      end_date: ~D[2025-01-12],
+      status: "completed",
+      source: "official"
+    })
+  end
+
+  if toronto_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: toronto_event.id,
+      year: 2025,
+      start_date: ~D[2025-09-04],
+      end_date: ~D[2025-09-14],
+      status: "upcoming",
+      source: "estimated"
+    })
+  end
+
+  if telluride_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: telluride_event.id,
+      year: 2025,
+      start_date: ~D[2025-08-29],
+      end_date: ~D[2025-09-01],
+      status: "upcoming",
+      source: "estimated"
+    })
+  end
+
+  if nyff_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: nyff_event.id,
+      year: 2025,
+      start_date: ~D[2025-09-26],
+      end_date: ~D[2025-10-12],
+      status: "upcoming",
+      source: "estimated"
+    })
+  end
+
+  if locarno_event do
+    Events.upsert_festival_date(%{
+      festival_event_id: locarno_event.id,
+      year: 2025,
+      start_date: ~D[2025-08-06],
+      end_date: ~D[2025-08-16],
+      status: "upcoming",
+      source: "estimated"
     })
   end
 end


### PR DESCRIPTION
### TL;DR

Added documentation for festival/award management and expanded the movie list catalog with additional canonical lists.

### What changed?

- Added documentation in `CLAUDE.md` explaining how to add new festivals/awards and canonical movie lists
- Updated `Cultural.import_all_festivals_for_year` to dynamically query active events from the database instead of using a hardcoded list
- Added 5 new canonical movie lists to the seed data:
  - BFI's Sight & Sound Directors' Top 100 (2022)
  - Roger Ebert's Great Movies
  - They Shoot Pictures, Don't They? - 1000 Greatest Films
  - Letterboxd Top 250 Narrative Feature Films
  - AFI's 100 Years...100 Movies
- Added 8 new festival/award ceremony configurations to the seed data:
  - Golden Globe Awards
  - BAFTA Film Awards
  - Screen Actors Guild Awards
  - Critics Choice Awards
  - Toronto International Film Festival
  - Telluride Film Festival
  - New York Film Festival
  - Locarno Film Festival
- Added 2024 (completed) and 2025 (upcoming) dates for all new festivals

### How to test?

1. Run the seed script to add the new festivals and movie lists: `mix run priv/repo/seeds.exs`
2. Verify new festivals appear in the admin UI: `/admin/festival-events`
3. Verify new movie lists appear in the admin UI: `/admin/lists-manager`
4. Test importing a festival year: `Cultural.import_festival_year("golden_globes", 2024)`
5. Test importing a canonical list: `CanonicalImporter.import_list_by_key("sight_sound_directors_2022")`
6. Verify `Cultural.import_all_festivals_for_year(2024)` includes all active festivals

### Why make this change?

This change makes the system more dynamic and maintainable by:
1. Eliminating hardcoded festival lists in favor of database-driven configuration
2. Providing clear documentation on how to add new festivals and lists
3. Expanding the catalog of prestigious film awards and canonical lists to improve movie recommendations and cultural relevance scoring
4. Adding more international festivals to broaden global coverage

The expanded festival and list coverage will provide richer data for movie recommendations and cultural significance algorithms.