### PR TITLE
fixes for routes

### DIFF
--- a/lib/cinegraph/events.ex
+++ b/lib/cinegraph/events.ex
@@ -42,6 +42,13 @@ defmodule Cinegraph.Events do
   end
 
   @doc """
+  Gets a festival event by abbreviation.
+  """
+  def get_by_abbreviation(abbreviation) do
+    Repo.get_by(FestivalEvent, abbreviation: abbreviation)
+  end
+
+  @doc """
   Gets an active festival event by source key.
   """
   def get_active_by_source_key(source_key) do

--- a/lib/cinegraph/workers/award_import_worker.ex
+++ b/lib/cinegraph/workers/award_import_worker.ex
@@ -388,14 +388,15 @@ defmodule Cinegraph.Workers.AwardImportWorker do
   end
 
   # Map organization abbreviation to festival key (source_key in festival_events)
-  # These mappings come from the festival_events table
-  defp abbreviation_to_festival_key("CFF"), do: "cannes"
-  defp abbreviation_to_festival_key("VIFF"), do: "venice"
-  defp abbreviation_to_festival_key("BIFF"), do: "berlin"
-  defp abbreviation_to_festival_key("SFF"), do: "sundance"
-  defp abbreviation_to_festival_key("SXSW"), do: "sxsw"
-  defp abbreviation_to_festival_key("NHIFF"), do: "new_horizons"
-  defp abbreviation_to_festival_key(_), do: nil
+  # Queries the festival_events table dynamically so new events are automatically supported
+  defp abbreviation_to_festival_key(abbreviation) do
+    alias Cinegraph.Events
+
+    case Events.get_by_abbreviation(abbreviation) do
+      %{source_key: source_key} -> source_key
+      nil -> nil
+    end
+  end
 
   defp broadcast_progress(action, data) do
     Phoenix.PubSub.broadcast(

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1182,6 +1182,97 @@ end
 create_festival_dates.()
 Logger.info("  ✅ Created festival dates for 2024/2025")
 
+# Seed festival organizations (for the /awards display page)
+# These correspond to festival_events but are the public-facing display entities
+Logger.info("Seeding festival organizations...")
+
+alias Cinegraph.Festivals
+
+festival_orgs = [
+  %{
+    name: "Golden Globe Awards",
+    abbreviation: "HFPA",
+    slug: "golden-globes",
+    country: "USA",
+    founded_year: 1944,
+    website: "https://www.goldenglobes.com"
+  },
+  %{
+    name: "BAFTA Film Awards",
+    abbreviation: "BAFTA",
+    slug: "bafta",
+    country: "UK",
+    founded_year: 1949,
+    website: "https://www.bafta.org"
+  },
+  %{
+    name: "Screen Actors Guild Awards",
+    abbreviation: "SAG",
+    slug: "sag-awards",
+    country: "USA",
+    founded_year: 1995,
+    website: "https://www.sagawards.org"
+  },
+  %{
+    name: "Critics Choice Awards",
+    abbreviation: "CCA",
+    slug: "critics-choice",
+    country: "USA",
+    founded_year: 1996,
+    website: "https://www.criticschoice.com"
+  },
+  %{
+    name: "Toronto International Film Festival",
+    abbreviation: "TIFF",
+    slug: "tiff",
+    country: "Canada",
+    founded_year: 1976,
+    website: "https://www.tiff.net"
+  },
+  %{
+    name: "Telluride Film Festival",
+    abbreviation: "TFF",
+    slug: "telluride",
+    country: "USA",
+    founded_year: 1974,
+    website: "https://www.telluridefilmfestival.org"
+  },
+  %{
+    name: "New York Film Festival",
+    abbreviation: "NYFF",
+    slug: "nyff",
+    country: "USA",
+    founded_year: 1963,
+    website: "https://www.filmlinc.org/nyff"
+  },
+  %{
+    name: "Locarno Film Festival",
+    abbreviation: "LFF",
+    slug: "locarno",
+    country: "Switzerland",
+    founded_year: 1946,
+    website: "https://www.locarnofestival.ch"
+  }
+]
+
+Enum.each(festival_orgs, fn attrs ->
+  case Festivals.get_organization_by_slug(attrs.slug) do
+    nil ->
+      case Festivals.create_organization(attrs) do
+        {:ok, _org} ->
+          Logger.info("  ✅ Created organization: #{attrs.name}")
+
+        {:error, changeset} ->
+          Logger.warning(
+            "  ⚠️  Failed to create organization #{attrs.name}: #{inspect(changeset.errors)}"
+          )
+      end
+
+    _existing ->
+      Logger.info("  ⏭️  Organization already exists: #{attrs.name}")
+  end
+end)
+
 # Seed metric definitions and weight profiles for discovery system
 Logger.info("Seeding metric definitions...")
 


### PR DESCRIPTION
### TL;DR

Added dynamic festival lookup by abbreviation to replace hardcoded mappings and seeded additional festival organizations.

### What changed?

- Added a new `get_by_abbreviation/1` function in `Cinegraph.Events` to fetch festival events by their abbreviation
- Refactored `abbreviation_to_festival_key/1` in `AwardImportWorker` to dynamically query the database instead of using hardcoded mappings
- Added seed data for 8 new festival organizations including Golden Globes, BAFTA, SAG Awards, Critics Choice, TIFF, Telluride, NYFF, and Locarno Film Festival

### How to test?

1. Run the seeds to populate the new festival organizations: `mix run priv/repo/seeds.exs`
2. Verify that award imports correctly map festival abbreviations to their source keys
3. Check that the new organizations appear in the awards display page

### Why make this change?

This change improves maintainability by eliminating hardcoded festival mappings in favor of a dynamic database lookup. When new festivals are added to the system, they will automatically be supported by the award import process without requiring code changes. The additional festival organization seeds enhance the awards display page with more comprehensive festival information.