### PR TITLE
last greps

### DIFF
--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -82,7 +82,7 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
       {:error, changeset} ->
         Logger.error(
           "Failed to record fetch_attempt for movie #{movie_id} " <>
-            "(reason=#{reason}): #{inspect(changeset.errors)}"
+            "(reason=#{reason}): #{inspect(changeset)}"
         )
 
         :ok


### PR DESCRIPTION
### TL;DR

Enhanced error logging in OMDb enrichment worker to include full changeset details instead of just errors.

### What changed?

Modified the error logging statement in the OMDb enrichment worker to log the complete changeset object rather than only the `changeset.errors` field when recording a fetch attempt fails.

### How to test?

Trigger a scenario where the OMDb enrichment worker fails to record a fetch attempt and verify that the error logs now contain the full changeset information including validation details, changes, and metadata.

### Why make this change?

Logging the full changeset provides more comprehensive debugging information beyond just the error messages, including the attempted changes, validation state, and other metadata that can be crucial for troubleshooting failed database operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging to provide more comprehensive diagnostic information during data retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->