### PR TITLE
constant improvement

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -113,7 +113,9 @@ config :cinegraph, Oban,
        {"0 2 * * *", Cinegraph.Workers.SitemapWorker},
        # Backfill queue regulation - runs every 15 minutes to check queue health
        # Queues more movies if pending jobs fall below threshold (stateless approach)
-       {"*/15 * * * *", Cinegraph.Workers.ScheduledBackfillWorker}
+       {"*/15 * * * *", Cinegraph.Workers.ScheduledBackfillWorker},
+       # Daily OMDb gap fill + stale refresh at 3 AM UTC
+       {"0 3 * * *", Cinegraph.Workers.RatingsRefreshWorker}
      ]}
     # PQS scheduling (temporarily disabled for basic functionality)
     # TODO: Fix cron job configuration format

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,6 +43,14 @@ config :cinegraph, Cinegraph.Services.TMDb.Client, api_key: tmdb_api_key
 # Configure OMDb (optional)
 config :cinegraph, Cinegraph.Services.OMDb.Client, api_key: omdb_api_key
 
+# Daily OMDb batch size for RatingsRefreshWorker (default 500)
+omdb_daily_batch_size =
+  if config_env() == :dev,
+    do: env!("OMDB_DAILY_BATCH_SIZE", :integer, 500),
+    else: String.to_integer(System.get_env("OMDB_DAILY_BATCH_SIZE") || "500")
+
+config :cinegraph, :omdb_daily_batch_size, omdb_daily_batch_size
+
 # Configure Crawlbase API (for Oscar and IMDb scraping)
 config :cinegraph, :crawlbase_api_key, crawlbase_api_key
 config :cinegraph, :crawlbase_js_api_key, crawlbase_js_api_key

--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -23,7 +23,9 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
     try do
       movie = Movies.get_movie!(movie_id)
 
-      if movie.omdb_data do
+      force = Map.get(args, "force", false)
+
+      if movie.omdb_data && !force do
         Logger.info("Movie #{movie_id} already has OMDb data, skipping")
         :ok
       else

--- a/lib/cinegraph/workers/ratings_refresh_worker.ex
+++ b/lib/cinegraph/workers/ratings_refresh_worker.ex
@@ -1,0 +1,105 @@
+defmodule Cinegraph.Workers.RatingsRefreshWorker do
+  @moduledoc """
+  Daily cron orchestrator for OMDb data enrichment.
+
+  Runs at 3 AM UTC and drains the OMDb null backlog in two phases:
+
+  ## Phase A – Gap Fill
+  Queries movies with `omdb_data IS NULL` ordered by TMDb popularity DESC
+  and queues them via `OMDbEnrichmentWorker`.
+
+  ## Phase B – Stale Refresh
+  If Phase A fills fewer than `batch_size` slots, tops up with the
+  stalest-fetched movies (by `external_metrics.fetched_at` for source='omdb'),
+  queuing with `"force" => true` to bypass the existing-data skip.
+
+  ## Configuration
+  - `OMDB_DAILY_BATCH_SIZE` env var (default 500)
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    unique: [
+      period: 23 * 3600,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  import Ecto.Query
+  alias Cinegraph.Repo
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Movies.ExternalMetric
+  alias Cinegraph.Workers.OMDbEnrichmentWorker
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    batch_size = Application.get_env(:cinegraph, :omdb_daily_batch_size, 500)
+    Logger.info("RatingsRefresh: Starting daily OMDb refresh (batch_size=#{batch_size})")
+
+    phase_a_count = run_phase_a(batch_size)
+    Logger.info("RatingsRefresh: Phase A queued #{phase_a_count} null-backlog movies")
+
+    remaining = batch_size - phase_a_count
+
+    if remaining > 0 do
+      phase_b_count = run_phase_b(remaining)
+      Logger.info("RatingsRefresh: Phase B queued #{phase_b_count} stale-refresh movies")
+    else
+      Logger.info("RatingsRefresh: Phase A filled batch, skipping Phase B")
+    end
+
+    :ok
+  end
+
+  # Phase A: queue movies where omdb_data IS NULL, by popularity DESC
+  defp run_phase_a(limit) do
+    movie_ids =
+      from(m in Movie,
+        where: is_nil(m.omdb_data),
+        order_by: [desc_nulls_last: m.popularity],
+        limit: ^limit,
+        select: m.id
+      )
+      |> Repo.all()
+
+    queue_enrichment_jobs(movie_ids, %{})
+  end
+
+  # Phase B: queue movies with omdb_data, stalest external_metrics.fetched_at first
+  defp run_phase_b(limit) do
+    stalest_subquery =
+      from(em in ExternalMetric,
+        where: em.source == "omdb",
+        group_by: em.movie_id,
+        select: %{movie_id: em.movie_id, last_fetched: max(em.fetched_at)}
+      )
+
+    movie_ids =
+      from(m in Movie,
+        where: not is_nil(m.omdb_data),
+        left_join: s in subquery(stalest_subquery),
+        on: s.movie_id == m.id,
+        order_by: [asc_nulls_first: s.last_fetched],
+        limit: ^limit,
+        select: m.id
+      )
+      |> Repo.all()
+
+    queue_enrichment_jobs(movie_ids, %{"force" => true})
+  end
+
+  defp queue_enrichment_jobs([], _extra_args), do: 0
+
+  defp queue_enrichment_jobs(movie_ids, extra_args) do
+    jobs =
+      Enum.map(movie_ids, fn id ->
+        OMDbEnrichmentWorker.new(Map.merge(%{"movie_id" => id}, extra_args))
+      end)
+
+    case Oban.insert_all(jobs) do
+      inserted when is_list(inserted) -> length(inserted)
+      _ -> 0
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Added a new daily cron job to refresh OMDb ratings data for movies, running at 3 AM UTC with configurable batch processing.

### What changed?

- Created `RatingsRefreshWorker` that runs daily to maintain OMDb data freshness through a two-phase approach:
  - **Phase A**: Fills gaps by queuing movies without OMDb data (ordered by popularity)
  - **Phase B**: Refreshes stale data by re-queuing movies with the oldest OMDb fetch timestamps
- Added `OMDB_DAILY_BATCH_SIZE` environment variable (defaults to 500) to control daily processing volume
- Enhanced `OMDbEnrichmentWorker` with a `force` parameter to bypass existing data checks during refresh operations
- Scheduled the worker to run daily at 3 AM UTC via Oban cron configuration

### How to test?

1. Set `OMDB_DAILY_BATCH_SIZE` environment variable to desired batch size (optional, defaults to 500)
2. Manually trigger the worker: `Oban.insert(Cinegraph.Workers.RatingsRefreshWorker.new(%{}))`
3. Verify Phase A queues movies with null `omdb_data` by popularity
4. Verify Phase B queues movies with stale OMDb data when batch isn't filled by Phase A
5. Check that `OMDbEnrichmentWorker` respects the `force` parameter for data refresh

### Why make this change?

This ensures OMDb ratings data stays current and complete by automatically filling data gaps for new movies and refreshing stale ratings for existing movies. The two-phase approach prioritizes popular movies without data while maintaining freshness of existing data within daily API quota limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated daily OMDb data enrichment scheduled for 3 AM UTC using a two-phase approach: fills missing movie data first, then refreshes stale metadata.
  * Enhanced OMDb enrichment with ability to force re-processing of existing movie data when needed.

* **Configuration**
  * Added configurable batch size for daily OMDb processing (default: 500 movies).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->