### PR TITLE
new refresh

### DIFF
--- a/lib/cinegraph/movies/external_metric.ex
+++ b/lib/cinegraph/movies/external_metric.ex
@@ -80,7 +80,10 @@ defmodule Cinegraph.Movies.ExternalMetric do
       "oscar_wins",
       "oscar_nominations",
       "total_awards",
-      "total_nominations"
+      "total_nominations",
+
+      # Availability
+      "fetch_attempt"
     ]
   end
 

--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -13,6 +13,7 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
     unique: [fields: [:args], keys: [:movie_id], period: 3600]
 
   alias Cinegraph.Movies
+  alias Cinegraph.Metrics
   alias Cinegraph.ApiProcessors.OMDb
   require Logger
 
@@ -51,9 +52,29 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
         # Retry in 1 hour
         {:snooze, 3600}
 
+      {:error, reason} when reason in ["Error getting data.", "Incorrect IMDb ID."] ->
+        Logger.info("OMDb unavailable for movie #{movie.id} (#{reason}), recording fetch attempt")
+        record_fetch_attempt(movie.id, reason)
+        :ok
+
+      {:error, %Jason.DecodeError{}} ->
+        Logger.warning("OMDb returned malformed JSON for movie #{movie.id}, recording fetch attempt")
+        record_fetch_attempt(movie.id, "malformed_response")
+        :ok
+
       {:error, reason} ->
         Logger.error("Failed to enrich movie #{movie.id} with OMDb: #{inspect(reason)}")
         {:error, reason}
     end
+  end
+
+  defp record_fetch_attempt(movie_id, reason) do
+    Metrics.upsert_metric(%{
+      movie_id: movie_id,
+      source: "omdb",
+      metric_type: "fetch_attempt",
+      text_value: reason,
+      fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
   end
 end

--- a/lib/cinegraph/workers/ratings_refresh_worker.ex
+++ b/lib/cinegraph/workers/ratings_refresh_worker.ex
@@ -80,12 +80,23 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
     |> Repo.one()
   end
 
-  # Phase A: queue movies where omdb_data IS NULL, by tmdb popularity DESC
+  # Phase A: queue movies where omdb_data IS NULL, by tmdb popularity DESC,
+  # excluding movies with a recent fetch_attempt record (90-day cooldown).
   defp fetch_null_backlog(limit) do
+    cutoff = DateTime.add(DateTime.utc_now(), -90 * 24 * 3600, :second)
+
+    recently_checked =
+      from(em in ExternalMetric,
+        where: em.source == "omdb" and em.metric_type == "fetch_attempt",
+        where: em.fetched_at > ^cutoff,
+        select: em.movie_id
+      )
+
     from(m in Movie,
       where: m.import_status == "full",
       where: is_nil(m.omdb_data),
       where: not is_nil(m.imdb_id),
+      where: m.id not in subquery(recently_checked),
       order_by: fragment("(tmdb_data->>'popularity')::float DESC NULLS LAST"),
       limit: ^limit,
       select: m.id

--- a/test/cinegraph/workers/ratings_refresh_worker_test.exs
+++ b/test/cinegraph/workers/ratings_refresh_worker_test.exs
@@ -4,6 +4,7 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
 
   alias Cinegraph.Repo
   alias Cinegraph.Movies.Movie
+  alias Cinegraph.Movies.ExternalMetric
   alias Cinegraph.Workers.RatingsRefreshWorker
   alias Cinegraph.Workers.OMDbEnrichmentWorker
 
@@ -78,6 +79,42 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
       jobs = all_enqueued(worker: OMDbEnrichmentWorker)
       assert length(jobs) > 0
       Enum.each(jobs, fn job -> refute Map.has_key?(job.args, "force") end)
+    end
+  end
+
+  defp insert_fetch_attempt(movie_id, fetched_at) do
+    {:ok, metric} =
+      %ExternalMetric{}
+      |> ExternalMetric.changeset(%{
+        movie_id: movie_id,
+        source: "omdb",
+        metric_type: "fetch_attempt",
+        text_value: "Error getting data.",
+        fetched_at: fetched_at
+      })
+      |> Repo.insert()
+
+    metric
+  end
+
+  describe "Phase A – fetch_attempt cooldown" do
+    test "excludes movies with a recent fetch_attempt record" do
+      movie = insert_movie(%{omdb_data: nil})
+      insert_fetch_attempt(movie.id, DateTime.utc_now() |> DateTime.truncate(:second))
+
+      perform_job(RatingsRefreshWorker, %{})
+
+      refute_enqueued(worker: OMDbEnrichmentWorker, args: %{"movie_id" => movie.id})
+    end
+
+    test "re-includes movies whose fetch_attempt is older than 90 days" do
+      movie = insert_movie(%{omdb_data: nil})
+      old_fetched_at = DateTime.add(DateTime.utc_now(), -91 * 24 * 3600, :second) |> DateTime.truncate(:second)
+      insert_fetch_attempt(movie.id, old_fetched_at)
+
+      perform_job(RatingsRefreshWorker, %{})
+
+      assert_enqueued(worker: OMDbEnrichmentWorker, args: %{"movie_id" => movie.id})
     end
   end
 


### PR DESCRIPTION
### TL;DR

Added a 90-day cooldown mechanism to prevent repeated OMDb API calls for movies that previously failed to fetch data.

### What changed?

- Added `fetch_attempt` as a new external metric type to track failed OMDb API requests
- Modified the OMDb enrichment worker to record fetch attempts when encountering specific errors ("Error getting data.", "Incorrect IMDb ID.", or malformed JSON responses)
- Updated the ratings refresh worker to exclude movies with recent fetch attempts (within 90 days) from Phase A processing
- Added test coverage for the fetch attempt cooldown functionality

### How to test?

1. Trigger an OMDb enrichment job for a movie with an invalid IMDb ID
2. Verify that a `fetch_attempt` metric is recorded in the database
3. Run the ratings refresh worker and confirm the movie is excluded from Phase A processing
4. Test that movies with fetch attempts older than 90 days are re-included for processing

### Why make this change?

This prevents unnecessary API calls to OMDb for movies that are known to be unavailable or have invalid data, reducing API usage and improving system efficiency while still allowing periodic retries after a reasonable cooldown period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movie data fetching now tracks and records failed fetch attempts for external sources.
  * System implements a 90-day cooldown period for previously failed retrieval attempts, preventing repeated retries on the same content.

* **Tests**
  * Added tests for fetch attempt cooldown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->