### PR TITLE
small fix

### DIFF
--- a/lib/cinegraph/movies/collection.ex
+++ b/lib/cinegraph/movies/collection.ex
@@ -27,12 +27,16 @@ defmodule Cinegraph.Movies.Collection do
   def from_tmdb(attrs) do
     collection_attrs = %{
       tmdb_id: attrs["id"],
-      name: attrs["name"],
+      name: truncate(attrs["name"], 255),
       overview: attrs["overview"],
-      poster_path: attrs["poster_path"],
-      backdrop_path: attrs["backdrop_path"]
+      poster_path: truncate(attrs["poster_path"], 255),
+      backdrop_path: truncate(attrs["backdrop_path"], 255)
     }
 
     changeset(%__MODULE__{}, collection_attrs)
   end
+
+  defp truncate(nil, _max), do: nil
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+  defp truncate(str, _max), do: str
 end

--- a/lib/cinegraph/movies/credit.ex
+++ b/lib/cinegraph/movies/credit.ex
@@ -32,8 +32,20 @@ defmodule Cinegraph.Movies.Credit do
     ])
     |> validate_required([:movie_id, :person_id, :credit_type])
     |> validate_inclusion(:credit_type, ["cast", "crew"])
+    |> truncate_field(:character, 255)
+    |> truncate_field(:department, 255)
+    |> truncate_field(:job, 255)
     |> foreign_key_constraint(:movie_id)
     |> foreign_key_constraint(:person_id)
+  end
+
+  defp truncate_field(changeset, field, max_length) do
+    case get_change(changeset, field) do
+      nil -> changeset
+      value when is_binary(value) and byte_size(value) > max_length ->
+        put_change(changeset, field, String.slice(value, 0, max_length))
+      _ -> changeset
+    end
   end
 
   @doc """

--- a/lib/cinegraph/movies/movie.ex
+++ b/lib/cinegraph/movies/movie.ex
@@ -159,10 +159,12 @@ defmodule Cinegraph.Movies.Movie do
   Note: Volatile metrics (vote_average, popularity, budget, etc.) are now stored in external_metrics table
   """
   def from_tmdb(attrs) do
+    title = sanitize_title(attrs["title"], attrs["original_title"])
+
     movie_attrs = %{
       tmdb_id: attrs["id"],
       imdb_id: truncate_string(attrs["imdb_id"], 255),
-      title: truncate_string(attrs["title"], 255),
+      title: truncate_string(title, 255),
       original_title: truncate_string(attrs["original_title"], 255),
       release_date: parse_date(attrs["release_date"]),
       runtime: attrs["runtime"],
@@ -181,6 +183,17 @@ defmodule Cinegraph.Movies.Movie do
 
     movie_attrs
   end
+
+  # Falls back to original_title when title is blank/whitespace-only
+  defp sanitize_title(title, original_title) when is_binary(title) do
+    case String.trim(title) do
+      "" -> original_title
+      trimmed -> trimmed
+    end
+  end
+
+  defp sanitize_title(nil, original_title), do: original_title
+  defp sanitize_title(_title, original_title), do: original_title
 
   # Truncates a string to max_length, handling nil values
   defp truncate_string(nil, _max_length), do: nil

--- a/lib/cinegraph/movies/movie_release_date.ex
+++ b/lib/cinegraph/movies/movie_release_date.ex
@@ -34,16 +34,20 @@ defmodule Cinegraph.Movies.MovieReleaseDate do
     |> Enum.map(fn release ->
       release_attrs = %{
         movie_id: movie_id,
-        country_code: country_code,
+        country_code: truncate(country_code, 255),
         release_date: parse_datetime(release["release_date"]),
-        certification: release["certification"],
+        certification: truncate(release["certification"], 255),
         release_type: release["type"],
-        note: release["note"]
+        note: truncate(release["note"], 255)
       }
 
       changeset(%__MODULE__{}, release_attrs)
     end)
   end
+
+  defp truncate(nil, _max), do: nil
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+  defp truncate(str, _max), do: str
 
   defp parse_datetime(nil), do: nil
 

--- a/lib/cinegraph/movies/movie_video.ex
+++ b/lib/cinegraph/movies/movie_video.ex
@@ -42,11 +42,11 @@ defmodule Cinegraph.Movies.MovieVideo do
   def from_tmdb(attrs, movie_id) do
     video_attrs = %{
       movie_id: movie_id,
-      tmdb_id: attrs["id"],
-      name: attrs["name"],
-      key: attrs["key"],
-      site: attrs["site"],
-      type: attrs["type"],
+      tmdb_id: truncate(attrs["id"], 255),
+      name: truncate(attrs["name"], 255),
+      key: truncate(attrs["key"], 255),
+      site: truncate(attrs["site"], 255),
+      type: truncate(attrs["type"], 255),
       size: attrs["size"],
       official: attrs["official"],
       published_at: parse_datetime(attrs["published_at"])
@@ -54,6 +54,10 @@ defmodule Cinegraph.Movies.MovieVideo do
 
     changeset(%__MODULE__{}, video_attrs)
   end
+
+  defp truncate(nil, _max), do: nil
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+  defp truncate(str, _max), do: str
 
   defp parse_datetime(nil), do: nil
 

--- a/lib/cinegraph/movies/production_company.ex
+++ b/lib/cinegraph/movies/production_company.ex
@@ -33,11 +33,15 @@ defmodule Cinegraph.Movies.ProductionCompany do
   def from_tmdb(attrs) do
     company_attrs = %{
       tmdb_id: attrs["id"],
-      name: attrs["name"],
-      logo_path: attrs["logo_path"],
-      origin_country: attrs["origin_country"]
+      name: truncate(attrs["name"], 255),
+      logo_path: truncate(attrs["logo_path"], 255),
+      origin_country: truncate(attrs["origin_country"], 255)
     }
 
     changeset(%__MODULE__{}, company_attrs)
   end
+
+  defp truncate(nil, _max), do: nil
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+  defp truncate(str, _max), do: str
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1257,7 +1257,7 @@ festival_orgs = [
 ]
 
 Enum.each(festival_orgs, fn attrs ->
-  case Festivals.get_organization_by_slug(attrs.slug) do
+  case Cinegraph.Repo.get_by(Cinegraph.Festivals.FestivalOrganization, slug: attrs.slug) do
     nil ->
       case Festivals.create_organization(attrs) do
         {:ok, _org} ->


### PR DESCRIPTION
### TL;DR

Added string truncation to prevent database constraint violations when importing data from TMDB API and improved movie title handling for edge cases.

### What changed?

- Added `truncate/2` helper functions across movie-related modules (Collection, Credit, MovieReleaseDate, MovieVideo, ProductionCompany) to limit string fields to 255 characters
- Enhanced movie title sanitization in `Movie.from_tmdb/1` to fall back to `original_title` when `title` is blank or whitespace-only
- Applied truncation to fields like `name`, `poster_path`, `backdrop_path`, `character`, `department`, `job`, `certification`, `note`, `tmdb_id`, `key`, `site`, `type`, `logo_path`, and `origin_country`
- Fixed a database query in the seeds file to use `Repo.get_by/2` instead of `get_organization_by_slug/1`

### How to test?

- Import movies from TMDB API with unusually long field values to verify truncation works correctly
- Test movie imports where the title field is empty, null, or contains only whitespace to ensure fallback to original_title
- Run the seeds file to confirm the festival organization query executes without errors
- Verify that all movie-related data imports complete successfully without database constraint violations

### Why make this change?

This prevents database insertion failures when TMDB API returns string values that exceed the 255-character limit defined in the database schema. The movie title sanitization ensures that movies always have a meaningful title displayed, even when the primary title field is empty or invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic truncation of string fields (255 character limit) across movie data, including titles, credits, release dates, videos, and production company information.
  * Enhanced movie title handling to fall back to original title when the primary title is missing or blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->