### PR TITLE
credentials

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -40,6 +40,7 @@ env:
     - CRAWLBASE_JS_API_KEY
     - ADMIN_USERNAME
     - ADMIN_PASSWORD
+    - CINEGRAPH_API_KEY
 
 ssh:
   user: holden


### PR DESCRIPTION
### TL;DR

Added CINEGRAPH_API_KEY environment variable to deployment configuration

### What changed?

Added `CINEGRAPH_API_KEY` to the list of environment variables in the deployment configuration file.

### How to test?

1. Ensure the CINEGRAPH_API_KEY environment variable is set in your deployment environment
2. Deploy the application and verify the environment variable is properly loaded
3. Test any functionality that depends on the Cinegraph API integration

### Why make this change?

This change enables the application to access Cinegraph API services by ensuring the API key is available in the deployment environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include additional required authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->