### PR TITLE
final

### DIFF
--- a/lib/cinegraph/workers/ratings_refresh_worker.ex
+++ b/lib/cinegraph/workers/ratings_refresh_worker.ex
@@ -127,8 +127,16 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
       job = OMDbEnrichmentWorker.new(Map.merge(%{"movie_id" => id}, extra_args))
 
       case Oban.insert(job) do
-        {:ok, _} -> count + 1
-        {:error, _} -> count
+        {:ok, _} ->
+          count + 1
+
+        {:error, reason} ->
+          Logger.error(
+            "RatingsRefresh: failed to insert OMDb job for movie_id=#{id} " <>
+              "extra_args=#{inspect(extra_args)} error=#{inspect(reason)}"
+          )
+
+          count
       end
     end)
   end

--- a/test/cinegraph/workers/ratings_refresh_worker_test.exs
+++ b/test/cinegraph/workers/ratings_refresh_worker_test.exs
@@ -7,6 +7,12 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
   alias Cinegraph.Workers.RatingsRefreshWorker
   alias Cinegraph.Workers.OMDbEnrichmentWorker
 
+  # Sets the daily batch size for the duration of the test and restores it on exit.
+  defp with_batch_size(size) do
+    Application.put_env(:cinegraph, :omdb_daily_batch_size, size)
+    on_exit(fn -> Application.delete_env(:cinegraph, :omdb_daily_batch_size) end)
+  end
+
   # Insert a minimal movie fixture with sensible defaults
   defp insert_movie(attrs) do
     defaults = %{
@@ -28,7 +34,6 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
     test "queues movies where omdb_data is nil" do
       movie = insert_movie(%{omdb_data: nil})
 
-      RatingsRefreshWorker.new(%{}) |> Oban.insert()
       perform_job(RatingsRefreshWorker, %{})
 
       assert_enqueued(worker: OMDbEnrichmentWorker, args: %{"movie_id" => movie.id})
@@ -36,7 +41,7 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
 
     test "movies with omdb_data are only queued via Phase B (with force: true, never without)" do
       # No null movies → Phase A queues nothing, Phase B picks up the enriched movie
-      Application.put_env(:cinegraph, :omdb_daily_batch_size, 1)
+      with_batch_size(1)
       movie = insert_movie(%{omdb_data: %{"Title" => "Already Enriched"}})
 
       perform_job(RatingsRefreshWorker, %{})
@@ -46,8 +51,6 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
         worker: OMDbEnrichmentWorker,
         args: %{"movie_id" => movie.id, "force" => true}
       )
-    after
-      Application.delete_env(:cinegraph, :omdb_daily_batch_size)
     end
 
     test "skips movies without an imdb_id" do
@@ -81,7 +84,7 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
   describe "Phase B – stale refresh" do
     test "queues stale movies with force: true when Phase A is under batch size" do
       # One null movie (Phase A) and one already-enriched movie (Phase B candidate)
-      Application.put_env(:cinegraph, :omdb_daily_batch_size, 2)
+      with_batch_size(2)
 
       _null_movie = insert_movie(%{omdb_data: nil})
       stale_movie = insert_movie(%{omdb_data: %{"Title" => "Stale"}})
@@ -92,12 +95,10 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
         worker: OMDbEnrichmentWorker,
         args: %{"movie_id" => stale_movie.id, "force" => true}
       )
-    after
-      Application.delete_env(:cinegraph, :omdb_daily_batch_size)
     end
 
     test "Phase B does not run when Phase A fills the entire batch" do
-      Application.put_env(:cinegraph, :omdb_daily_batch_size, 1)
+      with_batch_size(1)
 
       _null_movie = insert_movie(%{omdb_data: nil})
       stale_movie = insert_movie(%{omdb_data: %{"Title" => "Stale"}})
@@ -108,12 +109,10 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
         worker: OMDbEnrichmentWorker,
         args: %{"movie_id" => stale_movie.id, "force" => true}
       )
-    after
-      Application.delete_env(:cinegraph, :omdb_daily_batch_size)
     end
 
     test "Phase B skips enriched movies without an imdb_id" do
-      Application.put_env(:cinegraph, :omdb_daily_batch_size, 2)
+      with_batch_size(2)
 
       _null_movie = insert_movie(%{omdb_data: nil})
       no_imdb = insert_movie(%{omdb_data: %{"Title" => "No IMDb"}, imdb_id: nil})
@@ -121,8 +120,6 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
       perform_job(RatingsRefreshWorker, %{})
 
       refute_enqueued(worker: OMDbEnrichmentWorker, args: %{"movie_id" => no_imdb.id})
-    after
-      Application.delete_env(:cinegraph, :omdb_daily_batch_size)
     end
   end
 end


### PR DESCRIPTION
### TL;DR

Added error logging for failed OMDb job insertions and improved test helper for batch size configuration.

### What changed?

- Enhanced error handling in `RatingsRefreshWorker` to log detailed error messages when OMDb enrichment jobs fail to insert, including movie ID, extra arguments, and error reason
- Added `with_batch_size/1` test helper function that sets the daily batch size for test duration and automatically cleans up on exit
- Replaced manual application environment setup/teardown in tests with the new helper function
- Removed redundant `Oban.insert()` call in one test case

### How to test?

Run the existing test suite to verify the new test helper works correctly:
```bash
mix test test/cinegraph/workers/ratings_refresh_worker_test.exs
```

To test error logging, you could temporarily introduce a condition that causes job insertion to fail and verify the error message appears in logs.

### Why make this change?

The error logging improvement provides better observability when OMDb job insertions fail, making it easier to debug issues in production. The test helper reduces code duplication and ensures proper cleanup of application environment changes, making tests more maintainable and preventing potential test pollution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for OMDb enrichment job failures to provide clearer diagnostic information when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->