### PR TITLE
fixes for grap

### DIFF
--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -69,12 +69,23 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
   end
 
   defp record_fetch_attempt(movie_id, reason) do
-    Metrics.upsert_metric(%{
-      movie_id: movie_id,
-      source: "omdb",
-      metric_type: "fetch_attempt",
-      text_value: reason,
-      fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
-    })
+    case Metrics.upsert_metric(%{
+           movie_id: movie_id,
+           source: "omdb",
+           metric_type: "fetch_attempt",
+           text_value: reason,
+           fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
+         }) do
+      {:ok, _} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.error(
+          "Failed to record fetch_attempt for movie #{movie_id} " <>
+            "(reason=#{reason}): #{inspect(changeset.errors)}"
+        )
+
+        :ok
+    end
   end
 end

--- a/lib/cinegraph/workers/ratings_refresh_worker.ex
+++ b/lib/cinegraph/workers/ratings_refresh_worker.ex
@@ -70,11 +70,23 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
     :ok
   end
 
+  # Subquery for movies with a fetch_attempt record within the 90-day cooldown window.
+  defp recently_checked_subquery do
+    cutoff = DateTime.add(DateTime.utc_now(), -90 * 24 * 3600, :second)
+
+    from(em in ExternalMetric,
+      where: em.source == "omdb" and em.metric_type == "fetch_attempt",
+      where: em.fetched_at > ^cutoff,
+      select: em.movie_id
+    )
+  end
+
   defp count_null_backlog do
     from(m in Movie,
       where: m.import_status == "full",
       where: is_nil(m.omdb_data),
       where: not is_nil(m.imdb_id),
+      where: m.id not in subquery(recently_checked_subquery()),
       select: count(m.id)
     )
     |> Repo.one()
@@ -83,20 +95,11 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
   # Phase A: queue movies where omdb_data IS NULL, by tmdb popularity DESC,
   # excluding movies with a recent fetch_attempt record (90-day cooldown).
   defp fetch_null_backlog(limit) do
-    cutoff = DateTime.add(DateTime.utc_now(), -90 * 24 * 3600, :second)
-
-    recently_checked =
-      from(em in ExternalMetric,
-        where: em.source == "omdb" and em.metric_type == "fetch_attempt",
-        where: em.fetched_at > ^cutoff,
-        select: em.movie_id
-      )
-
     from(m in Movie,
       where: m.import_status == "full",
       where: is_nil(m.omdb_data),
       where: not is_nil(m.imdb_id),
-      where: m.id not in subquery(recently_checked),
+      where: m.id not in subquery(recently_checked_subquery()),
       order_by: fragment("(tmdb_data->>'popularity')::float DESC NULLS LAST"),
       limit: ^limit,
       select: m.id


### PR DESCRIPTION
### TL;DR

Added error handling for metric recording failures and implemented a 90-day cooldown period to prevent redundant OMDb API calls for movies that have already been checked recently.

### What changed?

- Added error handling in `record_fetch_attempt/2` to log failures when upserting metrics instead of silently ignoring them
- Introduced a 90-day cooldown mechanism by filtering out movies that have recent `fetch_attempt` records from both the backlog count and fetch queries
- Extracted the recently checked movies logic into a reusable `recently_checked_subquery/0` function

### How to test?

- Verify that failed metric upserts are properly logged by triggering a database constraint violation
- Confirm that movies with recent OMDb fetch attempts (within 90 days) are excluded from the ratings refresh queue
- Check that the backlog count accurately reflects only movies eligible for fetching

### Why make this change?

This prevents unnecessary API calls to OMDb for movies that were recently checked but returned no data, reducing API usage and improving worker efficiency. The error handling ensures that metric recording failures are visible for debugging rather than failing silently.