### PR TITLE
omdb updates

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -77,7 +77,8 @@ config :cinegraph, Oban,
     # All TMDb API work (orchestration, discovery, details) - single rate limit
     tmdb: 15,
     # OMDb data enrichment (separate API rate limit)
-    omdb: 5,
+    # Temporarily 20 for backfill burst — revert to 5 after backlog cleared
+    omdb: 20,
     # Collaboration processing
     collaboration: 5,
     # Web scraping (IMDb, festivals, Oscars) - low concurrency for rate limiting

--- a/lib/cinegraph/api_processors/omdb.ex
+++ b/lib/cinegraph/api_processors/omdb.ex
@@ -108,7 +108,7 @@ defmodule Cinegraph.ApiProcessors.OMDb do
   end
 
   defp fetch_and_store_omdb_data(movie) do
-    case OMDb.Client.get_movie_by_imdb_id(movie.imdb_id, tomatoes: true) do
+    case OMDb.Client.get_movie_by_imdb_id(movie.imdb_id) do
       {:ok, omdb_data} ->
         store_omdb_data(omdb_data, movie)
 

--- a/lib/cinegraph/movies/external_metric.ex
+++ b/lib/cinegraph/movies/external_metric.ex
@@ -83,7 +83,11 @@ defmodule Cinegraph.Movies.ExternalMetric do
       "total_nominations",
 
       # Availability
-      "fetch_attempt"
+      "fetch_attempt",
+
+      # Metadata
+      "content_rating",
+      "page_url"
     ]
   end
 
@@ -298,34 +302,72 @@ defmodule Cinegraph.Movies.ExternalMetric do
       end
 
     # Rotten Tomatoes from Ratings array
-    if omdb_data["Ratings"] && is_list(omdb_data["Ratings"]) do
-      Enum.reduce(omdb_data["Ratings"], metrics, fn rating, acc ->
-        case rating["Source"] do
-          "Rotten Tomatoes" ->
-            value =
-              rating["Value"]
-              |> String.replace("%", "")
-              |> String.to_integer()
+    metrics =
+      if omdb_data["Ratings"] && is_list(omdb_data["Ratings"]) do
+        Enum.reduce(omdb_data["Ratings"], metrics, fn rating, acc ->
+          case rating["Source"] do
+            "Rotten Tomatoes" ->
+              value =
+                rating["Value"]
+                |> String.replace("%", "")
+                |> String.to_integer()
 
-            [
-              %{
-                movie_id: movie_id,
-                source: "rotten_tomatoes",
-                metric_type: "tomatometer",
-                value: value,
-                metadata: %{"scale" => "0-100", "type" => "critics"},
-                fetched_at: now
-              }
-              | acc
-            ]
+              [
+                %{
+                  movie_id: movie_id,
+                  source: "rotten_tomatoes",
+                  metric_type: "tomatometer",
+                  value: value,
+                  metadata: %{"scale" => "0-100", "type" => "critics"},
+                  fetched_at: now
+                }
+                | acc
+              ]
 
-          _ ->
-            acc
-        end
-      end)
-    else
-      metrics
-    end
+            _ ->
+              acc
+          end
+        end)
+      else
+        metrics
+      end
+
+    # Content Rating (MPAA)
+    metrics =
+      if omdb_data["Rated"] &&
+           omdb_data["Rated"] not in ["N/A", "NOT RATED", "UNRATED", "NR"] do
+        [
+          %{
+            movie_id: movie_id,
+            source: "omdb",
+            metric_type: "content_rating",
+            text_value: omdb_data["Rated"],
+            fetched_at: now
+          }
+          | metrics
+        ]
+      else
+        metrics
+      end
+
+    # Rotten Tomatoes page URL (tomatoURL field — populated by OMDb Basic plan)
+    metrics =
+      if omdb_data["tomatoURL"] && omdb_data["tomatoURL"] not in [nil, "N/A"] do
+        [
+          %{
+            movie_id: movie_id,
+            source: "rotten_tomatoes",
+            metric_type: "page_url",
+            text_value: omdb_data["tomatoURL"],
+            fetched_at: now
+          }
+          | metrics
+        ]
+      else
+        metrics
+      end
+
+    metrics
   end
 
   defp parse_awards_text(text) do

--- a/lib/cinegraph/services/omdb/client.ex
+++ b/lib/cinegraph/services/omdb/client.ex
@@ -73,17 +73,13 @@ defmodule Cinegraph.Services.OMDb.Client do
     end
   end
 
-  defp base_params(opts) do
+  defp base_params(_opts) do
     %{
       "apikey" => api_key(),
       "plot" => "short",
       "r" => "json"
     }
-    |> maybe_add_tomatoes(opts[:tomatoes])
   end
-
-  defp maybe_add_tomatoes(params, true), do: Map.put(params, "tomatoes", "true")
-  defp maybe_add_tomatoes(params, _), do: params
 
   defp make_request(params) do
     url = build_url(params)

--- a/lib/cinegraph/workers/prediction_calculator.ex
+++ b/lib/cinegraph/workers/prediction_calculator.ex
@@ -57,61 +57,11 @@ defmodule Cinegraph.Workers.PredictionCalculator do
 
     Logger.info("Successfully cached #{map_size(movie_scores)} predictions for decade #{decade}")
 
-    # Also calculate and cache validation data to avoid expensive queries
-    # But only for 2020s decade to avoid making this job too heavy
-    if decade == 2020 do
-      Logger.info("Calculating validation data for profile #{profile_id}...")
-
-      validation_result =
-        try do
-          Cinegraph.Predictions.HistoricalValidator.validate_all_decades(profile)
-        rescue
-          error ->
-            Logger.error("Failed to calculate validation: #{inspect(error)}")
-            nil
-        end
-
-      if validation_result do
-        # Cache validation in Cachex for fast access
-        validation_cache_key = "validation:#{profile.name}:#{profile_hash(profile)}"
-
-        Cachex.put(:predictions_cache, validation_cache_key, validation_result,
-          ttl: :timer.hours(24)
-        )
-
-        Logger.info("Cached validation data for profile #{profile.name}")
-
-        # Also store validation in database cache metadata for persistence
-        cache = PredictionCache.get_cached_predictions(decade, profile_id)
-
-        if cache do
-          updated_metadata =
-            Map.put(cache.metadata || %{}, "validation_result", validation_result)
-
-          PredictionCache.upsert_cache(%{
-            decade: decade,
-            profile_id: profile_id,
-            movie_scores: cache.movie_scores,
-            statistics: cache.statistics,
-            calculated_at: cache.calculated_at,
-            metadata: updated_metadata
-          })
-        end
-      end
-    end
-
     :ok
   end
 
-  defp profile_hash(profile) do
-    profile.category_weights
-    |> :erlang.term_to_binary()
-    |> then(&:crypto.hash(:md5, &1))
-    |> Base.encode16(case: :lower)
-  end
-
   @impl Oban.Worker
-  def timeout(_job), do: :timer.seconds(60)
+  def timeout(_job), do: :timer.minutes(5)
 
   # Private helpers
 

--- a/lib/cinegraph/workers/ratings_refresh_worker.ex
+++ b/lib/cinegraph/workers/ratings_refresh_worker.ex
@@ -45,7 +45,16 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
         "null_backlog=#{null_count})"
     )
 
-    phase_a_ids = fetch_null_backlog(batch_size)
+    # Phase A0: 1001-list priority — fill first from movies on the canonical 1001 list
+    phase_a0_ids = fetch_1001_priority(batch_size)
+    phase_a0_count = queue_enrichment_jobs(phase_a0_ids, %{})
+
+    Logger.info("RatingsRefresh: Phase A0 queued #{phase_a0_count} 1001-list priority movies")
+
+    remaining_after_a0 = batch_size - phase_a0_count
+
+    # Phase A: fill remaining budget with null-backlog movies by popularity
+    phase_a_ids = fetch_null_backlog(remaining_after_a0, phase_a0_ids)
     phase_a_count = queue_enrichment_jobs(phase_a_ids, %{})
 
     Logger.info(
@@ -53,7 +62,7 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
         "(count includes Oban-deduplicated jobs from prior runs)"
     )
 
-    remaining = batch_size - phase_a_count
+    remaining = remaining_after_a0 - phase_a_count
 
     if remaining > 0 do
       phase_b_ids = fetch_stale_refresh(remaining)
@@ -64,7 +73,7 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
           "(count includes Oban-deduplicated jobs from prior runs)"
       )
     else
-      Logger.info("RatingsRefresh: Phase A filled batch, skipping Phase B")
+      Logger.info("RatingsRefresh: Phase A0+A filled batch, skipping Phase B")
     end
 
     :ok
@@ -92,13 +101,32 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
     |> Repo.one()
   end
 
-  # Phase A: queue movies where omdb_data IS NULL, by tmdb popularity DESC,
-  # excluding movies with a recent fetch_attempt record (90-day cooldown).
-  defp fetch_null_backlog(limit) do
+  # Phase A0: 1001-list priority — queue movies on the canonical 1001 list first.
+  defp fetch_1001_priority(limit) do
     from(m in Movie,
       where: m.import_status == "full",
       where: is_nil(m.omdb_data),
       where: not is_nil(m.imdb_id),
+      where: fragment("? \\? '1001_movies'", m.canonical_sources),
+      where: m.id not in subquery(recently_checked_subquery()),
+      order_by: fragment("(tmdb_data->>'popularity')::float DESC NULLS LAST"),
+      limit: ^limit,
+      select: m.id
+    )
+    |> Repo.all()
+  end
+
+  # Phase A: queue movies where omdb_data IS NULL, by tmdb popularity DESC,
+  # excluding movies with a recent fetch_attempt record (90-day cooldown)
+  # and any IDs already queued by Phase A0.
+  defp fetch_null_backlog(0, _exclude_ids), do: []
+
+  defp fetch_null_backlog(limit, exclude_ids) do
+    from(m in Movie,
+      where: m.import_status == "full",
+      where: is_nil(m.omdb_data),
+      where: not is_nil(m.imdb_id),
+      where: m.id not in ^exclude_ids,
       where: m.id not in subquery(recently_checked_subquery()),
       order_by: fragment("(tmdb_data->>'popularity')::float DESC NULLS LAST"),
       limit: ^limit,

--- a/priv/scripts/omdb_api_explorer.exs
+++ b/priv/scripts/omdb_api_explorer.exs
@@ -1,0 +1,229 @@
+#!/usr/bin/env elixir
+# OMDb API Explorer — confirms current API response structure
+#
+# Usage: mix run priv/scripts/omdb_api_explorer.exs
+#
+# Makes 3 calls for tt0111161 (The Shawshank Redemption) and compares:
+#   Call A — standard (no extras)
+#   Call B — with tomatoes: true (deprecated check)
+#   Call C — with plot=full
+#
+# Also queries stored DB data for tomatoURL coverage.
+
+alias Cinegraph.Services.OMDb.Client
+alias Cinegraph.Repo
+alias Cinegraph.Movies.Movie
+import Ecto.Query
+
+@test_imdb_id "tt0111161"
+
+defmodule OMDbExplorer do
+  # Fields currently extracted by from_omdb/2
+  @extracted_fields ~w(
+    imdbRating imdbVotes Metascore BoxOffice Awards Ratings tomatoURL
+    Rated
+  )
+
+  def separator(label) do
+    IO.puts("\n" <> String.duplicate("=", 60))
+    IO.puts("  #{label}")
+    IO.puts(String.duplicate("=", 60))
+  end
+
+  def print_fields(data, label) do
+    IO.puts("\n--- #{label} ---")
+
+    data
+    |> Enum.sort_by(fn {k, _} -> k end)
+    |> Enum.each(fn {key, value} ->
+      extracted = if key in @extracted_fields, do: " [EXTRACTED]", else: " [ignored]"
+      value_str = inspect(value, limit: 80, printable_limit: 80)
+      IO.puts("  #{String.pad_trailing(key, 22)} #{value_str}#{extracted}")
+    end)
+  end
+
+  def diff_calls(a, b, label_a, label_b) do
+    IO.puts("\n--- Differences: #{label_a} vs #{label_b} ---")
+
+    keys = MapSet.union(MapSet.new(Map.keys(a)), MapSet.new(Map.keys(b)))
+
+    diffs =
+      Enum.filter(keys, fn k ->
+        Map.get(a, k) != Map.get(b, k)
+      end)
+
+    if diffs == [] do
+      IO.puts("  (no differences)")
+    else
+      Enum.each(diffs, fn k ->
+        IO.puts("  #{k}:")
+        IO.puts("    #{label_a}: #{inspect(Map.get(a, k))}")
+        IO.puts("    #{label_b}: #{inspect(Map.get(b, k))}")
+      end)
+    end
+  end
+
+  def tomato_field_analysis(data) do
+    IO.puts("\n--- tomatoXxx field analysis ---")
+
+    tomato_keys = Map.keys(data) |> Enum.filter(&String.starts_with?(&1, "tomato"))
+
+    if tomato_keys == [] do
+      IO.puts("  No tomatoXxx fields returned.")
+    else
+      Enum.each(tomato_keys, fn k ->
+        v = data[k]
+        status = if v in [nil, "N/A"], do: "N/A (dead)", else: "POPULATED: #{inspect(v)}"
+        IO.puts("  #{String.pad_trailing(k, 24)} #{status}")
+      end)
+    end
+  end
+end
+
+# ---- Live API Calls ----
+
+OMDbExplorer.separator("Call A — Standard (no tomatoes param)")
+
+call_a =
+  case Client.get_movie_by_imdb_id(@test_imdb_id) do
+    {:ok, data} ->
+      IO.puts("SUCCESS — #{map_size(data)} fields returned")
+      OMDbExplorer.print_fields(data, "All fields")
+      OMDbExplorer.tomato_field_analysis(data)
+      data
+
+    {:error, reason} ->
+      IO.puts("ERROR: #{inspect(reason)}")
+      %{}
+  end
+
+OMDbExplorer.separator("Call B — With tomatoes: true")
+
+call_b =
+  case HTTPoison.get(
+         "https://www.omdbapi.com/?i=#{@test_imdb_id}&tomatoes=true&plot=short&r=json&apikey=#{Application.get_env(:cinegraph, Cinegraph.Services.OMDb.Client)[:api_key]}",
+         [],
+         timeout: 30_000,
+         recv_timeout: 30_000
+       ) do
+    {:ok, %{status_code: 200, body: body}} ->
+      case Jason.decode(body) do
+        {:ok, data} ->
+          IO.puts("SUCCESS — #{map_size(data)} fields returned")
+          OMDbExplorer.print_fields(data, "All fields")
+          OMDbExplorer.tomato_field_analysis(data)
+          data
+
+        {:error, e} ->
+          IO.puts("JSON decode error: #{inspect(e)}")
+          %{}
+      end
+
+    {:ok, %{status_code: code}} ->
+      IO.puts("HTTP #{code}")
+      %{}
+
+    {:error, e} ->
+      IO.puts("Request error: #{inspect(e)}")
+      %{}
+  end
+
+OMDbExplorer.separator("Call C — With plot=full")
+
+call_c =
+  case HTTPoison.get(
+         "https://www.omdbapi.com/?i=#{@test_imdb_id}&plot=full&r=json&apikey=#{Application.get_env(:cinegraph, Cinegraph.Services.OMDb.Client)[:api_key]}",
+         [],
+         timeout: 30_000,
+         recv_timeout: 30_000
+       ) do
+    {:ok, %{status_code: 200, body: body}} ->
+      case Jason.decode(body) do
+        {:ok, data} ->
+          IO.puts("SUCCESS — #{map_size(data)} fields returned")
+          IO.puts("  Plot (short): #{inspect(call_a["Plot"])}")
+          IO.puts("  Plot (full):  #{inspect(data["Plot"])}")
+          data
+
+        {:error, e} ->
+          IO.puts("JSON decode error: #{inspect(e)}")
+          %{}
+      end
+
+    {:ok, %{status_code: code}} ->
+      IO.puts("HTTP #{code}")
+      %{}
+
+    {:error, e} ->
+      IO.puts("Request error: #{inspect(e)}")
+      %{}
+  end
+
+# ---- Diffs ----
+
+OMDbExplorer.separator("Diffs")
+OMDbExplorer.diff_calls(call_a, call_b, "Call A", "Call B (tomatoes:true)")
+
+# ---- DB Analysis ----
+
+OMDbExplorer.separator("DB Analysis — tomatoURL coverage in stored omdb_data")
+
+total =
+  Repo.one(from m in Movie, where: not is_nil(m.omdb_data), select: count(m.id))
+
+with_tomato_url =
+  Repo.one(
+    from m in Movie,
+      where: not is_nil(m.omdb_data),
+      where: fragment("omdb_data->>'tomatoURL' IS NOT NULL"),
+      where: fragment("omdb_data->>'tomatoURL' != 'N/A'"),
+      select: count(m.id)
+  )
+
+na_tomato_url =
+  Repo.one(
+    from m in Movie,
+      where: not is_nil(m.omdb_data),
+      where: fragment("omdb_data->>'tomatoURL' = 'N/A'"),
+      select: count(m.id)
+  )
+
+null_tomato_url = total - with_tomato_url - na_tomato_url
+
+IO.puts("\n  Total movies with omdb_data: #{total}")
+IO.puts("  tomatoURL populated (non-N/A): #{with_tomato_url}")
+IO.puts("  tomatoURL = N/A:               #{na_tomato_url}")
+IO.puts("  tomatoURL missing/null:         #{null_tomato_url}")
+
+if total > 0 do
+  pct = Float.round(with_tomato_url / total * 100, 1)
+  IO.puts("  Coverage: #{pct}% have a valid tomatoURL")
+end
+
+# ---- Rated field coverage ----
+
+OMDbExplorer.separator("DB Analysis — Rated (content rating) coverage")
+
+rated_counts =
+  Repo.all(
+    from m in Movie,
+      where: not is_nil(m.omdb_data),
+      where: fragment("omdb_data->>'Rated' IS NOT NULL"),
+      group_by: fragment("omdb_data->>'Rated'"),
+      select: {fragment("omdb_data->>'Rated'"), count(m.id)},
+      order_by: [desc: count(m.id)]
+  )
+
+if rated_counts == [] do
+  IO.puts("\n  No Rated field found in stored data.")
+else
+  IO.puts("\n  Value distribution:")
+
+  Enum.each(rated_counts, fn {rated, count} ->
+    IO.puts("    #{String.pad_trailing(rated || "NULL", 12)} #{count}")
+  end)
+end
+
+IO.puts("\n#{String.duplicate("=", 60)}")
+IO.puts("Explorer complete.")
+IO.puts(String.duplicate("=", 60) <> "\n")

--- a/priv/scripts/phase1_audit.exs
+++ b/priv/scripts/phase1_audit.exs
@@ -1,0 +1,173 @@
+# Phase 1 Audit Script — Issue #597
+# Run with: mix run priv/scripts/phase1_audit.exs
+#
+# Answers all Phase 1 baseline questions:
+#   1. How many 1001-list films are in the DB?
+#   2. Per-source metric coverage for those films
+#   3. Current scoring distribution (decile buckets)
+#   4. What % of 1001 films land in the top 20% of all scored films
+
+alias Cinegraph.{Repo, Movies}
+alias Cinegraph.Metrics.ScoringService
+
+IO.puts("\n=== Phase 1 Audit: 1001 Movies Baseline ===\n")
+
+# ---------------------------------------------------------------------------
+# 1. DB coverage count
+# ---------------------------------------------------------------------------
+total_1001 = Movies.count_canonical_movies("1001_movies")
+IO.puts("1. 1001 Movies DB coverage: #{total_1001} films")
+IO.puts("   (target ≥ 90% of ~1,214 editions = ~1,093 films)")
+coverage_pct = Float.round(total_1001 / 1214 * 100, 1)
+IO.puts("   Current coverage: #{coverage_pct}%\n")
+
+# ---------------------------------------------------------------------------
+# 2. Per-source external metrics coverage
+# ---------------------------------------------------------------------------
+IO.puts("2. External metrics coverage for 1001-list films:")
+
+coverage_sql = """
+SELECT
+  COUNT(*) FILTER (WHERE em.source = 'imdb' AND em.metric_type = 'rating_average')           AS imdb_count,
+  COUNT(*) FILTER (WHERE em.source = 'rotten_tomatoes' AND em.metric_type = 'tomatometer')   AS rt_tomatometer_count,
+  COUNT(*) FILTER (WHERE em.source = 'rotten_tomatoes' AND em.metric_type = 'audience_score') AS rt_audience_count,
+  COUNT(*) FILTER (WHERE em.source = 'metacritic' AND em.metric_type = 'metascore')          AS metacritic_count,
+  COUNT(*) FILTER (WHERE em.source = 'tmdb' AND em.metric_type = 'rating_average')           AS tmdb_count,
+  COUNT(DISTINCT m.id) AS total_1001_films
+FROM movies m
+LEFT JOIN external_metrics em ON em.movie_id = m.id
+WHERE m.canonical_sources ? '1001_movies'
+"""
+
+%{rows: [[imdb, rt_tom, rt_aud, meta, tmdb, total_check]]} =
+  Repo.query!(coverage_sql)
+
+IO.puts("   Total 1001 films (double-check): #{total_check}")
+IO.puts("   IMDb rating:              #{imdb} / #{total_check} (#{Float.round(imdb / max(total_check, 1) * 100, 1)}%)")
+IO.puts("   RT Tomatometer:           #{rt_tom} / #{total_check} (#{Float.round(rt_tom / max(total_check, 1) * 100, 1)}%)")
+IO.puts("   RT Audience score:        #{rt_aud} / #{total_check} (#{Float.round(rt_aud / max(total_check, 1) * 100, 1)}%)")
+IO.puts("   Metacritic metascore:     #{meta} / #{total_check} (#{Float.round(meta / max(total_check, 1) * 100, 1)}%)")
+IO.puts("   TMDb rating:              #{tmdb} / #{total_check} (#{Float.round(tmdb / max(total_check, 1) * 100, 1)}%)\n")
+
+# ---------------------------------------------------------------------------
+# 3. Scoring distribution for 1001-list films (decile buckets)
+# ---------------------------------------------------------------------------
+IO.puts("3. Scoring distribution for 1001 films (decile buckets):")
+
+profile = ScoringService.get_default_profile()
+
+if profile do
+  import Ecto.Query
+
+  base_query =
+    from(m in Cinegraph.Movies.Movie,
+      where: fragment("? \\? '1001_movies'", m.canonical_sources)
+    )
+
+  scored =
+    base_query
+    |> ScoringService.apply_scoring(profile, %{min_score: 0.0})
+    |> Repo.all()
+
+  # discovery_score is a 0.0–1.0 float; scale to 0–100 for display
+  scores = Enum.map(scored, fn m -> (Map.get(m, :discovery_score, 0.0) || 0.0) * 100 end)
+  scored_count = length(scores)
+  IO.puts("   Scored films: #{scored_count}")
+
+  if scored_count > 0 do
+    buckets =
+      scores
+      |> Enum.group_by(fn s ->
+        bucket = trunc(s / 10) * 10
+        # cap at 90 so 100 falls in 90–100 bucket
+        min(bucket, 90)
+      end)
+      |> Enum.sort_by(fn {bucket, _} -> bucket end, :desc)
+
+    Enum.each(buckets, fn {bucket, films} ->
+      IO.puts("   #{String.pad_leading(to_string(bucket), 3)}–#{bucket + 10}: #{length(films)} films")
+    end)
+  end
+else
+  IO.puts("   WARNING: No default profile found — skipping scoring distribution")
+end
+
+IO.puts("")
+
+# ---------------------------------------------------------------------------
+# 4. % of 1001 films in top 20% of all scored films
+# ---------------------------------------------------------------------------
+IO.puts("4. 1001 films vs full catalog top-20% recall:")
+
+if profile do
+  import Ecto.Query
+
+  # Use raw SQL with PERCENT_RANK window function to avoid loading all movies into memory.
+  # Weights from the default profile: popular_opinion=0.3, awards=0.2, cultural=0.15,
+  # people=0.15, financial=0.2 (these match the normalized weights from the query above).
+  pw = profile.category_weights || %{}
+  pop_w = (Map.get(pw, "popular_opinion") || Map.get(pw, "ratings") || 0.3)
+  awd_w = (Map.get(pw, "awards") || 0.2)
+  cul_w = (Map.get(pw, "cultural") || 0.15)
+  ppl_w = (Map.get(pw, "people") || 0.15)
+  total_w = pop_w + awd_w + cul_w + ppl_w
+  {pop_n, awd_n, cul_n, ppl_n} = if total_w > 0,
+    do: {pop_w/total_w, awd_w/total_w, cul_w/total_w, ppl_w/total_w},
+    else: {0.25, 0.25, 0.25, 0.25}
+
+  recall_sql = """
+  WITH scored AS (
+    SELECT
+      m.id,
+      (m.canonical_sources ? '1001_movies') AS is_1001,
+      #{pop_n} * COALESCE(
+        (COALESCE(tr.value, 0)/10.0 * 0.25 + COALESCE(ir.value, 0)/10.0 * 0.25 +
+         COALESCE(mc.value, 0)/100.0 * 0.25 + COALESCE(rt.value, 0)/100.0 * 0.25), 0) +
+      #{awd_n} * COALESCE(LEAST(1.0, COALESCE(f.wins, 0) * 0.2 + COALESCE(f.nominations, 0) * 0.05), 0) +
+      #{cul_n} * COALESCE(LEAST(1.0,
+        COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(m.canonical_sources, '{}'::jsonb))), 0) * 0.1 +
+        CASE WHEN COALESCE(pop.value, 0) = 0 THEN 0 ELSE LN(COALESCE(pop.value, 0) + 1) / LN(1001) END), 0) +
+      #{ppl_n} * COALESCE(COALESCE(pq.avg_quality, 0) / 100.0, 0)
+      AS score
+    FROM movies m
+    LEFT JOIN external_metrics tr ON tr.movie_id = m.id AND tr.source = 'tmdb' AND tr.metric_type = 'rating_average'
+    LEFT JOIN external_metrics ir ON ir.movie_id = m.id AND ir.source = 'imdb' AND ir.metric_type = 'rating_average'
+    LEFT JOIN external_metrics mc ON mc.movie_id = m.id AND mc.source = 'metacritic' AND mc.metric_type = 'metascore'
+    LEFT JOIN external_metrics rt ON rt.movie_id = m.id AND rt.source = 'rotten_tomatoes' AND rt.metric_type = 'tomatometer'
+    LEFT JOIN external_metrics pop ON pop.movie_id = m.id AND pop.source = 'tmdb' AND pop.metric_type = 'popularity_score'
+    LEFT JOIN (
+      SELECT movie_id, count(CASE WHEN won THEN 1 END) AS wins, count(id) AS nominations
+      FROM festival_nominations GROUP BY movie_id
+    ) f ON f.movie_id = m.id
+    LEFT JOIN (
+      SELECT mc2.movie_id, avg(pm.score) AS avg_quality
+      FROM movie_credits mc2
+      JOIN person_metrics pm ON pm.person_id = mc2.person_id AND pm.metric_type = 'quality_score'
+      GROUP BY mc2.movie_id
+    ) pq ON pq.movie_id = m.id
+  ),
+  ranked AS (
+    SELECT *, PERCENT_RANK() OVER (ORDER BY score DESC) AS pct_rank
+    FROM scored
+  )
+  SELECT
+    COUNT(*) FILTER (WHERE is_1001 AND pct_rank < 0.2)  AS in_top_20,
+    COUNT(*) FILTER (WHERE is_1001)                     AS total_1001_scored,
+    COUNT(*)                                             AS total_catalog
+  FROM ranked
+  """
+
+  %{rows: [[in_top_20, total_1001_scored, total_catalog]]} =
+    Repo.query!(recall_sql, [], timeout: 120_000)
+
+  recall_pct = if total_1001_scored > 0, do: Float.round(in_top_20 / total_1001_scored * 100, 1), else: 0.0
+
+  IO.puts("   Total scored films in catalog: #{total_catalog}")
+  IO.puts("   1001 films in catalog (scored): #{total_1001_scored}")
+  IO.puts("   1001 films in top 20%: #{in_top_20} (#{recall_pct}% recall)")
+  IO.puts("   Baseline target: ≥ 80% recall (phase 1 goal)")
+else
+  IO.puts("   WARNING: No default profile found — skipping recall calculation")
+end
+
+IO.puts("\n=== Audit complete ===\n")


### PR DESCRIPTION
### TL;DR

Temporarily increased OMDb API concurrency from 5 to 20 workers for backfill processing, prioritized 1001-list movies in ratings refresh, and added content rating and Rotten Tomatoes URL extraction from OMDb data.

### What changed?

- **OMDb API optimization**: Increased worker concurrency to 20 (with note to revert to 5 after backlog cleared) and removed deprecated `tomatoes: true` parameter from API calls
- **Enhanced data extraction**: Added content rating (MPAA) and Rotten Tomatoes page URL extraction from OMDb responses to external metrics
- **Prioritized processing**: Modified ratings refresh worker to process 1001-list movies first (Phase A0) before handling general null-backlog movies
- **Performance improvements**: Increased prediction calculator timeout from 60 seconds to 5 minutes and removed expensive validation calculations for non-2020s decades
- **Analysis tooling**: Added OMDb API explorer script to verify response structure and Phase 1 audit script for 1001 movies baseline metrics

### How to test?

1. Run the ratings refresh worker and verify 1001-list movies are queued first
2. Check that OMDb enrichment jobs process content ratings and Rotten Tomatoes URLs correctly
3. Use the new audit script: `mix run priv/scripts/phase1_audit.exs` to verify 1001 movies coverage
4. Monitor OMDb API response structure with: `mix run priv/scripts/omdb_api_explorer.exs`

### Why make this change?

This change addresses a backlog of OMDb data enrichment by temporarily scaling up processing capacity while ensuring high-priority canonical films (1001 movies) are processed first. The enhanced data extraction captures additional valuable metadata (content ratings, RT URLs) that was previously ignored, improving the completeness of movie data for scoring and recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MPAA content ratings are now captured and stored from OMDb for enhanced movie information.
  * Rotten Tomatoes page URLs are now captured alongside tomatometer data.

* **Performance**
  * Increased concurrent processing of external API calls during bulk data backfill operations.
  * Optimized refresh queue to prioritize canonical film list entries.

* **Chores**
  * Added diagnostic and audit scripts for data analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->