### PR TITLE
small fixes more

### DIFF
--- a/lib/cinegraph_web/plugs/etag_plug.ex
+++ b/lib/cinegraph_web/plugs/etag_plug.ex
@@ -213,7 +213,7 @@ defmodule CinegraphWeb.Plugs.ETagPlug do
 
   defp get_list_freshness(slug) do
     query =
-      from l in "canonical_lists",
+      from l in "movie_lists",
         where: l.slug == ^slug,
         select: {l.id, l.updated_at},
         limit: 1


### PR DESCRIPTION
### TL;DR

Updated the database table reference in the ETagPlug from "canonical_lists" to "movie_lists".

### What changed?

Modified the query in the `get_list_freshness/1` function within `CinegraphWeb.Plugs.ETagPlug` to reference the "movie_lists" table instead of "canonical_lists" when retrieving a list's ID and updated_at timestamp by slug.

### How to test?

1. Verify that ETag functionality works correctly for movie lists
2. Check that list freshness is properly determined when accessing movie lists by slug
3. Confirm no 500 errors occur when the system attempts to query list data

### Why make this change?

The table name was likely renamed from "canonical_lists" to "movie_lists" in a previous database change, but this reference wasn't updated. This fix ensures the ETag system correctly queries the proper table when determining if content has been modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal data retrieval mechanism for list caching optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->