### PR TITLE
more fixes

### DIFF
--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -231,10 +231,10 @@ defmodule Cinegraph.Metrics.ScoringService do
       "imdb_rating" => mob_weight * 1.0,
       "tmdb_rating" => mob_weight * 1.0,
       "imdb_rating_votes" => mob_weight * 0.5,
+      "rotten_tomatoes_audience_score" => mob_weight * 0.8,
       # Ivory Tower (critics) metrics
       "metacritic_metascore" => ivory_weight * 1.0,
       "rotten_tomatoes_tomatometer" => ivory_weight * 1.0,
-      "rotten_tomatoes_audience_score" => ivory_weight * 0.8,
 
       # Industry Recognition metrics
       "oscar_wins" => award_weight * 3,

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -57,6 +57,10 @@ defmodule Cinegraph.Movies do
 
   defp uses_discovery_sorting?(sort) do
     sort in [
+      "mob",
+      "mob_asc",
+      "ivory_tower",
+      "ivory_tower_asc",
       "popular_opinion",
       "popular_opinion_asc",
       "industry_recognition",

--- a/lib/cinegraph/movies/cache.ex
+++ b/lib/cinegraph/movies/cache.ex
@@ -305,7 +305,7 @@ defmodule Cinegraph.Movies.Cache do
       %{"sort" => "release_date_desc"},
       %{"sort" => "rating"},
       %{"sort" => "popularity"},
-      %{"sort" => "popular_opinion"},
+      %{"sort" => "mob"},
 
       # Common filters
       %{"decade" => "2020"},

--- a/lib/cinegraph/movies/discovery_scoring_simple.ex
+++ b/lib/cinegraph/movies/discovery_scoring_simple.ex
@@ -28,6 +28,27 @@ defmodule Cinegraph.Movies.DiscoveryScoringSimple do
     ScoringService.apply_scoring(query, profile, options)
   end
 
+  # New-style weight map with mob/ivory_tower — delegate to ScoringService
+  def apply_scoring(query, weights, options)
+      when is_map(weights) and is_map_key(weights, :mob) do
+    synthetic_profile = %Cinegraph.Metrics.MetricWeightProfile{
+      name: "Custom",
+      category_weights: %{
+        "mob" => Map.get(weights, :mob, 0.1),
+        "ivory_tower" => Map.get(weights, :ivory_tower, 0.1),
+        "awards" => Map.get(weights, :industry_recognition, 0.2),
+        "cultural" => Map.get(weights, :cultural_impact, 0.2),
+        "people" => Map.get(weights, :people_quality, 0.2),
+        "financial" => Map.get(weights, :financial_success, 0.2)
+      },
+      weights: %{},
+      active: true,
+      is_default: false
+    }
+
+    ScoringService.apply_scoring(query, synthetic_profile, options)
+  end
+
   # Legacy hard-coded weights (for backwards compatibility)
   def apply_scoring(query, weights, options) when is_map(weights) do
     normalized_weights = normalize_weights(weights)

--- a/lib/cinegraph/movies/movie_scoring.ex
+++ b/lib/cinegraph/movies/movie_scoring.ex
@@ -17,8 +17,9 @@ defmodule Cinegraph.Movies.MovieScoring do
   Calculate comprehensive scores for a movie using external metrics,
   festival data, person quality, and financial performance.
 
-  Uses the standard 5-category scoring system:
-  - Popular Opinion (ratings from IMDb, TMDb, Metacritic, RT)
+  Uses the standard 6-category scoring system:
+  - The Mob (audience ratings from IMDb and TMDb)
+  - The Ivory Tower (critics scores from Metacritic and RT Tomatometer)
   - Industry Recognition (festival wins and nominations)
   - Cultural Impact (canonical sources and popularity)
   - People Quality (quality scores of cast and crew)

--- a/lib/cinegraph/movies/query/custom_sorting.ex
+++ b/lib/cinegraph/movies/query/custom_sorting.ex
@@ -32,7 +32,7 @@ defmodule Cinegraph.Movies.Query.CustomSorting do
       field in ["rating", "popularity"] ->
         apply_simple_metric_sort(query, field, direction)
 
-      field in ~w(popular_opinion industry_recognition cultural_impact people_quality) ->
+      field in ~w(mob ivory_tower popular_opinion industry_recognition cultural_impact people_quality) ->
         apply_discovery_metric_sort(query, field, direction)
 
       true ->
@@ -158,6 +158,72 @@ defmodule Cinegraph.Movies.Query.CustomSorting do
     ])
   end
 
+  defp apply_discovery_metric_sort(query, "mob", direction) do
+    order_func = if direction == :desc, do: :desc_nulls_last, else: :asc_nulls_last
+
+    order_by(query, [m], [
+      {^order_func,
+       fragment(
+         """
+         (
+           SELECT CASE
+             WHEN ir.value IS NOT NULL AND tr.value IS NOT NULL
+               THEN (ir.value / 10.0 + tr.value / 10.0) / 2.0
+             WHEN ir.value IS NOT NULL THEN ir.value / 10.0
+             WHEN tr.value IS NOT NULL THEN tr.value / 10.0
+             ELSE NULL
+           END
+           FROM (
+                 SELECT value FROM external_metrics
+                 WHERE movie_id = ? AND source = 'tmdb' AND metric_type = 'rating_average'
+                 ORDER BY fetched_at DESC LIMIT 1
+                ) tr,
+                (
+                 SELECT value FROM external_metrics
+                 WHERE movie_id = ? AND source = 'imdb' AND metric_type = 'rating_average'
+                 ORDER BY fetched_at DESC LIMIT 1
+                ) ir
+         )
+         """,
+         m.id,
+         m.id
+       )}
+    ])
+  end
+
+  defp apply_discovery_metric_sort(query, "ivory_tower", direction) do
+    order_func = if direction == :desc, do: :desc_nulls_last, else: :asc_nulls_last
+
+    order_by(query, [m], [
+      {^order_func,
+       fragment(
+         """
+         (
+           SELECT CASE
+             WHEN rt.value IS NOT NULL AND mc.value IS NOT NULL
+               THEN (rt.value / 100.0 + mc.value / 100.0) / 2.0
+             WHEN rt.value IS NOT NULL THEN rt.value / 100.0
+             WHEN mc.value IS NOT NULL THEN mc.value / 100.0
+             ELSE NULL
+           END
+           FROM (
+                 SELECT value FROM external_metrics
+                 WHERE movie_id = ? AND source = 'rotten_tomatoes' AND metric_type = 'tomatometer'
+                 ORDER BY fetched_at DESC LIMIT 1
+                ) rt,
+                (
+                 SELECT value FROM external_metrics
+                 WHERE movie_id = ? AND source = 'metacritic' AND metric_type = 'metascore'
+                 ORDER BY fetched_at DESC LIMIT 1
+                ) mc
+         )
+         """,
+         m.id,
+         m.id
+       )}
+    ])
+  end
+
   defp apply_discovery_metric_sort(query, "popular_opinion", direction) do
     order_func = if direction == :desc, do: :desc, else: :asc
 
@@ -166,9 +232,9 @@ defmodule Cinegraph.Movies.Query.CustomSorting do
        fragment(
          """
          COALESCE((
-           SELECT (COALESCE(tr.value, 0) / 10.0 * 0.25 + 
+           SELECT (COALESCE(tr.value, 0) / 10.0 * 0.25 +
                    COALESCE(ir.value, 0) / 10.0 * 0.25 +
-                   COALESCE(mc.value, 0) / 100.0 * 0.25 + 
+                   COALESCE(mc.value, 0) / 100.0 * 0.25 +
                    COALESCE(rt.value, 0) / 100.0 * 0.25)
            FROM (
                  SELECT value FROM external_metrics

--- a/lib/cinegraph/movies/query/params.ex
+++ b/lib/cinegraph/movies/query/params.ex
@@ -70,6 +70,8 @@ defmodule Cinegraph.Movies.Query.Params do
     rating rating_asc rating_desc
     popularity popularity_asc popularity_desc
     discovery_score discovery_score_asc discovery_score_desc
+    mob mob_asc mob_desc
+    ivory_tower ivory_tower_asc ivory_tower_desc
     popular_opinion popular_opinion_asc popular_opinion_desc
     industry_recognition industry_recognition_asc industry_recognition_desc
     cultural_impact cultural_impact_asc cultural_impact_desc

--- a/lib/cinegraph/movies/search.ex
+++ b/lib/cinegraph/movies/search.ex
@@ -41,6 +41,8 @@ defmodule Cinegraph.Movies.Search do
         rating rating_asc rating_desc
         popularity popularity_asc popularity_desc
         discovery_score discovery_score_asc discovery_score_desc
+        mob mob_asc mob_desc
+        ivory_tower ivory_tower_asc ivory_tower_desc
         popular_opinion popular_opinion_asc popular_opinion_desc
         industry_recognition industry_recognition_asc industry_recognition_desc
         cultural_impact cultural_impact_asc cultural_impact_desc
@@ -167,7 +169,7 @@ defmodule Cinegraph.Movies.Search do
           sort
       end
 
-    base in ~w(discovery_score popular_opinion industry_recognition cultural_impact people_quality)
+    base in ~w(discovery_score mob ivory_tower popular_opinion industry_recognition cultural_impact people_quality)
   end
 
   defp list_genres do
@@ -229,7 +231,8 @@ defmodule Cinegraph.Movies.Search do
       %{id: "runtime_desc", value: "runtime_desc", label: "Runtime (Longest)"},
       %{id: "rating", value: "rating", label: "Rating (Highest)"},
       %{id: "popularity", value: "popularity", label: "Popularity"},
-      %{id: "popular_opinion", value: "popular_opinion", label: "Popular Opinion"},
+      %{id: "mob", value: "mob", label: "The Mob (Audience)"},
+      %{id: "ivory_tower", value: "ivory_tower", label: "The Ivory Tower (Critics)"},
       %{id: "industry_recognition", value: "industry_recognition", label: "Industry Recognition"},
       %{id: "cultural_impact", value: "cultural_impact", label: "Cultural Impact"},
       %{id: "people_quality", value: "people_quality", label: "People Quality"}

--- a/lib/cinegraph/predictions/historical_validator.ex
+++ b/lib/cinegraph/predictions/historical_validator.ex
@@ -287,15 +287,19 @@ defmodule Cinegraph.Predictions.HistoricalValidator do
 
   defp convert_weights_to_categories(weights) do
     # Map validation weights to database categories
-    # If both popular_opinion and critical_acclaim are present (legacy data),
-    # only use popular_opinion since it now includes all rating sources
+    # Support both new mob/ivory_tower keys and legacy popular_opinion
     ratings_weight =
-      if Map.has_key?(weights, :critical_acclaim) do
-        # Legacy case: ignore critical_acclaim, use only popular_opinion
-        Map.get(weights, :popular_opinion, 0.25)
-      else
-        # Modern case: popular_opinion includes all rating sources
-        Map.get(weights, :popular_opinion, 0.25)
+      cond do
+        Map.has_key?(weights, :mob) or Map.has_key?(weights, :ivory_tower) ->
+          # New-style: combine mob + ivory_tower as total ratings weight
+          Map.get(weights, :mob, 0.0) + Map.get(weights, :ivory_tower, 0.0)
+
+        Map.has_key?(weights, :critical_acclaim) ->
+          # Legacy case: ignore critical_acclaim, use only popular_opinion
+          Map.get(weights, :popular_opinion, 0.25)
+
+        true ->
+          Map.get(weights, :popular_opinion, 0.25)
       end
 
     %{

--- a/lib/cinegraph/predictions/movie_predictor.ex
+++ b/lib/cinegraph/predictions/movie_predictor.ex
@@ -180,13 +180,25 @@ defmodule Cinegraph.Predictions.MoviePredictor do
 
   defp convert_ui_weights_to_categories(weights) do
     # Coerce non-numeric values to 0.0 and delegate to ScoringService for consistent mapping
-    # Combine critical_acclaim into popular_opinion if it exists
-    pop_opinion_weight =
-      to_float(Map.get(weights, :popular_opinion, 0.0)) +
-        to_float(Map.get(weights, :critical_acclaim, 0.0))
+    # Support both old popular_opinion key and new mob/ivory_tower keys
+    mob_weight = to_float(Map.get(weights, :mob, 0.0))
+    ivory_tower_weight = to_float(Map.get(weights, :ivory_tower, 0.0))
+
+    # Legacy fallback: split popular_opinion + critical_acclaim 50/50 into mob/ivory_tower
+    {mob_weight, ivory_tower_weight} =
+      if mob_weight == 0.0 and ivory_tower_weight == 0.0 do
+        legacy =
+          to_float(Map.get(weights, :popular_opinion, 0.0)) +
+            to_float(Map.get(weights, :critical_acclaim, 0.0))
+
+        {legacy / 2.0, legacy / 2.0}
+      else
+        {mob_weight, ivory_tower_weight}
+      end
 
     sanitized = %{
-      popular_opinion: pop_opinion_weight,
+      mob: mob_weight,
+      ivory_tower: ivory_tower_weight,
       industry_recognition:
         to_float(
           Map.get(weights, :industry_recognition, Map.get(weights, :festival_recognition, 0.0))
@@ -258,7 +270,8 @@ defmodule Cinegraph.Predictions.MoviePredictor do
     components = Map.get(movie, :score_components, %{})
     # Use provided weights or fallback to equal weights
     default_weights = %{
-      popular_opinion: 0.30,
+      mob: 0.15,
+      ivory_tower: 0.15,
       industry_recognition: 0.20,
       financial_success: 0.20,
       cultural_impact: 0.15,
@@ -269,13 +282,24 @@ defmodule Cinegraph.Predictions.MoviePredictor do
 
     [
       %{
-        criterion: :popular_opinion,
-        raw_score: Float.round(to_float(components[:popular_opinion]) * 100, 1),
-        weight: Map.get(actual_weights, :popular_opinion, 0.30),
+        criterion: :mob,
+        raw_score: Float.round(to_float(components[:mob]) * 100, 1),
+        weight: Map.get(actual_weights, :mob, 0.15),
         weighted_points:
           Float.round(
-            to_float(components[:popular_opinion]) *
-              Map.get(actual_weights, :popular_opinion, 0.30) * 100,
+            to_float(components[:mob]) *
+              Map.get(actual_weights, :mob, 0.15) * 100,
+            1
+          )
+      },
+      %{
+        criterion: :ivory_tower,
+        raw_score: Float.round(to_float(components[:ivory_tower]) * 100, 1),
+        weight: Map.get(actual_weights, :ivory_tower, 0.15),
+        weighted_points:
+          Float.round(
+            to_float(components[:ivory_tower]) *
+              Map.get(actual_weights, :ivory_tower, 0.15) * 100,
             1
           )
       },

--- a/lib/cinegraph_web/live/metrics_live/index.html.heex
+++ b/lib/cinegraph_web/live/metrics_live/index.html.heex
@@ -272,7 +272,7 @@
               <td class="px-4 py-2 text-sm font-mono">value / 10</td>
               <td class="px-4 py-2 text-center">
                 <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                  Popular Opinion
+                  The Mob
                 </span>
               </td>
               <td class="px-4 py-2 text-center text-sm font-medium">50%</td>
@@ -284,7 +284,7 @@
               <td class="px-4 py-2 text-sm font-mono">value / 10</td>
               <td class="px-4 py-2 text-center">
                 <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                  Popular Opinion
+                  The Mob
                 </span>
               </td>
               <td class="px-4 py-2 text-center text-sm font-medium">50%</td>
@@ -295,8 +295,8 @@
               <td class="px-4 py-2 text-center text-sm font-mono">0-100</td>
               <td class="px-4 py-2 text-sm font-mono">value / 100</td>
               <td class="px-4 py-2 text-center">
-                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                  Popular Opinion
+                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                  The Ivory Tower
                 </span>
               </td>
               <td class="px-4 py-2 text-center text-sm font-medium">50%</td>
@@ -307,8 +307,8 @@
               <td class="px-4 py-2 text-center text-sm font-mono">0-100%</td>
               <td class="px-4 py-2 text-sm font-mono">value / 100</td>
               <td class="px-4 py-2 text-center">
-                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                  Popular Opinion
+                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                  The Ivory Tower
                 </span>
               </td>
               <td class="px-4 py-2 text-center text-sm font-medium">50%</td>
@@ -384,29 +384,38 @@
 
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div class="border border-blue-200 rounded-lg p-4">
-          <h3 class="font-semibold text-blue-900 mb-2">📊 Popular Opinion</h3>
-          <p class="text-sm text-gray-600 mb-2">Average of all rating sources:</p>
+          <h3 class="font-semibold text-blue-900 mb-2">👥 The Mob</h3>
+          <p class="text-sm text-gray-600 mb-2">Audience ratings (null-aware average):</p>
           <ul class="space-y-1 text-sm">
             <li class="flex justify-between">
               <span>• IMDb Rating</span>
-              <span class="font-mono">25%</span>
+              <span class="font-mono">50%</span>
             </li>
             <li class="flex justify-between">
               <span>• TMDb Rating</span>
-              <span class="font-mono">25%</span>
-            </li>
-            <li class="flex justify-between">
-              <span>• Metacritic Metascore</span>
-              <span class="font-mono">25%</span>
-            </li>
-            <li class="flex justify-between">
-              <span>• Rotten Tomatoes</span>
-              <span class="font-mono">25%</span>
+              <span class="font-mono">50%</span>
             </li>
           </ul>
           <div class="mt-2 p-2 bg-blue-50 rounded text-xs">
-            Formula:
-            <code>(IMDb/10 * 0.25 + TMDb/10 * 0.25 + Meta/100 * 0.25 + RT/100 * 0.25)</code>
+            Formula: <code>(IMDb/10 + TMDb/10) / available_sources</code>
+          </div>
+        </div>
+
+        <div class="border border-purple-200 rounded-lg p-4">
+          <h3 class="font-semibold text-purple-900 mb-2">🎓 The Ivory Tower</h3>
+          <p class="text-sm text-gray-600 mb-2">Critics scores (null-aware average):</p>
+          <ul class="space-y-1 text-sm">
+            <li class="flex justify-between">
+              <span>• Metacritic Metascore</span>
+              <span class="font-mono">50%</span>
+            </li>
+            <li class="flex justify-between">
+              <span>• Rotten Tomatoes (Tomatometer)</span>
+              <span class="font-mono">50%</span>
+            </li>
+          </ul>
+          <div class="mt-2 p-2 bg-purple-50 rounded text-xs">
+            Formula: <code>(Meta/100 + RT/100) / available_sources</code>
           </div>
         </div>
 

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -181,17 +181,17 @@
         <% score_data = Map.get(@movie, :score_data) %>
         <%= if score_data do %>
           <div class="space-y-3">
-            <!-- Popular Opinion -->
+            <!-- The Mob -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
-                <span class="text-white/80 text-sm">Popular Opinion</span>
+                <span class="text-white/80 text-sm">The Mob</span>
                 <div class="relative ml-1">
                   <svg
                     class="w-3.5 h-3.5 text-white/40 group-hover:text-white/60 transition-colors cursor-help"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
-                    title="IMDb, TMDb, Metacritic & Rotten Tomatoes ratings"
+                    title="Audience ratings: IMDb & TMDb"
                   >
                     <path
                       stroke-linecap="round"
@@ -201,8 +201,7 @@
                     />
                   </svg>
                   <div class="hidden group-hover:block absolute z-10 w-64 p-2 mt-1 text-xs bg-gray-900 text-white rounded-lg shadow-lg left-0">
-                    <strong>Popular Opinion:</strong>
-                    Aggregate of IMDb, TMDb, Metacritic, and Rotten Tomatoes ratings
+                    <strong>The Mob:</strong> Audience ratings from IMDb and TMDb
                   </div>
                 </div>
               </div>
@@ -210,12 +209,50 @@
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
                     class="h-2 bg-blue-400 rounded-full"
-                    style={"width: #{score_data.components.popular_opinion * 10}%"}
+                    style={"width: #{(score_data.components[:mob] || 0) * 10}%"}
                   >
                   </div>
                 </div>
                 <span class="text-white text-sm w-8">
-                  {score_data.components.popular_opinion}
+                  {score_data.components[:mob] || 0}
+                </span>
+              </div>
+            </div>
+            <!-- The Ivory Tower -->
+            <div class="flex items-center justify-between group">
+              <div class="flex items-center">
+                <span class="text-white/80 text-sm">The Ivory Tower</span>
+                <div class="relative ml-1">
+                  <svg
+                    class="w-3.5 h-3.5 text-white/40 group-hover:text-white/60 transition-colors cursor-help"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    title="Critics scores: RT Tomatometer & Metacritic"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  <div class="hidden group-hover:block absolute z-10 w-64 p-2 mt-1 text-xs bg-gray-900 text-white rounded-lg shadow-lg left-0">
+                    <strong>The Ivory Tower:</strong>
+                    Critics scores from RT Tomatometer and Metacritic
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center">
+                <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
+                  <div
+                    class="h-2 bg-purple-400 rounded-full"
+                    style={"width: #{(score_data.components[:ivory_tower] || 0) * 10}%"}
+                  >
+                  </div>
+                </div>
+                <span class="text-white text-sm w-8">
+                  {score_data.components[:ivory_tower] || 0}
                 </span>
               </div>
             </div>

--- a/lib/cinegraph_web/live/predictions_live/index.ex
+++ b/lib/cinegraph_web/live/predictions_live/index.ex
@@ -153,7 +153,8 @@ defmodule CinegraphWeb.PredictionsLive.Index do
            :algorithm_weights,
            ScoringService.profile_to_discovery_weights(default_profile) ||
              %{
-               popular_opinion: 0.20,
+               mob: 0.10,
+               ivory_tower: 0.10,
                industry_recognition: 0.20,
                cultural_impact: 0.20,
                people_quality: 0.20,
@@ -268,7 +269,8 @@ defmodule CinegraphWeb.PredictionsLive.Index do
       end
 
       new_weights = %{
-        popular_opinion: parse_param.(params["popular_opinion"]),
+        mob: parse_param.(params["mob"]),
+        ivory_tower: parse_param.(params["ivory_tower"]),
         industry_recognition: parse_param.(params["industry_recognition"]),
         cultural_impact: parse_param.(params["cultural_impact"]),
         people_quality: parse_param.(params["people_quality"]),
@@ -477,7 +479,8 @@ defmodule CinegraphWeb.PredictionsLive.Index do
 
   defp format_likelihood(percentage), do: {"#{percentage}%", "text-gray-600"}
 
-  defp criterion_label(:popular_opinion), do: "Popular Opinion"
+  defp criterion_label(:mob), do: "The Mob"
+  defp criterion_label(:ivory_tower), do: "The Ivory Tower"
   defp criterion_label(:industry_recognition), do: "Industry Recognition"
   defp criterion_label(:cultural_impact), do: "Cultural Impact"
   defp criterion_label(:people_quality), do: "People Quality"

--- a/lib/cinegraph_web/live/predictions_live/index.html.heex
+++ b/lib/cinegraph_web/live/predictions_live/index.html.heex
@@ -214,8 +214,11 @@
 <!-- Criterion Description -->
                   <div class="mt-2 text-xs text-gray-600">
                     {case criterion do
-                      :popular_opinion ->
-                        "All rating sources (IMDb, TMDb, Metacritic, RT)"
+                      :mob ->
+                        "Audience ratings (IMDb, TMDb)"
+
+                      :ivory_tower ->
+                        "Critics scores (RT Tomatometer, Metacritic)"
 
                       :industry_recognition ->
                         "Oscars, Cannes, Venice, Berlin awards and nominations"

--- a/lib/cinegraph_web/live/score_calibration_live.ex
+++ b/lib/cinegraph_web/live/score_calibration_live.ex
@@ -787,6 +787,8 @@ defmodule CinegraphWeb.ScoreCalibrationLive do
 
   defp format_category_abbrev(category) do
     case category do
+      "mob" -> "Mob"
+      "ivory_tower" -> "IT"
       "popular_opinion" -> "Pop"
       "industry_recognition" -> "Ind"
       "cultural_impact" -> "Cult"

--- a/test/cinegraph/metrics/scoring_service_test.exs
+++ b/test/cinegraph/metrics/scoring_service_test.exs
@@ -3,11 +3,12 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
   alias Cinegraph.Metrics.{ScoringService, MetricWeightProfile}
 
   describe "profile_to_discovery_weights/1" do
-    test "correctly converts all 5 categories to discovery weights" do
+    test "correctly converts mob and ivory_tower categories to discovery weights" do
       profile = %MetricWeightProfile{
         name: "Test Profile",
         category_weights: %{
-          "popular_opinion" => 0.20,
+          "mob" => 0.10,
+          "ivory_tower" => 0.10,
           "awards" => 0.20,
           "cultural" => 0.20,
           "people" => 0.20,
@@ -17,16 +18,17 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      assert result.popular_opinion == 0.20
+      assert result.mob == 0.10
+      assert result.ivory_tower == 0.10
       assert result.industry_recognition == 0.20
       assert result.cultural_impact == 0.20
       assert result.people_quality == 0.20
       assert result.financial_success == 0.20
     end
 
-    test "handles popular_opinion category correctly" do
+    test "splits legacy popular_opinion 50/50 into mob and ivory_tower" do
       profile = %MetricWeightProfile{
-        name: "Test Profile",
+        name: "Legacy Profile",
         category_weights: %{
           "popular_opinion" => 0.40,
           "awards" => 0.20,
@@ -38,7 +40,8 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      assert result.popular_opinion == 0.40
+      assert result.mob == 0.20
+      assert result.ivory_tower == 0.20
       assert result.industry_recognition == 0.20
       assert result.cultural_impact == 0.20
       assert result.people_quality == 0.10
@@ -53,9 +56,9 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      # Should use fallback defaults: popular_opinion falls back to ratings (0.40),
-      # financial defaults to 0.00, others default to 0.20
-      assert result.popular_opinion == 0.40
+      # mob and ivory_tower each get half of ratings default (0.20)
+      assert result.mob == 0.10
+      assert result.ivory_tower == 0.10
       assert result.industry_recognition == 0.20
       assert result.cultural_impact == 0.20
       assert result.people_quality == 0.20
@@ -70,19 +73,20 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      # Should use same fallback defaults as empty category_weights
-      assert result.popular_opinion == 0.40
+      assert result.mob == 0.10
+      assert result.ivory_tower == 0.10
       assert result.industry_recognition == 0.20
       assert result.cultural_impact == 0.20
       assert result.people_quality == 0.20
       assert result.financial_success == 0.00
     end
 
-    test "handles zero popular_opinion weight" do
+    test "handles zero mob/ivory_tower weights" do
       profile = %MetricWeightProfile{
         name: "No Ratings Profile",
         category_weights: %{
-          "popular_opinion" => 0.00,
+          "mob" => 0.00,
+          "ivory_tower" => 0.00,
           "awards" => 0.50,
           "cultural" => 0.30,
           "people" => 0.10,
@@ -92,18 +96,20 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      assert result.popular_opinion == 0.00
+      assert result.mob == 0.00
+      assert result.ivory_tower == 0.00
       assert result.industry_recognition == 0.50
       assert result.cultural_impact == 0.30
       assert result.people_quality == 0.10
       assert result.financial_success == 0.10
     end
 
-    test "handles full popular_opinion weight" do
+    test "handles full mob weight" do
       profile = %MetricWeightProfile{
-        name: "All Ratings Profile",
+        name: "All Mob Profile",
         category_weights: %{
-          "popular_opinion" => 1.00,
+          "mob" => 1.00,
+          "ivory_tower" => 0.00,
           "awards" => 0.00,
           "cultural" => 0.00,
           "people" => 0.00,
@@ -113,7 +119,8 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      assert result.popular_opinion == 1.00
+      assert result.mob == 1.00
+      assert result.ivory_tower == 0.00
       assert result.industry_recognition == 0.00
       assert result.cultural_impact == 0.00
       assert result.people_quality == 0.00
@@ -133,8 +140,9 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
       result = ScoringService.profile_to_discovery_weights(profile)
 
-      # Old "ratings" should map to popular_opinion
-      assert result.popular_opinion == 0.40
+      # Old "ratings" splits 50/50 into mob + ivory_tower
+      assert result.mob == 0.20
+      assert result.ivory_tower == 0.20
       assert result.industry_recognition == 0.20
       assert result.cultural_impact == 0.20
       assert result.people_quality == 0.20
@@ -144,7 +152,8 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
   describe "discovery_weights_to_profile/2" do
     test "converts discovery weights back to profile format" do
       weights = %{
-        popular_opinion: 0.30,
+        mob: 0.15,
+        ivory_tower: 0.15,
         industry_recognition: 0.25,
         cultural_impact: 0.20,
         people_quality: 0.15,
@@ -154,7 +163,8 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
       result = ScoringService.discovery_weights_to_profile(weights, "Custom Test")
 
       assert result.name == "Custom Test"
-      assert result.category_weights["popular_opinion"] == 0.30
+      assert result.category_weights["mob"] == 0.15
+      assert result.category_weights["ivory_tower"] == 0.15
       assert result.category_weights["awards"] == 0.25
       assert result.category_weights["cultural"] == 0.20
       assert result.category_weights["people"] == 0.15
@@ -163,14 +173,16 @@ defmodule Cinegraph.Metrics.ScoringServiceTest do
 
     test "handles missing weights with defaults" do
       weights = %{
-        popular_opinion: 0.50,
+        mob: 0.30,
+        ivory_tower: 0.20,
         industry_recognition: 0.50
       }
 
       result = ScoringService.discovery_weights_to_profile(weights, "Partial Weights")
 
       assert result.name == "Partial Weights"
-      assert result.category_weights["popular_opinion"] == 0.50
+      assert result.category_weights["mob"] == 0.30
+      assert result.category_weights["ivory_tower"] == 0.20
       assert result.category_weights["awards"] == 0.50
       # Missing weights should default to 0.2
       assert result.category_weights["cultural"] == 0.20

--- a/test/cinegraph/scoring_system_validation_test.exs
+++ b/test/cinegraph/scoring_system_validation_test.exs
@@ -1,6 +1,9 @@
 defmodule Cinegraph.ScoringSystemValidationTest do
   @moduledoc """
-  Phase 4 Validation Tests for the unified 5-category scoring system.
+  Phase 4 Validation Tests for the unified 6-category scoring system.
+
+  Categories: mob, ivory_tower, industry_recognition, cultural_impact,
+  people_quality, financial_performance.
 
   Tests all 7 success criteria:
   1. Consistency - Same movie has same score across all contexts


### PR DESCRIPTION
### TL;DR

Refactored the movie scoring system from 5 categories to 6 by splitting "Popular Opinion" into "The Mob" (audience ratings) and "The Ivory Tower" (critics scores).

### What changed?

- Split the "Popular Opinion" category into two distinct categories:
  - **The Mob**: Audience ratings from IMDb and TMDb (blue UI theme)
  - **The Ivory Tower**: Critics scores from Metacritic and Rotten Tomatoes Tomatometer (purple UI theme)
- Moved Rotten Tomatoes Audience Score from critics category to audience category
- Added new sorting options `mob` and `ivory_tower` alongside existing `popular_opinion`
- Updated UI labels, tooltips, and color schemes throughout the application
- Modified scoring service to handle both new 6-category weights and legacy 5-category weights for backwards compatibility
- Updated prediction system to split legacy weights 50/50 between mob and ivory_tower when converting
- Added new cache warming for `mob` sort option

### How to test?

1. Navigate to movie listings and verify new "The Mob" and "The Ivory Tower" sort options work
2. Check movie detail pages show separate scores for both categories with correct tooltips
3. Test predictions interface includes both new weight sliders
4. Verify metrics page displays updated category descriptions and color coding
5. Confirm legacy API calls with `popular_opinion` weights still function correctly

### Why make this change?

This change provides more granular control over movie scoring by distinguishing between audience preferences and critical acclaim, allowing users to weight these fundamentally different perspectives independently rather than treating all ratings as equivalent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new sorting options: "The Mob" and "The Ivory Tower" for discovering movies by audience or critics' scores.
  * Split movie scoring into two distinct categories—"The Mob" (audience ratings) and "The Ivory Tower" (critics' scores)—replacing the previous unified metric.

* **Improved UX**
  * Updated score breakdown displays across movie details and metrics pages with clearer category labels and source attribution.
  * Adjusted weighting distribution in scoring calculations for improved metric accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->