### PR TITLE
small removal

### DIFF
--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -642,11 +642,6 @@
                       </svg>
                     </div>
                   <% end %>
-                  <%= if cast_member.cast_order && cast_member.cast_order <= 3 do %>
-                    <span class="absolute top-2 left-2 bg-yellow-400 text-black text-xs font-bold px-2 py-1 rounded-full">
-                      #{cast_member.cast_order}
-                    </span>
-                  <% end %>
                 </div>
                 <div class="px-1">
                   <p class="font-medium text-sm text-gray-900 group-hover:text-blue-600 truncate">


### PR DESCRIPTION
### TL;DR

Removed cast order badges from movie cast member display

### What changed?

Removed the yellow badge that displayed cast order numbers (1-3) in the top-left corner of cast member profile images on the movie show page.

### How to test?

1. Navigate to any movie detail page
2. Scroll to the cast section
3. Verify that cast member images no longer show yellow numbered badges in the top-left corner

### Why make this change?

The cast order badges may have been cluttering the UI or providing unnecessary information that detracted from the overall user experience when viewing cast members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the cast order badge that previously appeared over the top 3 cast members' avatars in the movie cast display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->