### PR TITLE
final changes

### DIFF
--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -400,15 +400,15 @@ defmodule Cinegraph.Metrics.ScoringService do
           fragment(
             """
             ? * CASE
-              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
-              WHEN ? IS NOT NULL THEN ? / 10.0
-              WHEN ? IS NOT NULL THEN ? / 10.0
+              WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
               ELSE 0.0
             END +
             ? * CASE
-              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
-              WHEN ? IS NOT NULL THEN ? / 100.0
-              WHEN ? IS NOT NULL THEN ? / 100.0
+              WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
               ELSE 0.0
             END +
             ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
@@ -457,7 +457,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           ),
         mob_score:
           fragment(
-            "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 10.0 WHEN ? IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
+            "CASE WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
             ir.value,
             tr.value,
             ir.value,
@@ -469,7 +469,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           ),
         ivory_tower_score:
           fragment(
-            "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 100.0 WHEN ? IS NOT NULL THEN ? / 100.0 ELSE 0.0 END",
+            "CASE WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0 ELSE 0.0 END",
             rt.value,
             mc.value,
             rt.value,
@@ -490,7 +490,7 @@ defmodule Cinegraph.Metrics.ScoringService do
         score_components: %{
           mob:
             fragment(
-              "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 10.0 WHEN ? IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
+              "CASE WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
               ir.value,
               tr.value,
               ir.value,
@@ -502,7 +502,7 @@ defmodule Cinegraph.Metrics.ScoringService do
             ),
           ivory_tower:
             fragment(
-              "CASE WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0 WHEN ? IS NOT NULL THEN ? / 100.0 WHEN ? IS NOT NULL THEN ? / 100.0 ELSE 0.0 END",
+              "CASE WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0 ELSE 0.0 END",
               rt.value,
               mc.value,
               rt.value,
@@ -573,15 +573,15 @@ defmodule Cinegraph.Metrics.ScoringService do
           fragment(
             """
             ? * CASE
-              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
               ELSE 0.0
             END +
             ? * CASE
-              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
               ELSE 0.0
             END +
             ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) +
@@ -631,7 +631,7 @@ defmodule Cinegraph.Metrics.ScoringService do
         score_components: %{
           mob:
             fragment(
-              "CASE WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0 ELSE 0.0 END",
+              "CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0 WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0 WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0 ELSE 0.0 END",
               ir.value,
               tr.value,
               ir.value,
@@ -643,7 +643,7 @@ defmodule Cinegraph.Metrics.ScoringService do
             ),
           ivory_tower:
             fragment(
-              "CASE WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0 WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0 ELSE 0.0 END",
+              "CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0 WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0 WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0 ELSE 0.0 END",
               rt.value,
               mc.value,
               rt.value,
@@ -712,15 +712,15 @@ defmodule Cinegraph.Metrics.ScoringService do
         fragment(
           """
           ? * CASE
-            WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
-            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
-            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+            WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
+            WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
+            WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
             ELSE 0.0
           END +
           ? * CASE
-            WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
-            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
-            WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+            WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
+            WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
+            WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
             ELSE 0.0
           END +
           ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) +
@@ -787,15 +787,15 @@ defmodule Cinegraph.Metrics.ScoringService do
         fragment(
           """
           ? * CASE
-            WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
-            WHEN ? IS NOT NULL THEN ? / 10.0
-            WHEN ? IS NOT NULL THEN ? / 10.0
+            WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
+            WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
+            WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
             ELSE 0.0
           END +
           ? * CASE
-            WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
-            WHEN ? IS NOT NULL THEN ? / 100.0
-            WHEN ? IS NOT NULL THEN ? / 100.0
+            WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
+            WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
+            WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
             ELSE 0.0
           END +
           ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +
@@ -867,15 +867,15 @@ defmodule Cinegraph.Metrics.ScoringService do
           fragment(
             """
             ? * CASE
-              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 10.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
               ELSE 0.0
             END +
             ? * CASE
-              WHEN MAX(?) IS NOT NULL AND MAX(?) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
-              WHEN MAX(?) IS NOT NULL THEN MAX(?) / 100.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
+              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
               ELSE 0.0
             END +
             ? * COALESCE(LEAST(1.0, (COALESCE(MAX(?), 0) * 0.2 + COALESCE(MAX(?), 0) * 0.05)), 0) +
@@ -942,15 +942,15 @@ defmodule Cinegraph.Metrics.ScoringService do
           fragment(
             """
             ? * CASE
-              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
-              WHEN ? IS NOT NULL THEN ? / 10.0
-              WHEN ? IS NOT NULL THEN ? / 10.0
+              WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
               ELSE 0.0
             END +
             ? * CASE
-              WHEN ? IS NOT NULL AND ? IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
-              WHEN ? IS NOT NULL THEN ? / 100.0
-              WHEN ? IS NOT NULL THEN ? / 100.0
+              WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
+              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
               ELSE 0.0
             END +
             ? * COALESCE(LEAST(1.0, (COALESCE(?, 0) * 0.2 + COALESCE(?, 0) * 0.05)), 0) +


### PR DESCRIPTION
### TL;DR

Modified SQL scoring queries to treat zero values as NULL using `NULLIF(?, 0)` instead of checking only for `IS NOT NULL`.

### What changed?

Replaced all `IS NOT NULL` conditions in SQL fragments with `NULLIF(?, 0) IS NOT NULL` throughout the scoring service. This affects both individual value checks and `MAX()` aggregated value checks in the mob score and ivory tower score calculations.

### How to test?

Test scoring calculations with movies/shows that have zero values for ratings (IMDB, Tomatoes, Rotten Tomatoes, Metacritic) to ensure they are now treated as missing data rather than valid scores in the weighted calculations.

### Why make this change?

Zero ratings should be treated as missing data rather than valid scores of zero. Previously, a rating of 0 would be considered a valid score and included in calculations, potentially skewing results. With this change, zero values are properly excluded from scoring calculations, ensuring more accurate weighted averages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the scoring system to correctly handle zero values in metric calculations. Zero ratings and baseline values are now treated as missing data rather than valid data points, preventing them from inflating score averages and normalization processes. This delivers more accurate content discovery rankings and better overall scoring performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->