### PR TITLE
tiny

### DIFF
--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -481,7 +481,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           ),
         score_confidence:
           fragment(
-            "(CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN ? IS NOT NULL THEN 1 ELSE 0 END) / 4.0",
+            "(CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END) / 4.0",
             ir.value,
             tr.value,
             rt.value,

--- a/lib/cinegraph/movies/movie_scoring.ex
+++ b/lib/cinegraph/movies/movie_scoring.ex
@@ -166,7 +166,13 @@ defmodule Cinegraph.Movies.MovieScoring do
   """
   def calculate_score_confidence(metrics) do
     keys = [:imdb_rating, :tmdb_rating, :rt_tomatometer, :metacritic]
-    present = Enum.count(keys, &(not is_nil(Map.get(metrics, &1))))
+
+    present =
+      Enum.count(keys, fn k ->
+        v = Map.get(metrics, k)
+        not is_nil(v) and v != 0
+      end)
+
     present / 4.0
   end
 


### PR DESCRIPTION
### TL;DR

Fixed score confidence calculation to treat zero values as missing data instead of valid ratings.

### What changed?

Modified the score confidence calculation in both the database query and Elixir code to exclude zero values when determining how many rating sources are present. The SQL fragment now uses `NULLIF(?, 0)` to convert zeros to NULL before checking, and the Elixir function adds an additional condition `v != 0` alongside the existing nil check.

### How to test?

Test with movies that have zero values in their rating fields (imdb_rating, tmdb_rating, rt_tomatometer, metacritic) and verify that the score_confidence reflects only non-zero, non-null values in the calculation.

### Why make this change?

Zero ratings likely represent missing or invalid data rather than actual ratings of zero, so they should not contribute to the confidence score calculation. This ensures the confidence metric accurately reflects the number of legitimate rating sources available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed confidence score calculation to properly handle missing rating data. Values of 0 are now treated as absent when determining metric presence, resulting in more accurate confidence assessments for scoring data completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->