### PR TITLE
fixes for graph

### DIFF
--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -18,6 +18,7 @@ defmodule CinegraphWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug CinegraphWeb.Plugs.ApiAuthPlug
   end
 
   pipeline :admin do
@@ -145,9 +146,7 @@ defmodule CinegraphWeb.Router do
   scope "/api" do
     pipe_through :api
 
-    forward "/graphql", Absinthe.Plug,
-      schema: CinegraphWeb.Schema,
-      context: &CinegraphWeb.Plugs.ApiAuthPlug.build_context/1
+    forward "/graphql", Absinthe.Plug, schema: CinegraphWeb.Schema
   end
 
   if Mix.env() == :dev do
@@ -156,8 +155,7 @@ defmodule CinegraphWeb.Router do
 
       forward "/graphiql", Absinthe.Plug.GraphiQL,
         schema: CinegraphWeb.Schema,
-        interface: :playground,
-        context: &CinegraphWeb.Plugs.ApiAuthPlug.build_context/1
+        interface: :playground
     end
   end
 


### PR DESCRIPTION
### TL;DR

Refactored `ApiAuthPlug` from a context builder function to a proper Plug that runs in the API pipeline.

### What changed?

- Converted `ApiAuthPlug.build_context/1` function to a proper Plug implementation with `init/1` and `call/2` callbacks
- Added the plug to the `:api` pipeline in the router so it runs before Absinthe.Plug
- Removed the `context:` parameter from both `/graphql` and `/graphiql` Absinthe.Plug forwards
- The plug now stores the auth token in the connection's private Absinthe context instead of returning a context map
- Updated module documentation to reflect the new usage pattern

### How to test?

- Send GraphQL requests to `/api/graphql` with `Authorization: Bearer <token>` headers
- Verify that the `auth_token` is still accessible in GraphQL resolvers through the Absinthe context
- Test both authenticated and unauthenticated requests to ensure proper token extraction

### Why make this change?

This refactoring follows standard Plug patterns and integrates better with Phoenix's pipeline architecture. Running authentication as a pipeline plug provides more flexibility and consistency compared to using Absinthe's context builder function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API authentication pipeline structure for Bearer token processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->