### PR TITLE
fix filtering

### DIFF
--- a/lib/cinegraph/movies/movie_slug.ex
+++ b/lib/cinegraph/movies/movie_slug.ex
@@ -45,7 +45,10 @@ defmodule Cinegraph.Movies.MovieSlug do
   end
 
   defp create_base_slug(title, year) when is_binary(title) do
-    SlugUtils.create_slug_with_year(title, year)
+    year_str = if year, do: "#{year}", else: "unknown"
+    # Cap title slug at 200 chars so the full slug (with year + disambiguators) stays under 255
+    title_slug = title |> SlugUtils.slugify() |> String.slice(0, 200)
+    "#{title_slug}-#{year_str}"
   end
 
   defp resolve_conflict(base_slug, changeset) do


### PR DESCRIPTION
### TL;DR

Optimized movie filtering queries by replacing joins with subqueries and added title length limits for movie slugs.

### What changed?

- **Movie slug generation**: Added 200-character limit to title slugs and handle null years by using "unknown" as fallback
- **Country filtering**: Replaced inner join with subquery approach for better performance
- **Rating filtering**: Changed from join to fragment query using subquery to get latest rating
- **People filtering**: Refactored to use subqueries instead of joins, extracting logic into separate `build_people_subquery/2` function

### How to test?

- Test movie creation with very long titles to verify slug truncation
- Test movie creation with missing year data
- Verify country, rating, and people filters still return correct results in movie search
- Check query performance for large datasets with these filters applied

### Why make this change?

The subquery approach improves database performance by avoiding complex joins that can become expensive with large datasets. The slug length limitation prevents database constraint violations while maintaining readability. The null year handling makes the system more robust when dealing with incomplete movie data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated movie slug generation to include year information for improved identification.
  * Enhanced filtering performance for searches by country, rating, and cast/crew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->