### PR TITLE
lastly

### DIFF
--- a/lib/cinegraph/cultural.ex
+++ b/lib/cinegraph/cultural.ex
@@ -1045,6 +1045,15 @@ defmodule Cinegraph.Cultural do
       Events.list_active_events()
       |> Enum.map(& &1.source_key)
 
+    if festivals == [] do
+      Logger.warning("No active festival events found in database — nothing to import")
+      {:ok, %{year: year, festivals: [], jobs: 0}}
+    else
+      import_festivals_for_year(year, festivals, options)
+    end
+  end
+
+  defp import_festivals_for_year(year, festivals, options) do
     jobs =
       Enum.map(festivals, fn festival ->
         job_args = %{

--- a/lib/cinegraph/events.ex
+++ b/lib/cinegraph/events.ex
@@ -43,9 +43,11 @@ defmodule Cinegraph.Events do
 
   @doc """
   Gets a festival event by abbreviation.
+  Uses a query with limit 1 since abbreviation has no unique constraint.
   """
   def get_by_abbreviation(abbreviation) do
-    Repo.get_by(FestivalEvent, abbreviation: abbreviation)
+    from(e in FestivalEvent, where: e.abbreviation == ^abbreviation, limit: 1)
+    |> Repo.one()
   end
 
   @doc """

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -756,6 +756,7 @@ case Events.get_by_source_key("nyff") do
           "location" => "New York City, New York",
           "organization" => "Film at Lincoln Center",
           "specialization" => "curated selection, no competitive awards",
+          "category_mappings" => %{},
           "default_category" => "nyff_selection",
           "parser_hints" => %{
             "expected_format" => "key_value_awards",


### PR DESCRIPTION
### TL;DR

Improved festival import handling with better error handling for empty festival lists and fixed the festival key lookup process.

### What changed?

- Added early return with warning when no active festival events are found in the database
- Refactored `import_festivals_for_year` into a separate function for better organization
- Updated `get_by_abbreviation` in Events module to use a query with limit 1 since abbreviation has no unique constraint
- Simplified festival import process by removing redundant `import_festival` function and directly using `import_festival_by_key`
- Added `category_mappings` field to NYFF festival event seed data

### How to test?

1. Run the application with an empty festival database to verify the warning message appears
2. Test festival imports with various abbreviations to ensure they're properly mapped to festival keys
3. Verify that NYFF festival event is properly seeded with the category_mappings field

### Why make this change?

These changes improve error handling and logging during festival imports, particularly when no festivals are found. The code is also more robust by properly handling non-unique abbreviations in the database query. The refactoring simplifies the import process by removing an unnecessary intermediate function and directly using the festival key from the database.