### PR TITLE
phase 2

### DIFF
--- a/lib/cinegraph/metrics/metric_weight_profile.ex
+++ b/lib/cinegraph/metrics/metric_weight_profile.ex
@@ -21,15 +21,17 @@ defmodule Cinegraph.Metrics.MetricWeightProfile do
     # Example: {"imdb_rating" => 1.0, "oscar_wins" => 2.0, "revenue_worldwide" => 0.8}
 
     # Category multipliers (applied after individual weights)
-    # Using the standard 5-category scoring system:
-    # - popular_opinion: Ratings from IMDb, TMDb, Metacritic, Rotten Tomatoes
+    # Using the standard 6-category scoring system:
+    # - mob: Audience ratings (IMDb, TMDb)
+    # - ivory_tower: Critics scores (RT Tomatometer, Metacritic)
     # - awards: Industry recognition through festival wins and nominations
     # - financial: Revenue and budget performance
     # - cultural: Canonical sources and cultural impact
     # - people: Quality scores of cast and crew
     field :category_weights, :map,
       default: %{
-        "popular_opinion" => 0.20,
+        "mob" => 0.10,
+        "ivory_tower" => 0.10,
         "awards" => 0.20,
         "financial" => 0.20,
         "cultural" => 0.20,
@@ -75,9 +77,9 @@ defmodule Cinegraph.Metrics.MetricWeightProfile do
         changeset
 
       weights ->
-        # Accept both old and new category names for backward compatibility
         valid_categories = [
-          "popular_opinion",
+          "mob",
+          "ivory_tower",
           "ratings",
           "awards",
           "financial",

--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -61,7 +61,8 @@ defmodule Cinegraph.Metrics.ScoringService do
       name: "Fallback",
       description: "Emergency fallback profile",
       category_weights: %{
-        "popular_opinion" => 0.20,
+        "mob" => 0.10,
+        "ivory_tower" => 0.10,
         "awards" => 0.20,
         "cultural" => 0.20,
         "people" => 0.20,
@@ -83,28 +84,34 @@ defmodule Cinegraph.Metrics.ScoringService do
   - "people" category represents person quality scores (directors, actors, etc.)
   """
   def profile_to_discovery_weights(%MetricWeightProfile{} = profile) do
-    # Use popular_opinion if it exists, otherwise fall back to ratings for backward compatibility
-    popular_weight =
-      get_category_weight(
-        profile,
-        "popular_opinion",
-        get_category_weight(profile, "ratings", 0.4)
-      )
+    # If profile has legacy popular_opinion, split it 50/50 into mob + ivory_tower
+    legacy_popular = get_category_weight(profile, "popular_opinion", nil)
 
-    financial_weight = get_category_weight(profile, "financial", 0.0)
-    cultural_weight = get_category_weight(profile, "cultural", 0.2)
-    people_weight = get_category_weight(profile, "people", 0.2)
+    {mob_weight, ivory_tower_weight} =
+      if legacy_popular do
+        half = legacy_popular / 2.0
+        {half, half}
+      else
+        mob =
+          get_category_weight(profile, "mob", get_category_weight(profile, "ratings", 0.2) / 2)
 
-    # All rating sources are now combined into popular_opinion
+        ivory =
+          get_category_weight(
+            profile,
+            "ivory_tower",
+            get_category_weight(profile, "ratings", 0.2) / 2
+          )
+
+        {mob, ivory}
+      end
+
     %{
-      popular_opinion: popular_weight,
+      mob: mob_weight,
+      ivory_tower: ivory_tower_weight,
       industry_recognition: get_category_weight(profile, "awards", 0.2),
-      # Cultural impact (separate from financial now that we expose both)
-      cultural_impact: cultural_weight,
-      # Person quality from directors, actors, writers, etc.
-      people_quality: people_weight,
-      # Financial success as separate dimension for UI control
-      financial_success: financial_weight
+      cultural_impact: get_category_weight(profile, "cultural", 0.2),
+      people_quality: get_category_weight(profile, "people", 0.2),
+      financial_success: get_category_weight(profile, "financial", 0.0)
     }
   end
 
@@ -116,7 +123,8 @@ defmodule Cinegraph.Metrics.ScoringService do
       name: name,
       description: "Custom weight profile created from discovery UI",
       category_weights: %{
-        "popular_opinion" => Map.get(weights, :popular_opinion, 0.2),
+        "mob" => Map.get(weights, :mob, 0.1),
+        "ivory_tower" => Map.get(weights, :ivory_tower, 0.1),
         "awards" => Map.get(weights, :industry_recognition, 0.2),
         "financial" => Map.get(weights, :financial_success, 0.2),
         "cultural" => Map.get(weights, :cultural_impact, 0.2),
@@ -213,19 +221,20 @@ defmodule Cinegraph.Metrics.ScoringService do
   # The discovery score calculation is kept inline in each context for now
 
   defp build_metric_weights_from_discovery(weights) do
-    # All rating sources now combined under popular_opinion
-    pop_weight = Map.get(weights, :popular_opinion, 0.4)
+    mob_weight = Map.get(weights, :mob, 0.2)
+    ivory_weight = Map.get(weights, :ivory_tower, 0.2)
     award_weight = Map.get(weights, :industry_recognition, 0.2)
     cultural_weight = Map.get(weights, :cultural_impact, 0.2)
 
     %{
-      # Popular Opinion metrics (all rating sources)
-      "imdb_rating" => pop_weight * 1.0,
-      "tmdb_rating" => pop_weight * 1.0,
-      "metacritic_metascore" => pop_weight * 1.0,
-      "rotten_tomatoes_tomatometer" => pop_weight * 1.0,
-      "rotten_tomatoes_audience_score" => pop_weight * 0.8,
-      "imdb_rating_votes" => pop_weight * 0.5,
+      # Mob (audience) metrics
+      "imdb_rating" => mob_weight * 1.0,
+      "tmdb_rating" => mob_weight * 1.0,
+      "imdb_rating_votes" => mob_weight * 0.5,
+      # Ivory Tower (critics) metrics
+      "metacritic_metascore" => ivory_weight * 1.0,
+      "rotten_tomatoes_tomatometer" => ivory_weight * 1.0,
+      "rotten_tomatoes_audience_score" => ivory_weight * 0.8,
 
       # Industry Recognition metrics
       "oscar_wins" => award_weight * 3,
@@ -247,7 +256,8 @@ defmodule Cinegraph.Metrics.ScoringService do
 
     if total == 0 do
       %{
-        popular_opinion: 0.20,
+        mob: 0.10,
+        ivory_tower: 0.10,
         industry_recognition: 0.20,
         cultural_impact: 0.20,
         people_quality: 0.20,
@@ -390,21 +400,45 @@ defmodule Cinegraph.Metrics.ScoringService do
         discovery_score:
           fragment(
             """
-            ? * COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0) + 
-            ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + 
+            ? * CASE
+              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
+              WHEN ? IS NOT NULL THEN ? / 10.0
+              WHEN ? IS NOT NULL THEN ? / 10.0
+              ELSE 0.0
+            END +
+            ? * CASE
+              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
+              WHEN ? IS NOT NULL THEN ? / 100.0
+              WHEN ? IS NOT NULL THEN ? / 100.0
+              ELSE 0.0
+            END +
+            ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
             ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) +
             ? * COALESCE(COALESCE(?, 0) / 100.0, 0) +
-            ? * COALESCE(CASE 
-              WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0 
+            ? * COALESCE(CASE
+              WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0
               THEN LEAST(1.0, (LN(COALESCE(?, 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(?, 0) / COALESCE(?, 0)) * 0.4)
               ELSE COALESCE(LN(COALESCE(?, 0) + 1) / LN(1000000000), 0)
             END, 0)
             """,
-            ^weights.popular_opinion,
+            ^Map.get(weights, :mob, 0.0),
+            ir.value,
             tr.value,
             ir.value,
+            tr.value,
+            ir.value,
+            ir.value,
+            tr.value,
+            tr.value,
+            ^Map.get(weights, :ivory_tower, 0.0),
+            rt.value,
             mc.value,
             rt.value,
+            mc.value,
+            rt.value,
+            rt.value,
+            mc.value,
+            mc.value,
             ^weights.industry_recognition,
             f.wins,
             f.nominations,
@@ -422,14 +456,62 @@ defmodule Cinegraph.Metrics.ScoringService do
             b.value,
             r.value
           ),
+        mob_score:
+          fragment(
+            "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 10.0 WHEN ? IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
+            ir.value,
+            tr.value,
+            ir.value,
+            tr.value,
+            ir.value,
+            ir.value,
+            tr.value,
+            tr.value
+          ),
+        ivory_tower_score:
+          fragment(
+            "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 100.0 WHEN ? IS NOT NULL THEN ? / 100.0 ELSE 0.0 END",
+            rt.value,
+            mc.value,
+            rt.value,
+            mc.value,
+            rt.value,
+            rt.value,
+            mc.value,
+            mc.value
+          ),
+        score_confidence:
+          fragment(
+            "(CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END) / 4.0",
+            ir.value,
+            tr.value,
+            rt.value,
+            mc.value
+          ),
         score_components: %{
-          popular_opinion:
+          mob:
             fragment(
-              "COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0)",
+              "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 10.0 WHEN ? IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
+              ir.value,
               tr.value,
               ir.value,
+              tr.value,
+              ir.value,
+              ir.value,
+              tr.value,
+              tr.value
+            ),
+          ivory_tower:
+            fragment(
+              "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 100.0 WHEN ? IS NOT NULL THEN ? / 100.0 ELSE 0.0 END",
+              rt.value,
               mc.value,
-              rt.value
+              rt.value,
+              mc.value,
+              rt.value,
+              rt.value,
+              mc.value,
+              mc.value
             ),
           industry_recognition:
             fragment(
@@ -452,8 +534,8 @@ defmodule Cinegraph.Metrics.ScoringService do
           financial_success:
             fragment(
               """
-              COALESCE(CASE 
-                WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0 
+              COALESCE(CASE
+                WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0
                 THEN LEAST(1.0, (LN(COALESCE(?, 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(?, 0) / COALESCE(?, 0)) * 0.4)
                 ELSE COALESCE(LN(COALESCE(?, 0) + 1) / LN(1000000000), 0)
               END, 0)
@@ -491,21 +573,45 @@ defmodule Cinegraph.Metrics.ScoringService do
         discovery_score:
           fragment(
             """
-            ? * COALESCE((COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25), 0) + 
-            ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) + 
+            ? * CASE
+              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+              ELSE 0.0
+            END +
+            ? * CASE
+              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+              ELSE 0.0
+            END +
+            ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) +
             ? * COALESCE(LEAST(1.0, COALESCE(MAX((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb)))), 0) * 0.1 + CASE WHEN COALESCE(MAX(?), 0) = 0 THEN 0 ELSE LN(COALESCE(MAX(?), 0) + 1) / LN(1001) END), 0) +
             ? * COALESCE(COALESCE(MAX(?), 0) / 100.0, 0) +
-            ? * COALESCE(CASE 
-              WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0 
+            ? * COALESCE(CASE
+              WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0
               THEN LEAST(1.0, (LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(MAX(?), 0) / COALESCE(MAX(?), 0)) * 0.4)
               ELSE COALESCE(LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000), 0)
             END, 0)
             """,
-            ^weights.popular_opinion,
+            ^Map.get(weights, :mob, 0.0),
+            ir.value,
             tr.value,
             ir.value,
+            tr.value,
+            ir.value,
+            ir.value,
+            tr.value,
+            tr.value,
+            ^Map.get(weights, :ivory_tower, 0.0),
+            rt.value,
             mc.value,
             rt.value,
+            mc.value,
+            rt.value,
+            rt.value,
+            mc.value,
+            mc.value,
             ^weights.industry_recognition,
             f.wins,
             f.nominations,
@@ -524,13 +630,29 @@ defmodule Cinegraph.Metrics.ScoringService do
             r.value
           ),
         score_components: %{
-          popular_opinion:
+          mob:
             fragment(
-              "COALESCE((COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25), 0)",
+              "CASE WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0 ELSE 0.0 END",
+              ir.value,
               tr.value,
               ir.value,
+              tr.value,
+              ir.value,
+              ir.value,
+              tr.value,
+              tr.value
+            ),
+          ivory_tower:
+            fragment(
+              "CASE WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0 ELSE 0.0 END",
+              rt.value,
               mc.value,
-              rt.value
+              rt.value,
+              mc.value,
+              rt.value,
+              rt.value,
+              mc.value,
+              mc.value
             ),
           industry_recognition:
             fragment(
@@ -553,8 +675,8 @@ defmodule Cinegraph.Metrics.ScoringService do
           financial_success:
             fragment(
               """
-              COALESCE(CASE 
-                WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0 
+              COALESCE(CASE
+                WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0
                 THEN LEAST(1.0, (LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(MAX(?), 0) / COALESCE(MAX(?), 0)) * 0.4)
                 ELSE COALESCE(LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000), 0)
               END, 0)
@@ -590,21 +712,45 @@ defmodule Cinegraph.Metrics.ScoringService do
         ],
         fragment(
           """
-          ? * COALESCE((COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25), 0) + 
-          ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) + 
-          ? * COALESCE(LEAST(1.0, COALESCE(MAX((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb)))), 0) * 0.1 + CASE WHEN COALESCE(MAX(?), 0) = 0 THEN 0 ELSE LN(COALESCE(MAX(?), 0) + 1) / LN(1001) END), 0) + 
+          ? * CASE
+            WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
+            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+            ELSE 0.0
+          END +
+          ? * CASE
+            WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
+            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+            ELSE 0.0
+          END +
+          ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) +
+          ? * COALESCE(LEAST(1.0, COALESCE(MAX((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb)))), 0) * 0.1 + CASE WHEN COALESCE(MAX(?), 0) = 0 THEN 0 ELSE LN(COALESCE(MAX(?), 0) + 1) / LN(1001) END), 0) +
           ? * COALESCE(COALESCE(MAX(?), 0) / 100.0, 0) +
-          ? * COALESCE(CASE 
-            WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0 
+          ? * COALESCE(CASE
+            WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0
             THEN LEAST(1.0, (LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(MAX(?), 0) / COALESCE(MAX(?), 0)) * 0.4)
             ELSE COALESCE(LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000), 0)
           END, 0) >= ?
           """,
-          ^weights.popular_opinion,
+          ^Map.get(weights, :mob, 0.0),
+          ir.value,
           tr.value,
           ir.value,
+          tr.value,
+          ir.value,
+          ir.value,
+          tr.value,
+          tr.value,
+          ^Map.get(weights, :ivory_tower, 0.0),
+          rt.value,
           mc.value,
           rt.value,
+          mc.value,
+          rt.value,
+          rt.value,
+          mc.value,
+          mc.value,
           ^weights.industry_recognition,
           f.wins,
           f.nominations,
@@ -641,21 +787,45 @@ defmodule Cinegraph.Metrics.ScoringService do
         ],
         fragment(
           """
-          ? * COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0) + 
-          ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + 
-          ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) + 
+          ? * CASE
+            WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
+            WHEN ? IS NOT NULL THEN ? / 10.0
+            WHEN ? IS NOT NULL THEN ? / 10.0
+            ELSE 0.0
+          END +
+          ? * CASE
+            WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
+            WHEN ? IS NOT NULL THEN ? / 100.0
+            WHEN ? IS NOT NULL THEN ? / 100.0
+            ELSE 0.0
+          END +
+          ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
+          ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) +
           ? * COALESCE(COALESCE(?, 0) / 100.0, 0) +
-          ? * COALESCE(CASE 
-            WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0 
+          ? * COALESCE(CASE
+            WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0
             THEN LEAST(1.0, (LN(COALESCE(?, 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(?, 0) / COALESCE(?, 0)) * 0.4)
             ELSE COALESCE(LN(COALESCE(?, 0) + 1) / LN(1000000000), 0)
           END, 0) >= ?
           """,
-          ^weights.popular_opinion,
+          ^Map.get(weights, :mob, 0.0),
+          ir.value,
           tr.value,
           ir.value,
+          tr.value,
+          ir.value,
+          ir.value,
+          tr.value,
+          tr.value,
+          ^Map.get(weights, :ivory_tower, 0.0),
+          rt.value,
           mc.value,
           rt.value,
+          mc.value,
+          rt.value,
+          rt.value,
+          mc.value,
+          mc.value,
           ^weights.industry_recognition,
           f.wins,
           f.nominations,
@@ -697,21 +867,45 @@ defmodule Cinegraph.Metrics.ScoringService do
         desc:
           fragment(
             """
-            ? * COALESCE((COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 10.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25 + COALESCE(MAX(?), 0) / 100.0 * 0.25), 0) + 
-            ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) + 
-            ? * COALESCE(LEAST(1.0, COALESCE(MAX((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb)))), 0) * 0.1 + CASE WHEN COALESCE(MAX(?), 0) = 0 THEN 0 ELSE LN(COALESCE(MAX(?), 0) + 1) / LN(1001) END), 0) + 
+            ? * CASE
+              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+              ELSE 0.0
+            END +
+            ? * CASE
+              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+              ELSE 0.0
+            END +
+            ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) +
+            ? * COALESCE(LEAST(1.0, COALESCE(MAX((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb)))), 0) * 0.1 + CASE WHEN COALESCE(MAX(?), 0) = 0 THEN 0 ELSE LN(COALESCE(MAX(?), 0) + 1) / LN(1001) END), 0) +
             ? * COALESCE(COALESCE(MAX(?), 0) / 100.0, 0) +
-            ? * COALESCE(CASE 
-              WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0 
+            ? * COALESCE(CASE
+              WHEN COALESCE(MAX(?), 0) > 0 AND COALESCE(MAX(?), 0) > 0
               THEN LEAST(1.0, (LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(MAX(?), 0) / COALESCE(MAX(?), 0)) * 0.4)
               ELSE COALESCE(LN(COALESCE(MAX(?), 0) + 1) / LN(1000000000), 0)
             END, 0)
             """,
-            ^weights.popular_opinion,
+            ^Map.get(weights, :mob, 0.0),
+            ir.value,
             tr.value,
             ir.value,
+            tr.value,
+            ir.value,
+            ir.value,
+            tr.value,
+            tr.value,
+            ^Map.get(weights, :ivory_tower, 0.0),
+            rt.value,
             mc.value,
             rt.value,
+            mc.value,
+            rt.value,
+            rt.value,
+            mc.value,
+            mc.value,
             ^weights.industry_recognition,
             f.wins,
             f.nominations,
@@ -748,21 +942,45 @@ defmodule Cinegraph.Metrics.ScoringService do
         desc:
           fragment(
             """
-            ? * COALESCE((COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 10.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25 + COALESCE(?, 0) / 100.0 * 0.25), 0) + 
-            ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) + 
-            ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) + 
+            ? * CASE
+              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
+              WHEN ? IS NOT NULL THEN ? / 10.0
+              WHEN ? IS NOT NULL THEN ? / 10.0
+              ELSE 0.0
+            END +
+            ? * CASE
+              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
+              WHEN ? IS NOT NULL THEN ? / 100.0
+              WHEN ? IS NOT NULL THEN ? / 100.0
+              ELSE 0.0
+            END +
+            ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
+            ? * COALESCE(LEAST(1.0, COALESCE((SELECT count(*) FROM jsonb_each(COALESCE(?, '{}'::jsonb))), 0) * 0.1 + CASE WHEN COALESCE(?, 0) = 0 THEN 0 ELSE LN(COALESCE(?, 0) + 1) / LN(1001) END), 0) +
             ? * COALESCE(COALESCE(?, 0) / 100.0, 0) +
-            ? * COALESCE(CASE 
-              WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0 
+            ? * COALESCE(CASE
+              WHEN COALESCE(?, 0) > 0 AND COALESCE(?, 0) > 0
               THEN LEAST(1.0, (LN(COALESCE(?, 0) + 1) / LN(1000000000)) * 0.6 + (COALESCE(?, 0) / COALESCE(?, 0)) * 0.4)
               ELSE COALESCE(LN(COALESCE(?, 0) + 1) / LN(1000000000), 0)
             END, 0)
             """,
-            ^weights.popular_opinion,
+            ^Map.get(weights, :mob, 0.0),
+            ir.value,
             tr.value,
             ir.value,
+            tr.value,
+            ir.value,
+            ir.value,
+            tr.value,
+            tr.value,
+            ^Map.get(weights, :ivory_tower, 0.0),
+            rt.value,
             mc.value,
             rt.value,
+            mc.value,
+            rt.value,
+            rt.value,
+            mc.value,
+            mc.value,
             ^weights.industry_recognition,
             f.wins,
             f.nominations,

--- a/lib/cinegraph/movies/collection.ex
+++ b/lib/cinegraph/movies/collection.ex
@@ -37,6 +37,9 @@ defmodule Cinegraph.Movies.Collection do
   end
 
   defp truncate(nil, _max), do: nil
-  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max,
+    do: String.slice(str, 0, max)
+
   defp truncate(str, _max), do: str
 end

--- a/lib/cinegraph/movies/credit.ex
+++ b/lib/cinegraph/movies/credit.ex
@@ -41,10 +41,14 @@ defmodule Cinegraph.Movies.Credit do
 
   defp truncate_field(changeset, field, max_length) do
     case get_change(changeset, field) do
-      nil -> changeset
+      nil ->
+        changeset
+
       value when is_binary(value) and byte_size(value) > max_length ->
         put_change(changeset, field, String.slice(value, 0, max_length))
-      _ -> changeset
+
+      _ ->
+        changeset
     end
   end
 

--- a/lib/cinegraph/movies/external_metric.ex
+++ b/lib/cinegraph/movies/external_metric.ex
@@ -222,7 +222,10 @@ defmodule Cinegraph.Movies.ExternalMetric do
     # IMDb Votes
     metrics =
       if omdb_data["imdbVotes"] && omdb_data["imdbVotes"] != "N/A" do
-        case omdb_data["imdbVotes"] |> String.replace(",", "") |> String.trim() |> Integer.parse() do
+        case omdb_data["imdbVotes"]
+             |> String.replace(",", "")
+             |> String.trim()
+             |> Integer.parse() do
           {votes, ""} ->
             [
               %{
@@ -320,7 +323,10 @@ defmodule Cinegraph.Movies.ExternalMetric do
             "Rotten Tomatoes" ->
               # Use Integer.parse/1 to avoid raising on malformed values
               # (e.g., "N/A" slipping through if the outer guard is absent).
-              case rating["Value"] |> String.trim() |> String.replace("%", "") |> Integer.parse() do
+              case rating["Value"]
+                   |> String.trim()
+                   |> String.replace("%", "")
+                   |> Integer.parse() do
                 {value, ""} ->
                   [
                     %{

--- a/lib/cinegraph/movies/movie.ex
+++ b/lib/cinegraph/movies/movie.ex
@@ -120,6 +120,9 @@ defmodule Cinegraph.Movies.Movie do
     # Virtual fields for discovery scoring
     field :discovery_score, :float, virtual: true
     field :score_components, :map, virtual: true
+    field :mob_score, :float, virtual: true
+    field :ivory_tower_score, :float, virtual: true
+    field :score_confidence, :float, virtual: true
 
     timestamps()
   end

--- a/lib/cinegraph/movies/movie_release_date.ex
+++ b/lib/cinegraph/movies/movie_release_date.ex
@@ -46,7 +46,10 @@ defmodule Cinegraph.Movies.MovieReleaseDate do
   end
 
   defp truncate(nil, _max), do: nil
-  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max,
+    do: String.slice(str, 0, max)
+
   defp truncate(str, _max), do: str
 
   defp parse_datetime(nil), do: nil

--- a/lib/cinegraph/movies/movie_scoring.ex
+++ b/lib/cinegraph/movies/movie_scoring.ex
@@ -99,7 +99,8 @@ defmodule Cinegraph.Movies.MovieScoring do
       end
 
     # Calculate component scores (0-10 scale)
-    popular_opinion = calculate_popular_opinion(metrics)
+    mob = calculate_mob_score(metrics)
+    ivory_tower = calculate_ivory_tower_score(metrics)
     industry_recognition = calculate_industry_recognition(festival_data)
     cultural_impact = calculate_cultural_impact(movie, metrics)
     # Convert from 0-100 to 0-10
@@ -107,9 +108,10 @@ defmodule Cinegraph.Movies.MovieScoring do
     # Calculate financial performance score
     financial_performance = calculate_financial_performance(metrics)
 
-    # Calculate overall score (weighted average with equal weights for all 5 categories)
+    # Calculate overall score (mob + ivory_tower each weight 0.10, others 0.20)
     overall =
-      popular_opinion * 0.20 +
+      mob * 0.10 +
+        ivory_tower * 0.10 +
         industry_recognition * 0.20 +
         cultural_impact * 0.20 +
         people_quality_score * 0.20 +
@@ -117,8 +119,10 @@ defmodule Cinegraph.Movies.MovieScoring do
 
     %{
       overall_score: Float.round(overall, 1),
+      score_confidence: calculate_score_confidence(metrics),
       components: %{
-        popular_opinion: Float.round(popular_opinion, 1),
+        mob: Float.round(mob, 1),
+        ivory_tower: Float.round(ivory_tower, 1),
         industry_recognition: Float.round(industry_recognition, 1),
         cultural_impact: Float.round(cultural_impact, 1),
         people_quality: Float.round(people_quality_score, 1),
@@ -129,30 +133,51 @@ defmodule Cinegraph.Movies.MovieScoring do
   end
 
   @doc """
+  Calculate mob score (audience): IMDb + TMDb ratings, null-aware averaging.
+  Returns a 0–10 score.
+  """
+  def calculate_mob_score(metrics) do
+    imdb = Map.get(metrics, :imdb_rating)
+    tmdb = Map.get(metrics, :tmdb_rating)
+    sources = [imdb, tmdb] |> Enum.reject(&is_nil/1) |> Enum.filter(&(&1 > 0))
+
+    if sources == [], do: 0.0, else: Enum.sum(sources) / length(sources)
+  end
+
+  @doc """
+  Calculate ivory tower score (critics): RT Tomatometer + Metacritic, null-aware averaging.
+  Returns a 0–10 score (normalizes from 0–100 sources).
+  """
+  def calculate_ivory_tower_score(metrics) do
+    rt = Map.get(metrics, :rt_tomatometer)
+    mc = Map.get(metrics, :metacritic)
+
+    sources =
+      [{rt, 100.0}, {mc, 100.0}]
+      |> Enum.reject(fn {v, _} -> is_nil(v) or v == 0 end)
+      |> Enum.map(fn {v, scale} -> v / scale * 10.0 end)
+
+    if sources == [], do: 0.0, else: Enum.sum(sources) / length(sources)
+  end
+
+  @doc """
+  Calculate score confidence: fraction of the 4 core rating sources present (0.0–1.0).
+  """
+  def calculate_score_confidence(metrics) do
+    keys = [:imdb_rating, :tmdb_rating, :rt_tomatometer, :metacritic]
+    present = Enum.count(keys, &(not is_nil(Map.get(metrics, &1))))
+    present / 4.0
+  end
+
+  @doc """
   Calculate popular opinion score based on all rating sources.
+  Kept for backward compatibility — prefer calculate_mob_score/calculate_ivory_tower_score.
   """
   def calculate_popular_opinion(metrics) do
-    imdb = Map.get(metrics, :imdb_rating, 0) || 0
-    tmdb = Map.get(metrics, :tmdb_rating, 0) || 0
-    rt_audience = Map.get(metrics, :rt_audience, 0) || 0
-    metacritic = Map.get(metrics, :metacritic, 0) || 0
-    rt_tomatometer = Map.get(metrics, :rt_tomatometer, 0) || 0
-
-    scores =
-      [
-        imdb,
-        tmdb,
-        rt_audience / 10.0,
-        metacritic / 10.0,
-        rt_tomatometer / 10.0
-      ]
-      |> Enum.filter(&(&1 > 0))
-
-    if length(scores) > 0 do
-      Enum.sum(scores) / length(scores)
-    else
-      5.0
-    end
+    mob = calculate_mob_score(metrics)
+    ivory = calculate_ivory_tower_score(metrics)
+    sources = [mob, ivory] |> Enum.filter(&(&1 > 0))
+    if sources == [], do: 5.0, else: Enum.sum(sources) / length(sources)
   end
 
   @doc """

--- a/lib/cinegraph/movies/movie_video.ex
+++ b/lib/cinegraph/movies/movie_video.ex
@@ -56,7 +56,10 @@ defmodule Cinegraph.Movies.MovieVideo do
   end
 
   defp truncate(nil, _max), do: nil
-  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max,
+    do: String.slice(str, 0, max)
+
   defp truncate(str, _max), do: str
 
   defp parse_datetime(nil), do: nil

--- a/lib/cinegraph/movies/production_company.ex
+++ b/lib/cinegraph/movies/production_company.ex
@@ -42,6 +42,9 @@ defmodule Cinegraph.Movies.ProductionCompany do
   end
 
   defp truncate(nil, _max), do: nil
-  defp truncate(str, max) when is_binary(str) and byte_size(str) > max, do: String.slice(str, 0, max)
+
+  defp truncate(str, max) when is_binary(str) and byte_size(str) > max,
+    do: String.slice(str, 0, max)
+
   defp truncate(str, _max), do: str
 end

--- a/lib/cinegraph/movies/query/custom_filters.ex
+++ b/lib/cinegraph/movies/query/custom_filters.ex
@@ -475,7 +475,15 @@ defmodule Cinegraph.Movies.Query.CustomFilters do
         where(
           base,
           [mc],
-          mc.job in ["Writer", "Screenplay", "Story", "Novel", "Characters", "Teleplay", "Adaptation"]
+          mc.job in [
+            "Writer",
+            "Screenplay",
+            "Story",
+            "Novel",
+            "Characters",
+            "Teleplay",
+            "Adaptation"
+          ]
         )
 
       "producer" ->
@@ -492,10 +500,18 @@ defmodule Cinegraph.Movies.Query.CustomFilters do
         )
 
       "cinematographer" ->
-        where(base, [mc], mc.job in ["Director of Photography", "Cinematography", "Cinematographer"])
+        where(
+          base,
+          [mc],
+          mc.job in ["Director of Photography", "Cinematography", "Cinematographer"]
+        )
 
       "composer" ->
-        where(base, [mc], mc.job in ["Original Music Composer", "Composer", "Music", "Music Score"])
+        where(
+          base,
+          [mc],
+          mc.job in ["Original Music Composer", "Composer", "Music", "Music Score"]
+        )
 
       "editor" ->
         where(base, [mc], mc.job in ["Editor", "Film Editor", "Editorial", "Editing"])

--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -58,7 +58,10 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
         :ok
 
       {:error, %Jason.DecodeError{}} ->
-        Logger.warning("OMDb returned malformed JSON for movie #{movie.id}, recording fetch attempt")
+        Logger.warning(
+          "OMDb returned malformed JSON for movie #{movie.id}, recording fetch attempt"
+        )
+
         record_fetch_attempt(movie.id, "malformed_response")
         :ok
 

--- a/lib/cinegraph_web/live/metrics_live/index.html.heex
+++ b/lib/cinegraph_web/live/metrics_live/index.html.heex
@@ -513,8 +513,8 @@
             <!-- Category Weights -->
             <tr>
               <td class="px-4 py-2 text-sm font-medium text-gray-900">
-                Popular Opinion<br />
-                <span class="text-xs text-gray-500">(all ratings)</span>
+                The Mob<br />
+                <span class="text-xs text-gray-500">(IMDb, TMDb)</span>
               </td>
               <%= for profile <- @weight_profiles do %>
                 <td class="px-4 py-2 text-center">
@@ -522,12 +522,34 @@
                     <div class="w-20 bg-gray-200 rounded-full h-2 mr-2">
                       <div
                         class="bg-blue-600 h-2 rounded-full"
-                        style={"width: #{min(100, get_profile_weight_actual(profile, "popular_opinion"))}%"}
+                        style={"width: #{min(100, get_profile_weight_actual(profile, "mob"))}%"}
                       >
                       </div>
                     </div>
                     <span class="text-sm font-medium">
-                      {get_profile_weight_actual(profile, "popular_opinion")}%
+                      {get_profile_weight_actual(profile, "mob")}%
+                    </span>
+                  </div>
+                </td>
+              <% end %>
+            </tr>
+            <tr>
+              <td class="px-4 py-2 text-sm font-medium text-gray-900">
+                The Ivory Tower<br />
+                <span class="text-xs text-gray-500">(RT, Metacritic)</span>
+              </td>
+              <%= for profile <- @weight_profiles do %>
+                <td class="px-4 py-2 text-center">
+                  <div class="inline-flex items-center">
+                    <div class="w-20 bg-gray-200 rounded-full h-2 mr-2">
+                      <div
+                        class="bg-purple-600 h-2 rounded-full"
+                        style={"width: #{min(100, get_profile_weight_actual(profile, "ivory_tower"))}%"}
+                      >
+                      </div>
+                    </div>
+                    <span class="text-sm font-medium">
+                      {get_profile_weight_actual(profile, "ivory_tower")}%
                     </span>
                   </div>
                 </td>
@@ -884,10 +906,10 @@
                     {Float.round(movie.score * 100, 1)}%
                   </div>
                   <div class="text-xs text-gray-500">
-                    Pop: {Float.round((movie.components["popular_opinion"] || 0) * 100, 0)}% |
+                    Mob: {Float.round((movie.components["mob"] || 0) * 100, 0)}% |
+                    IT: {Float.round((movie.components["ivory_tower"] || 0) * 100, 0)}% |
                     Ind: {Float.round((movie.components["industry_recognition"] || 0) * 100, 0)}% |
-                    Cult: {Float.round((movie.components["cultural_impact"] || 0) * 100, 0)}% |
-                    People: {Float.round((movie.components["people_quality"] || 0) * 100, 0)}%
+                    Cult: {Float.round((movie.components["cultural_impact"] || 0) * 100, 0)}%
                   </div>
                 </div>
               </div>

--- a/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
+++ b/lib/cinegraph_web/live/movie_live/discovery_tuner.ex
@@ -15,10 +15,11 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
     # Load presets from database
     presets = DiscoveryScoring.get_presets()
 
-    # Get the default/balanced weights - now including people_quality and financial_success
+    # Get the default/balanced weights - mob + ivory_tower replace popular_opinion
     weights =
       Map.get(presets, :balanced, %{
-        popular_opinion: 0.20,
+        mob: 0.10,
+        ivory_tower: 0.10,
         industry_recognition: 0.20,
         cultural_impact: 0.20,
         people_quality: 0.20,
@@ -54,7 +55,8 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
       Enum.reduce(params, %{}, fn
         {key, value}, acc
         when key in [
-               "popular_opinion",
+               "mob",
+               "ivory_tower",
                "industry_recognition",
                "cultural_impact",
                "people_quality",
@@ -321,7 +323,10 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
               </p>
               <ul class="list-disc list-inside mt-2 space-y-1">
                 <li>
-                  <strong>Popular Opinion:</strong> IMDb, TMDb, Metacritic and Rotten Tomatoes ratings
+                  <strong>The Mob:</strong> Audience ratings (IMDb, TMDb)
+                </li>
+                <li>
+                  <strong>The Ivory Tower:</strong> Critics scores (RT Tomatometer, Metacritic)
                 </li>
                 <li>
                   <strong>Industry Recognition:</strong> Festival awards and Oscar nominations/wins
@@ -456,16 +461,16 @@ defmodule CinegraphWeb.MovieLive.DiscoveryTuner do
   defp humanize_preset(:cult_classic), do: "Cult Classic"
   defp humanize_preset(preset), do: Phoenix.Naming.humanize(preset)
 
-  defp humanize_dimension(:popular_opinion), do: "Popular Opinion"
+  defp humanize_dimension(:mob), do: "The Mob"
+  defp humanize_dimension(:ivory_tower), do: "The Ivory Tower"
   defp humanize_dimension(:industry_recognition), do: "Industry Recognition"
   defp humanize_dimension(:cultural_impact), do: "Cultural Impact"
   defp humanize_dimension(:people_quality), do: "People Quality"
   defp humanize_dimension(:financial_success), do: "Financial Success"
   defp humanize_dimension(dimension), do: Phoenix.Naming.humanize(dimension)
 
-  defp dimension_description(:popular_opinion),
-    do: "All rating sources (IMDb, TMDb, Metacritic, RT)"
-
+  defp dimension_description(:mob), do: "Audience ratings (IMDb, TMDb)"
+  defp dimension_description(:ivory_tower), do: "Critics scores (RT Tomatometer, Metacritic)"
   defp dimension_description(:industry_recognition), do: "Festival awards and nominations"
   defp dimension_description(:cultural_impact), do: "Canonical lists and popularity metrics"
   defp dimension_description(:people_quality), do: "Quality of directors, actors, and crew"

--- a/lib/cinegraph_web/live/movie_live/index.html.heex
+++ b/lib/cinegraph_web/live/movie_live/index.html.heex
@@ -99,7 +99,8 @@
           %{value: "runtime", label: "⏱️ Runtime", group: "Basic"},
           %{value: "rating", label: "⭐ Rating", group: "Ratings"},
           %{value: "popularity", label: "🔥 Popularity", group: "Ratings"},
-          %{value: "popular_opinion", label: "🎬 Popular Opinion", group: "Discovery Metrics"},
+          %{value: "mob", label: "👥 The Mob", group: "Discovery Metrics"},
+          %{value: "ivory_tower", label: "🎓 The Ivory Tower", group: "Discovery Metrics"},
           %{
             value: "industry_recognition",
             label: "🌟 Industry Recognition",
@@ -374,9 +375,14 @@
               <!-- Score Breakdown -->
               <%= if movie.score_components do %>
                 <div class="flex flex-wrap gap-1 text-xs">
-                  <%= if movie.score_components.popular_opinion && has_meaningful_score?(movie.score_components.popular_opinion) do %>
+                  <%= if movie.score_components[:mob] && has_meaningful_score?(movie.score_components[:mob]) do %>
                     <span class="inline-flex items-center px-2 py-0.5 rounded bg-green-50 text-green-700 border border-green-200">
-                      🎬 {to_percentage(movie.score_components.popular_opinion)}%
+                      👥 {to_percentage(movie.score_components[:mob])}%
+                    </span>
+                  <% end %>
+                  <%= if movie.score_components[:ivory_tower] && has_meaningful_score?(movie.score_components[:ivory_tower]) do %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded bg-blue-50 text-blue-700 border border-blue-200">
+                      🎓 {to_percentage(movie.score_components[:ivory_tower])}%
                     </span>
                   <% end %>
                   <%= if movie.score_components.industry_recognition && has_meaningful_score?(movie.score_components.industry_recognition) do %>

--- a/priv/repo/migrations/20260323120000_phase2_lens_split.exs
+++ b/priv/repo/migrations/20260323120000_phase2_lens_split.exs
@@ -1,0 +1,33 @@
+defmodule Cinegraph.Repo.Migrations.Phase2LensSplit do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE metric_weight_profiles
+    SET category_weights = (
+      category_weights
+      - 'popular_opinion'
+      || jsonb_build_object('mob',
+           ROUND((COALESCE((category_weights->>'popular_opinion')::numeric, 0.2) / 2)::numeric, 4))
+      || jsonb_build_object('ivory_tower',
+           ROUND((COALESCE((category_weights->>'popular_opinion')::numeric, 0.2) / 2)::numeric, 4))
+    )
+    WHERE category_weights ? 'popular_opinion'
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE metric_weight_profiles
+    SET category_weights = (
+      category_weights
+      - 'mob'
+      - 'ivory_tower'
+      || jsonb_build_object('popular_opinion',
+           COALESCE((category_weights->>'mob')::numeric, 0)
+           + COALESCE((category_weights->>'ivory_tower')::numeric, 0))
+    )
+    WHERE category_weights ? 'mob' OR category_weights ? 'ivory_tower'
+    """)
+  end
+end

--- a/test/cinegraph/scoring_system_validation_test.exs
+++ b/test/cinegraph/scoring_system_validation_test.exs
@@ -65,12 +65,13 @@ defmodule Cinegraph.ScoringSystemValidationTest do
       end
     end
 
-    test "all 5 categories are present in both systems" do
+    test "all categories are present in both systems" do
       # MovieScoring categories
       movie = %Movie{id: 1, canonical_sources: %{}}
       score_data = MovieScoring.calculate_movie_scores(movie)
 
-      assert Map.has_key?(score_data.components, :popular_opinion)
+      assert Map.has_key?(score_data.components, :mob)
+      assert Map.has_key?(score_data.components, :ivory_tower)
       assert Map.has_key?(score_data.components, :industry_recognition)
       assert Map.has_key?(score_data.components, :cultural_impact)
       assert Map.has_key?(score_data.components, :people_quality)
@@ -80,7 +81,8 @@ defmodule Cinegraph.ScoringSystemValidationTest do
       profile = ScoringService.get_default_profile()
       weights = ScoringService.profile_to_discovery_weights(profile)
 
-      assert Map.has_key?(weights, :popular_opinion)
+      assert Map.has_key?(weights, :mob)
+      assert Map.has_key?(weights, :ivory_tower)
       assert Map.has_key?(weights, :industry_recognition)
       assert Map.has_key?(weights, :cultural_impact)
       assert Map.has_key?(weights, :people_quality)
@@ -99,7 +101,7 @@ defmodule Cinegraph.ScoringSystemValidationTest do
       scoring_service_categories =
         ScoringService.profile_to_discovery_weights(profile) |> Map.keys()
 
-      # Convert to strings for easier comparison
+      # Convert to strings for easier comparison (financial_performance vs financial_success is expected difference)
       movie_scoring_names = Enum.map(movie_scoring_categories, &to_string/1) |> Enum.sort()
 
       scoring_service_names =
@@ -122,7 +124,8 @@ defmodule Cinegraph.ScoringSystemValidationTest do
     test "all categories have human-readable descriptions" do
       # Check that descriptions exist for all categories
       categories = [
-        :popular_opinion,
+        :mob,
+        :ivory_tower,
         :industry_recognition,
         :cultural_impact,
         :people_quality,
@@ -131,7 +134,8 @@ defmodule Cinegraph.ScoringSystemValidationTest do
 
       # These descriptions should be defined in DiscoveryTuner
       descriptions = %{
-        popular_opinion: "All rating sources (IMDb, TMDb, Metacritic, RT)",
+        mob: "Audience ratings (IMDb, TMDb)",
+        ivory_tower: "Critics scores (RT Tomatometer, Metacritic)",
         industry_recognition: "Festival awards and nominations",
         cultural_impact: "Canonical lists and popularity metrics",
         people_quality: "Quality of directors, actors, and crew",
@@ -185,7 +189,8 @@ defmodule Cinegraph.ScoringSystemValidationTest do
         name: "Test Custom Profile",
         description: "Test profile for validation",
         category_weights: %{
-          "popular_opinion" => 0.30,
+          "mob" => 0.15,
+          "ivory_tower" => 0.15,
           "awards" => 0.25,
           "cultural" => 0.20,
           "people" => 0.15,
@@ -204,20 +209,20 @@ defmodule Cinegraph.ScoringSystemValidationTest do
       retrieved = ScoringService.get_profile(created.name)
 
       assert retrieved
-      assert retrieved.category_weights["popular_opinion"] == 0.30
+      assert retrieved.category_weights["mob"] == 0.15
+      assert retrieved.category_weights["ivory_tower"] == 0.15
 
       # Cleanup
       Repo.delete(created)
     end
 
-    test "all weight profiles use the 5-category system" do
+    test "all weight profiles use the 6-category system" do
       profiles = ScoringService.get_all_profiles()
 
       for profile <- profiles do
         weights = profile.category_weights
 
-        # Should have exactly 5 categories (though some may be 0.0)
-        valid_categories = ["popular_opinion", "awards", "cultural", "people", "financial"]
+        valid_categories = ["mob", "ivory_tower", "awards", "cultural", "people", "financial"]
 
         for category <- Map.keys(weights) do
           assert category in valid_categories,
@@ -235,10 +240,11 @@ defmodule Cinegraph.ScoringSystemValidationTest do
 
         # Update weights
         new_weights = %{
-          "popular_opinion" => 0.25,
+          "mob" => 0.15,
+          "ivory_tower" => 0.15,
           "awards" => 0.25,
           "cultural" => 0.20,
-          "people" => 0.20,
+          "people" => 0.15,
           "financial" => 0.10
         }
 
@@ -326,12 +332,15 @@ defmodule Cinegraph.ScoringSystemValidationTest do
 
       # Should have component scores (even if 0)
       assert is_map(score_data.components)
-      assert Map.has_key?(score_data.components, :popular_opinion)
+      assert Map.has_key?(score_data.components, :mob)
+      assert Map.has_key?(score_data.components, :ivory_tower)
 
       # Verify ScoringService queries database
       profile = ScoringService.get_profile("Balanced")
       assert profile
-      assert profile.category_weights["popular_opinion"] > 0
+
+      assert (profile.category_weights["mob"] || 0) +
+               (profile.category_weights["ivory_tower"] || 0) > 0
     end
 
     test "no hard-coded weight values in scoring calculations" do
@@ -373,7 +382,7 @@ defmodule Cinegraph.ScoringSystemValidationTest do
 
       # User can see breakdown
       assert Map.has_key?(score_data, :components)
-      assert map_size(score_data.components) == 5
+      assert map_size(score_data.components) == 6
 
       # All components have values
       for {_category, score} <- score_data.components do
@@ -406,7 +415,7 @@ defmodule Cinegraph.ScoringSystemValidationTest do
 
   describe "SUCCESS CRITERION 7: Maintainability" do
     test "single source of truth for category definitions" do
-      # Both systems should reference the same 5 categories
+      # Both systems should reference the same 6 categories
       movie_categories =
         MovieScoring.calculate_movie_scores(%Movie{id: 1, canonical_sources: %{}}).components
         |> Map.keys()
@@ -418,8 +427,8 @@ defmodule Cinegraph.ScoringSystemValidationTest do
         |> Enum.sort()
 
       # Should have same number of categories
-      assert length(movie_categories) == 5
-      assert length(scoring_service_categories) == 5
+      assert length(movie_categories) == 6
+      assert length(scoring_service_categories) == 6
     end
 
     test "no duplicate scoring logic across modules" do

--- a/test/cinegraph/workers/ratings_refresh_worker_test.exs
+++ b/test/cinegraph/workers/ratings_refresh_worker_test.exs
@@ -109,7 +109,10 @@ defmodule Cinegraph.Workers.RatingsRefreshWorkerTest do
 
     test "re-includes movies whose fetch_attempt is older than 90 days" do
       movie = insert_movie(%{omdb_data: nil})
-      old_fetched_at = DateTime.add(DateTime.utc_now(), -91 * 24 * 3600, :second) |> DateTime.truncate(:second)
+
+      old_fetched_at =
+        DateTime.add(DateTime.utc_now(), -91 * 24 * 3600, :second) |> DateTime.truncate(:second)
+
       insert_fetch_attempt(movie.id, old_fetched_at)
 
       perform_job(RatingsRefreshWorker, %{})


### PR DESCRIPTION
### TL;DR

Split the "popular_opinion" rating category into two separate categories: "mob" (audience ratings) and "ivory_tower" (critics scores) to provide more granular control over rating sources in the movie scoring system.

### What changed?

- Replaced the single "popular_opinion" category with two new categories:
  - "mob": Audience ratings from IMDb and TMDb (weight: 0.10)
  - "ivory_tower": Critics scores from Rotten Tomatoes Tomatometer and Metacritic (weight: 0.10)
- Updated all scoring calculations to use null-aware averaging for each category separately
- Added new virtual fields `mob_score`, `ivory_tower_score`, and `score_confidence` to the Movie schema
- Modified database queries to calculate scores using the new category split
- Updated UI components to display the new categories with appropriate labels and icons
- Added migration to automatically convert existing "popular_opinion" weights by splitting them 50/50 into the new categories
- Maintained backward compatibility by handling legacy "popular_opinion" weights during the transition

### How to test?

1. Run the migration to convert existing weight profiles
2. Verify that movies with different combinations of audience vs. critics ratings show distinct scores for each category
3. Test the discovery tuner UI to ensure both "The Mob" and "The Ivory Tower" sliders work independently
4. Check that existing weight profiles are properly converted and still produce reasonable scores
5. Confirm that the metrics dashboard displays both categories correctly

### Why make this change?

This change provides users with more precise control over how different types of ratings influence movie scores. Previously, audience ratings (IMDb, TMDb) and critics scores (RT, Metacritic) were lumped together, making it impossible to weight popular opinion versus critical acclaim separately. The split allows users to create more nuanced scoring profiles, such as favoring audience preferences over critics or vice versa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced "Popular Opinion" rating with two distinct dimensions: "The Mob" (audience ratings from IMDb/TMDb) and "The Ivory Tower" (critics scores from Rotten Tomatoes/Metacritic)
  * Added new sorting options for movies by mob and ivory tower scores
  * Enhanced movie score breakdown display with separate mob and ivory tower score components and confidence metrics

* **Bug Fixes**
  * Fixed scoring system migration from legacy 5-category to 6-category classification with proper data preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->