### PR TITLE
small changes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,19 +43,13 @@ config :cinegraph, Cinegraph.Services.TMDb.Client, api_key: tmdb_api_key
 # Configure OMDb (optional)
 config :cinegraph, Cinegraph.Services.OMDb.Client, api_key: omdb_api_key
 
-# Daily OMDb batch size for RatingsRefreshWorker (default 500)
+# Daily OMDb batch size for RatingsRefreshWorker.
+# Defaults to 100,000 — the full Basic plan daily limit.
+# Override via OMDB_DAILY_BATCH_SIZE env var only if you need to throttle.
 omdb_daily_batch_size =
   if config_env() == :dev,
-    do: env!("OMDB_DAILY_BATCH_SIZE", :integer, 500),
-    else: String.to_integer(System.get_env("OMDB_DAILY_BATCH_SIZE") || "500")
-
-omdb_daily_batch_size =
-  if omdb_daily_batch_size > 0,
-    do: omdb_daily_batch_size,
-    else:
-      raise(
-        "OMDB_DAILY_BATCH_SIZE must be a positive integer, got: #{omdb_daily_batch_size}"
-      )
+    do: env!("OMDB_DAILY_BATCH_SIZE", :integer, 100_000),
+    else: String.to_integer(System.get_env("OMDB_DAILY_BATCH_SIZE") || "100000")
 
 config :cinegraph, :omdb_daily_batch_size, omdb_daily_batch_size
 

--- a/lib/cinegraph/movies/external_metric.ex
+++ b/lib/cinegraph/movies/external_metric.ex
@@ -307,22 +307,25 @@ defmodule Cinegraph.Movies.ExternalMetric do
         Enum.reduce(omdb_data["Ratings"], metrics, fn rating, acc ->
           case rating["Source"] do
             "Rotten Tomatoes" ->
-              value =
-                rating["Value"]
-                |> String.replace("%", "")
-                |> String.to_integer()
+              # Use Integer.parse/1 to avoid raising on malformed values
+              # (e.g., "N/A" slipping through if the outer guard is absent).
+              case rating["Value"] |> String.replace("%", "") |> Integer.parse() do
+                {value, _} ->
+                  [
+                    %{
+                      movie_id: movie_id,
+                      source: "rotten_tomatoes",
+                      metric_type: "tomatometer",
+                      value: value,
+                      metadata: %{"scale" => "0-100", "type" => "critics"},
+                      fetched_at: now
+                    }
+                    | acc
+                  ]
 
-              [
-                %{
-                  movie_id: movie_id,
-                  source: "rotten_tomatoes",
-                  metric_type: "tomatometer",
-                  value: value,
-                  metadata: %{"scale" => "0-100", "type" => "critics"},
-                  fetched_at: now
-                }
-                | acc
-              ]
+                :error ->
+                  acc
+              end
 
             _ ->
               acc

--- a/lib/cinegraph/workers/ratings_refresh_worker.ex
+++ b/lib/cinegraph/workers/ratings_refresh_worker.ex
@@ -36,7 +36,7 @@ defmodule Cinegraph.Workers.RatingsRefreshWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    batch_size = Application.get_env(:cinegraph, :omdb_daily_batch_size, 500)
+    batch_size = Application.get_env(:cinegraph, :omdb_daily_batch_size, 100_000)
 
     null_count = count_null_backlog()
 

--- a/priv/scripts/omdb_api_explorer.exs
+++ b/priv/scripts/omdb_api_explorer.exs
@@ -15,7 +15,7 @@ alias Cinegraph.Repo
 alias Cinegraph.Movies.Movie
 import Ecto.Query
 
-@test_imdb_id "tt0111161"
+test_imdb_id = "tt0111161"
 
 defmodule OMDbExplorer do
   # Fields currently extracted by from_omdb/2
@@ -85,7 +85,7 @@ end
 OMDbExplorer.separator("Call A — Standard (no tomatoes param)")
 
 call_a =
-  case Client.get_movie_by_imdb_id(@test_imdb_id) do
+  case Client.get_movie_by_imdb_id(test_imdb_id) do
     {:ok, data} ->
       IO.puts("SUCCESS — #{map_size(data)} fields returned")
       OMDbExplorer.print_fields(data, "All fields")
@@ -101,7 +101,7 @@ OMDbExplorer.separator("Call B — With tomatoes: true")
 
 call_b =
   case HTTPoison.get(
-         "https://www.omdbapi.com/?i=#{@test_imdb_id}&tomatoes=true&plot=short&r=json&apikey=#{Application.get_env(:cinegraph, Cinegraph.Services.OMDb.Client)[:api_key]}",
+         "https://www.omdbapi.com/?i=#{test_imdb_id}&tomatoes=true&plot=short&r=json&apikey=#{Application.get_env(:cinegraph, Cinegraph.Services.OMDb.Client)[:api_key]}",
          [],
          timeout: 30_000,
          recv_timeout: 30_000
@@ -132,7 +132,7 @@ OMDbExplorer.separator("Call C — With plot=full")
 
 call_c =
   case HTTPoison.get(
-         "https://www.omdbapi.com/?i=#{@test_imdb_id}&plot=full&r=json&apikey=#{Application.get_env(:cinegraph, Cinegraph.Services.OMDb.Client)[:api_key]}",
+         "https://www.omdbapi.com/?i=#{test_imdb_id}&plot=full&r=json&apikey=#{Application.get_env(:cinegraph, Cinegraph.Services.OMDb.Client)[:api_key]}",
          [],
          timeout: 30_000,
          recv_timeout: 30_000

--- a/priv/scripts/phase1_audit.exs
+++ b/priv/scripts/phase1_audit.exs
@@ -9,6 +9,7 @@
 
 alias Cinegraph.{Repo, Movies}
 alias Cinegraph.Metrics.ScoringService
+import Ecto.Query
 
 IO.puts("\n=== Phase 1 Audit: 1001 Movies Baseline ===\n")
 
@@ -18,6 +19,7 @@ IO.puts("\n=== Phase 1 Audit: 1001 Movies Baseline ===\n")
 total_1001 = Movies.count_canonical_movies("1001_movies")
 IO.puts("1. 1001 Movies DB coverage: #{total_1001} films")
 IO.puts("   (target ≥ 90% of ~1,214 editions = ~1,093 films)")
+# 1,214 = total films across all known editions of the 1001 Movies book
 coverage_pct = Float.round(total_1001 / 1214 * 100, 1)
 IO.puts("   Current coverage: #{coverage_pct}%\n")
 
@@ -43,11 +45,26 @@ WHERE m.canonical_sources ? '1001_movies'
   Repo.query!(coverage_sql)
 
 IO.puts("   Total 1001 films (double-check): #{total_check}")
-IO.puts("   IMDb rating:              #{imdb} / #{total_check} (#{Float.round(imdb / max(total_check, 1) * 100, 1)}%)")
-IO.puts("   RT Tomatometer:           #{rt_tom} / #{total_check} (#{Float.round(rt_tom / max(total_check, 1) * 100, 1)}%)")
-IO.puts("   RT Audience score:        #{rt_aud} / #{total_check} (#{Float.round(rt_aud / max(total_check, 1) * 100, 1)}%)")
-IO.puts("   Metacritic metascore:     #{meta} / #{total_check} (#{Float.round(meta / max(total_check, 1) * 100, 1)}%)")
-IO.puts("   TMDb rating:              #{tmdb} / #{total_check} (#{Float.round(tmdb / max(total_check, 1) * 100, 1)}%)\n")
+
+IO.puts(
+  "   IMDb rating:              #{imdb} / #{total_check} (#{Float.round(imdb / max(total_check, 1) * 100, 1)}%)"
+)
+
+IO.puts(
+  "   RT Tomatometer:           #{rt_tom} / #{total_check} (#{Float.round(rt_tom / max(total_check, 1) * 100, 1)}%)"
+)
+
+IO.puts(
+  "   RT Audience score:        #{rt_aud} / #{total_check} (#{Float.round(rt_aud / max(total_check, 1) * 100, 1)}%)"
+)
+
+IO.puts(
+  "   Metacritic metascore:     #{meta} / #{total_check} (#{Float.round(meta / max(total_check, 1) * 100, 1)}%)"
+)
+
+IO.puts(
+  "   TMDb rating:              #{tmdb} / #{total_check} (#{Float.round(tmdb / max(total_check, 1) * 100, 1)}%)\n"
+)
 
 # ---------------------------------------------------------------------------
 # 3. Scoring distribution for 1001-list films (decile buckets)
@@ -57,8 +74,6 @@ IO.puts("3. Scoring distribution for 1001 films (decile buckets):")
 profile = ScoringService.get_default_profile()
 
 if profile do
-  import Ecto.Query
-
   base_query =
     from(m in Cinegraph.Movies.Movie,
       where: fragment("? \\? '1001_movies'", m.canonical_sources)
@@ -85,7 +100,9 @@ if profile do
       |> Enum.sort_by(fn {bucket, _} -> bucket end, :desc)
 
     Enum.each(buckets, fn {bucket, films} ->
-      IO.puts("   #{String.pad_leading(to_string(bucket), 3)}–#{bucket + 10}: #{length(films)} films")
+      IO.puts(
+        "   #{String.pad_leading(to_string(bucket), 3)}–#{bucket + 10}: #{length(films)} films"
+      )
     end)
   end
 else
@@ -100,20 +117,20 @@ IO.puts("")
 IO.puts("4. 1001 films vs full catalog top-20% recall:")
 
 if profile do
-  import Ecto.Query
-
   # Use raw SQL with PERCENT_RANK window function to avoid loading all movies into memory.
   # Weights from the default profile: popular_opinion=0.3, awards=0.2, cultural=0.15,
   # people=0.15, financial=0.2 (these match the normalized weights from the query above).
   pw = profile.category_weights || %{}
-  pop_w = (Map.get(pw, "popular_opinion") || Map.get(pw, "ratings") || 0.3)
-  awd_w = (Map.get(pw, "awards") || 0.2)
-  cul_w = (Map.get(pw, "cultural") || 0.15)
-  ppl_w = (Map.get(pw, "people") || 0.15)
+  pop_w = Map.get(pw, "popular_opinion") || Map.get(pw, "ratings") || 0.3
+  awd_w = Map.get(pw, "awards") || 0.2
+  cul_w = Map.get(pw, "cultural") || 0.15
+  ppl_w = Map.get(pw, "people") || 0.15
   total_w = pop_w + awd_w + cul_w + ppl_w
-  {pop_n, awd_n, cul_n, ppl_n} = if total_w > 0,
-    do: {pop_w/total_w, awd_w/total_w, cul_w/total_w, ppl_w/total_w},
-    else: {0.25, 0.25, 0.25, 0.25}
+
+  {pop_n, awd_n, cul_n, ppl_n} =
+    if total_w > 0,
+      do: {pop_w / total_w, awd_w / total_w, cul_w / total_w, ppl_w / total_w},
+      else: {0.25, 0.25, 0.25, 0.25}
 
   recall_sql = """
   WITH scored AS (
@@ -160,7 +177,8 @@ if profile do
   %{rows: [[in_top_20, total_1001_scored, total_catalog]]} =
     Repo.query!(recall_sql, [], timeout: 120_000)
 
-  recall_pct = if total_1001_scored > 0, do: Float.round(in_top_20 / total_1001_scored * 100, 1), else: 0.0
+  recall_pct =
+    if total_1001_scored > 0, do: Float.round(in_top_20 / total_1001_scored * 100, 1), else: 0.0
 
   IO.puts("   Total scored films in catalog: #{total_catalog}")
   IO.puts("   1001 films in catalog (scored): #{total_1001_scored}")

--- a/priv/scripts/queue_1001_omdb_backfill.exs
+++ b/priv/scripts/queue_1001_omdb_backfill.exs
@@ -1,0 +1,44 @@
+# One-time trigger: immediately queue all 1001-list films missing OMDb data.
+#
+# Usage: mix run priv/scripts/queue_1001_omdb_backfill.exs
+#
+# Bypasses the 3 AM RatingsRefreshWorker cron. Safe to run multiple times —
+# Oban deduplicates jobs already in the queue.
+
+import Ecto.Query
+alias Cinegraph.Repo
+alias Cinegraph.Movies.Movie
+alias Cinegraph.Movies.ExternalMetric
+alias Cinegraph.Workers.OMDbEnrichmentWorker
+
+cooldown_cutoff = DateTime.add(DateTime.utc_now(), -90 * 24 * 3600, :second)
+
+recently_checked =
+  from(em in ExternalMetric,
+    where: em.source == "omdb" and em.metric_type == "fetch_attempt",
+    where: em.fetched_at > ^cooldown_cutoff,
+    select: em.movie_id
+  )
+
+ids =
+  from(m in Movie,
+    where: m.import_status == "full",
+    where: is_nil(m.omdb_data),
+    where: not is_nil(m.imdb_id),
+    where: fragment("? \\? '1001_movies'", m.canonical_sources),
+    where: m.id not in subquery(recently_checked),
+    select: m.id
+  )
+  |> Repo.all()
+
+IO.puts("Queuing #{length(ids)} 1001-list films for OMDb enrichment...")
+
+{queued, failed} =
+  Enum.reduce(ids, {0, 0}, fn id, {ok, err} ->
+    case Oban.insert(OMDbEnrichmentWorker.new(%{"movie_id" => id})) do
+      {:ok, _} -> {ok + 1, err}
+      {:error, _} -> {ok, err + 1}
+    end
+  end)
+
+IO.puts("Done — queued: #{queued}, failed: #{failed}")


### PR DESCRIPTION
### TL;DR

Increased OMDb daily batch size from 500 to 100,000 requests and improved error handling for malformed Rotten Tomatoes ratings data.

### What changed?

- Changed the default OMDb daily batch size from 500 to 100,000 (the full Basic plan daily limit) in both configuration and worker files
- Removed validation logic that enforced positive batch size values
- Updated comments to clarify that the environment variable should only be used for throttling
- Replaced `String.to_integer/1` with `Integer.parse/1` when parsing Rotten Tomatoes percentage values to gracefully handle malformed data like "N/A"
- Converted module attribute `@test_imdb_id` to local variable in the OMDb API explorer script
- Added a new script `queue_1001_omdb_backfill.exs` for immediately queuing 1001-list films missing OMDb data
- Improved code formatting and added explanatory comments in the phase1 audit script

### How to test?

- Verify the RatingsRefreshWorker processes up to 100,000 movies per day by default
- Test that malformed Rotten Tomatoes ratings (like "N/A%") are skipped instead of causing crashes
- Run the new backfill script: `mix run priv/scripts/queue_1001_omdb_backfill.exs`
- Confirm that setting `OMDB_DAILY_BATCH_SIZE` environment variable still overrides the default

### Why make this change?

The previous batch size of 500 was too conservative for the OMDb Basic plan's 100,000 daily request limit, significantly slowing down data collection. The error handling improvement prevents crashes when OMDb returns unexpected rating formats, making the system more robust when processing large batches of movie data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Rotten Tomatoes ratings parsing—malformed ratings are now gracefully skipped instead of interrupting data processing.

* **Performance**
  * Increased batch processing capacity for movie enrichment from 500 to 100,000 items per cycle, enabling faster data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->