### PR TITLE
pre phase 3

### DIFF
--- a/lib/cinegraph/calibration.ex
+++ b/lib/cinegraph/calibration.ex
@@ -665,7 +665,8 @@ defmodule Cinegraph.Calibration do
     weights = Map.get(config, :category_weights, %{})
 
     # Get component scores
-    popular = get_popular_opinion_score(movie.id)
+    mob = get_mob_score(movie.id)
+    ivory_tower = get_ivory_tower_score(movie.id)
     awards = get_awards_score(movie.id)
     cultural = get_cultural_score(movie.id)
     people = get_people_score(movie.id)
@@ -673,7 +674,8 @@ defmodule Cinegraph.Calibration do
 
     # Apply weights and missing data strategies
     components = [
-      {popular, Map.get(weights, "popular_opinion", 0.2), "popular_opinion"},
+      {mob, Map.get(weights, "mob", 0.1), "mob"},
+      {ivory_tower, Map.get(weights, "ivory_tower", 0.1), "ivory_tower"},
       {awards, Map.get(weights, "industry_recognition", 0.2), "industry_recognition"},
       {cultural, Map.get(weights, "cultural_impact", 0.2), "cultural_impact"},
       {people, Map.get(weights, "people_quality", 0.2), "people_quality"},
@@ -709,13 +711,35 @@ defmodule Cinegraph.Calibration do
     end
   end
 
-  defp get_popular_opinion_score(movie_id) do
+  defp get_mob_score(movie_id) do
     query = """
-    SELECT AVG(value)
+    SELECT AVG(CASE
+      WHEN source = 'imdb' AND metric_type = 'rating_average' THEN value
+      WHEN source = 'tmdb' AND metric_type = 'rating_average' THEN value
+      WHEN source = 'rotten_tomatoes' AND metric_type = 'audience_score' THEN value / 10.0
+    END)
     FROM external_metrics
     WHERE movie_id = $1
-      AND source IN ('imdb', 'tmdb')
-      AND metric_type = 'rating_average'
+      AND ((source IN ('imdb', 'tmdb') AND metric_type = 'rating_average')
+        OR (source = 'rotten_tomatoes' AND metric_type = 'audience_score'))
+    """
+
+    case Repo.query(query, [movie_id]) do
+      {:ok, %{rows: [[score]]}} -> to_float(score)
+      _ -> nil
+    end
+  end
+
+  defp get_ivory_tower_score(movie_id) do
+    query = """
+    SELECT AVG(CASE
+      WHEN source = 'rotten_tomatoes' AND metric_type = 'tomatometer' THEN value / 10.0
+      WHEN source = 'metacritic' AND metric_type = 'metascore' THEN value / 10.0
+    END)
+    FROM external_metrics
+    WHERE movie_id = $1
+      AND ((source = 'rotten_tomatoes' AND metric_type = 'tomatometer')
+        OR  (source = 'metacritic' AND metric_type = 'metascore'))
     """
 
     case Repo.query(query, [movie_id]) do

--- a/lib/cinegraph/calibration/scoring_configuration.ex
+++ b/lib/cinegraph/calibration/scoring_configuration.ex
@@ -12,7 +12,7 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
   @normalization_methods ~w(none bayesian percentile zscore)
   @missing_data_strategies ~w(neutral exclude average penalize)
 
-  @categories ~w(popular_opinion industry_recognition cultural_impact people_quality financial_performance)
+  @categories ~w(mob ivory_tower industry_recognition cultural_impact people_quality financial_performance)
 
   schema "calibration_scoring_configurations" do
     field :version, :integer
@@ -24,7 +24,8 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
     # Category weights (must sum to 1.0)
     field :category_weights, :map,
       default: %{
-        "popular_opinion" => 0.20,
+        "mob" => 0.10,
+        "ivory_tower" => 0.10,
         "industry_recognition" => 0.20,
         "cultural_impact" => 0.20,
         "people_quality" => 0.20,
@@ -38,7 +39,8 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
     # Per-category missing data handling
     field :missing_data_strategies, :map,
       default: %{
-        "popular_opinion" => "neutral",
+        "mob" => "neutral",
+        "ivory_tower" => "neutral",
         "industry_recognition" => "exclude",
         "cultural_impact" => "neutral",
         "people_quality" => "average",
@@ -205,7 +207,8 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
       is_active: true,
       is_draft: false,
       category_weights: %{
-        "popular_opinion" => 0.20,
+        "mob" => 0.10,
+        "ivory_tower" => 0.10,
         "industry_recognition" => 0.20,
         "cultural_impact" => 0.20,
         "people_quality" => 0.20,
@@ -213,7 +216,8 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
       },
       normalization_method: "none",
       missing_data_strategies: %{
-        "popular_opinion" => "neutral",
+        "mob" => "neutral",
+        "ivory_tower" => "neutral",
         "industry_recognition" => "exclude",
         "cultural_impact" => "neutral",
         "people_quality" => "average",
@@ -232,7 +236,8 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
       description: "Weights adjusted to reduce financial penalty and emphasize ratings",
       is_draft: true,
       category_weights: %{
-        "popular_opinion" => 0.40,
+        "mob" => 0.20,
+        "ivory_tower" => 0.20,
         "industry_recognition" => 0.15,
         "cultural_impact" => 0.25,
         "people_quality" => 0.15,
@@ -244,7 +249,8 @@ defmodule Cinegraph.Calibration.ScoringConfiguration do
         "min_votes" => 500
       },
       missing_data_strategies: %{
-        "popular_opinion" => "neutral",
+        "mob" => "neutral",
+        "ivory_tower" => "neutral",
         "industry_recognition" => "exclude",
         "cultural_impact" => "neutral",
         "people_quality" => "average",

--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -297,6 +297,13 @@ defmodule Cinegraph.Metrics.ScoringService do
           em_rt.metric_type == "tomatometer",
       as: :rotten_tomatoes
     )
+    |> join(:left, [m], em_rta in "external_metrics",
+      on:
+        em_rta.movie_id == m.id and
+          em_rta.source == "rotten_tomatoes" and
+          em_rta.metric_type == "audience_score",
+      as: :rt_audience
+    )
     |> join(:left, [m], em_pop in "external_metrics",
       on:
         em_pop.movie_id == m.id and
@@ -389,6 +396,7 @@ defmodule Cinegraph.Metrics.ScoringService do
         imdb_rating: ir,
         metacritic: mc,
         rotten_tomatoes: rt,
+        rt_audience: ra,
         popularity: pop,
         festivals: f,
         person_quality: pq,
@@ -399,12 +407,18 @@ defmodule Cinegraph.Metrics.ScoringService do
         discovery_score:
           fragment(
             """
-            ? * CASE
-              WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
-              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
-              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
-              ELSE 0.0
-            END +
+            ? * COALESCE(
+              (COALESCE(NULLIF(?, 0), 0) / 10.0 +
+               COALESCE(NULLIF(?, 0), 0) / 10.0 +
+               COALESCE(NULLIF(?, 0), 0) / 100.0) /
+              NULLIF(
+                CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END,
+                0
+              ),
+              0.0
+            ) +
             ? * CASE
               WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
               WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
@@ -423,12 +437,10 @@ defmodule Cinegraph.Metrics.ScoringService do
             ^Map.get(weights, :mob, 0.0),
             ir.value,
             tr.value,
+            ra.value,
             ir.value,
             tr.value,
-            ir.value,
-            ir.value,
-            tr.value,
-            tr.value,
+            ra.value,
             ^Map.get(weights, :ivory_tower, 0.0),
             rt.value,
             mc.value,
@@ -457,15 +469,13 @@ defmodule Cinegraph.Metrics.ScoringService do
           ),
         mob_score:
           fragment(
-            "CASE WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
+            "COALESCE((COALESCE(NULLIF(?, 0), 0) / 10.0 + COALESCE(NULLIF(?, 0), 0) / 10.0 + COALESCE(NULLIF(?, 0), 0) / 100.0) / NULLIF(CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END, 0), 0.0)",
             ir.value,
             tr.value,
+            ra.value,
             ir.value,
             tr.value,
-            ir.value,
-            ir.value,
-            tr.value,
-            tr.value
+            ra.value
           ),
         ivory_tower_score:
           fragment(
@@ -481,24 +491,23 @@ defmodule Cinegraph.Metrics.ScoringService do
           ),
         score_confidence:
           fragment(
-            "(CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END) / 4.0",
+            "(CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END) / 5.0",
             ir.value,
             tr.value,
             rt.value,
-            mc.value
+            mc.value,
+            ra.value
           ),
         score_components: %{
           mob:
             fragment(
-              "CASE WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0 ELSE 0.0 END",
+              "COALESCE((COALESCE(NULLIF(?, 0), 0) / 10.0 + COALESCE(NULLIF(?, 0), 0) / 10.0 + COALESCE(NULLIF(?, 0), 0) / 100.0) / NULLIF(CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END, 0), 0.0)",
               ir.value,
               tr.value,
+              ra.value,
               ir.value,
               tr.value,
-              ir.value,
-              ir.value,
-              tr.value,
-              tr.value
+              ra.value
             ),
           ivory_tower:
             fragment(
@@ -562,6 +571,7 @@ defmodule Cinegraph.Metrics.ScoringService do
         imdb_rating: ir,
         metacritic: mc,
         rotten_tomatoes: rt,
+        rt_audience: ra,
         popularity: pop,
         festivals: f,
         person_quality: pq,
@@ -572,12 +582,18 @@ defmodule Cinegraph.Metrics.ScoringService do
         discovery_score:
           fragment(
             """
-            ? * CASE
-              WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
-              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
-              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
-              ELSE 0.0
-            END +
+            ? * COALESCE(
+              (COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 +
+               COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 +
+               COALESCE(NULLIF(MAX(?), 0), 0) / 100.0) /
+              NULLIF(
+                CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END,
+                0
+              ),
+              0.0
+            ) +
             ? * CASE
               WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
               WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
@@ -596,12 +612,10 @@ defmodule Cinegraph.Metrics.ScoringService do
             ^Map.get(weights, :mob, 0.0),
             ir.value,
             tr.value,
+            ra.value,
             ir.value,
             tr.value,
-            ir.value,
-            ir.value,
-            tr.value,
-            tr.value,
+            ra.value,
             ^Map.get(weights, :ivory_tower, 0.0),
             rt.value,
             mc.value,
@@ -631,15 +645,13 @@ defmodule Cinegraph.Metrics.ScoringService do
         score_components: %{
           mob:
             fragment(
-              "CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0 WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0 WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0 ELSE 0.0 END",
+              "COALESCE((COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 + COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 + COALESCE(NULLIF(MAX(?), 0), 0) / 100.0) / NULLIF(CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END, 0), 0.0)",
               ir.value,
               tr.value,
+              ra.value,
               ir.value,
               tr.value,
-              ir.value,
-              ir.value,
-              tr.value,
-              tr.value
+              ra.value
             ),
           ivory_tower:
             fragment(
@@ -703,6 +715,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           imdb_rating: ir,
           metacritic: mc,
           rotten_tomatoes: rt,
+          rt_audience: ra,
           popularity: pop,
           festivals: f,
           person_quality: pq,
@@ -711,12 +724,18 @@ defmodule Cinegraph.Metrics.ScoringService do
         ],
         fragment(
           """
-          ? * CASE
-            WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
-            WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
-            WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
-            ELSE 0.0
-          END +
+          ? * COALESCE(
+            (COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 +
+             COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 +
+             COALESCE(NULLIF(MAX(?), 0), 0) / 100.0) /
+            NULLIF(
+              CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END +
+              CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END +
+              CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END,
+              0
+            ),
+            0.0
+          ) +
           ? * CASE
             WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
             WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
@@ -735,12 +754,10 @@ defmodule Cinegraph.Metrics.ScoringService do
           ^Map.get(weights, :mob, 0.0),
           ir.value,
           tr.value,
+          ra.value,
           ir.value,
           tr.value,
-          ir.value,
-          ir.value,
-          tr.value,
-          tr.value,
+          ra.value,
           ^Map.get(weights, :ivory_tower, 0.0),
           rt.value,
           mc.value,
@@ -778,6 +795,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           imdb_rating: ir,
           metacritic: mc,
           rotten_tomatoes: rt,
+          rt_audience: ra,
           popularity: pop,
           festivals: f,
           person_quality: pq,
@@ -786,12 +804,18 @@ defmodule Cinegraph.Metrics.ScoringService do
         ],
         fragment(
           """
-          ? * CASE
-            WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
-            WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
-            WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
-            ELSE 0.0
-          END +
+          ? * COALESCE(
+            (COALESCE(NULLIF(?, 0), 0) / 10.0 +
+             COALESCE(NULLIF(?, 0), 0) / 10.0 +
+             COALESCE(NULLIF(?, 0), 0) / 100.0) /
+            NULLIF(
+              CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END +
+              CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END +
+              CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END,
+              0
+            ),
+            0.0
+          ) +
           ? * CASE
             WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
             WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
@@ -810,12 +834,10 @@ defmodule Cinegraph.Metrics.ScoringService do
           ^Map.get(weights, :mob, 0.0),
           ir.value,
           tr.value,
+          ra.value,
           ir.value,
           tr.value,
-          ir.value,
-          ir.value,
-          tr.value,
-          tr.value,
+          ra.value,
           ^Map.get(weights, :ivory_tower, 0.0),
           rt.value,
           mc.value,
@@ -857,6 +879,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           imdb_rating: ir,
           metacritic: mc,
           rotten_tomatoes: rt,
+          rt_audience: ra,
           popularity: pop,
           festivals: f,
           person_quality: pq,
@@ -866,12 +889,18 @@ defmodule Cinegraph.Metrics.ScoringService do
         desc:
           fragment(
             """
-            ? * CASE
-              WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 10.0 + MAX(?) / 10.0) / 2.0
-              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
-              WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 10.0
-              ELSE 0.0
-            END +
+            ? * COALESCE(
+              (COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 +
+               COALESCE(NULLIF(MAX(?), 0), 0) / 10.0 +
+               COALESCE(NULLIF(MAX(?), 0), 0) / 100.0) /
+              NULLIF(
+                CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN 1 ELSE 0 END,
+                0
+              ),
+              0.0
+            ) +
             ? * CASE
               WHEN NULLIF(MAX(?), 0) IS NOT NULL AND NULLIF(MAX(?), 0) IS NOT NULL THEN (MAX(?) / 100.0 + MAX(?) / 100.0) / 2.0
               WHEN NULLIF(MAX(?), 0) IS NOT NULL THEN MAX(?) / 100.0
@@ -890,12 +919,10 @@ defmodule Cinegraph.Metrics.ScoringService do
             ^Map.get(weights, :mob, 0.0),
             ir.value,
             tr.value,
+            ra.value,
             ir.value,
             tr.value,
-            ir.value,
-            ir.value,
-            tr.value,
-            tr.value,
+            ra.value,
             ^Map.get(weights, :ivory_tower, 0.0),
             rt.value,
             mc.value,
@@ -932,6 +959,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           imdb_rating: ir,
           metacritic: mc,
           rotten_tomatoes: rt,
+          rt_audience: ra,
           popularity: pop,
           festivals: f,
           person_quality: pq,
@@ -941,12 +969,18 @@ defmodule Cinegraph.Metrics.ScoringService do
         desc:
           fragment(
             """
-            ? * CASE
-              WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 10.0 + ? / 10.0) / 2.0
-              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
-              WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 10.0
-              ELSE 0.0
-            END +
+            ? * COALESCE(
+              (COALESCE(NULLIF(?, 0), 0) / 10.0 +
+               COALESCE(NULLIF(?, 0), 0) / 10.0 +
+               COALESCE(NULLIF(?, 0), 0) / 100.0) /
+              NULLIF(
+                CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END +
+                CASE WHEN NULLIF(?, 0) IS NOT NULL THEN 1 ELSE 0 END,
+                0
+              ),
+              0.0
+            ) +
             ? * CASE
               WHEN NULLIF(?, 0) IS NOT NULL AND NULLIF(?, 0) IS NOT NULL THEN (? / 100.0 + ? / 100.0) / 2.0
               WHEN NULLIF(?, 0) IS NOT NULL THEN ? / 100.0
@@ -965,12 +999,10 @@ defmodule Cinegraph.Metrics.ScoringService do
             ^Map.get(weights, :mob, 0.0),
             ir.value,
             tr.value,
+            ra.value,
             ir.value,
             tr.value,
-            ir.value,
-            ir.value,
-            tr.value,
-            tr.value,
+            ra.value,
             ^Map.get(weights, :ivory_tower, 0.0),
             rt.value,
             mc.value,

--- a/lib/cinegraph/movies/movie_scoring.ex
+++ b/lib/cinegraph/movies/movie_scoring.ex
@@ -134,13 +134,20 @@ defmodule Cinegraph.Movies.MovieScoring do
   end
 
   @doc """
-  Calculate mob score (audience): IMDb + TMDb ratings, null-aware averaging.
+  Calculate mob score (audience): IMDb + TMDb + RT Audience ratings, null-aware averaging.
   Returns a 0–10 score.
   """
   def calculate_mob_score(metrics) do
     imdb = Map.get(metrics, :imdb_rating)
     tmdb = Map.get(metrics, :tmdb_rating)
-    sources = [imdb, tmdb] |> Enum.reject(&is_nil/1) |> Enum.filter(&(&1 > 0))
+
+    rta =
+      case Map.get(metrics, :rt_audience) do
+        v when is_number(v) and v > 0 -> v / 10.0
+        _ -> nil
+      end
+
+    sources = [imdb, tmdb, rta] |> Enum.reject(&is_nil/1) |> Enum.filter(&(&1 > 0))
 
     if sources == [], do: 0.0, else: Enum.sum(sources) / length(sources)
   end
@@ -162,10 +169,10 @@ defmodule Cinegraph.Movies.MovieScoring do
   end
 
   @doc """
-  Calculate score confidence: fraction of the 4 core rating sources present (0.0–1.0).
+  Calculate score confidence: fraction of the 5 core rating sources present (0.0–1.0).
   """
   def calculate_score_confidence(metrics) do
-    keys = [:imdb_rating, :tmdb_rating, :rt_tomatometer, :metacritic]
+    keys = [:imdb_rating, :tmdb_rating, :rt_tomatometer, :metacritic, :rt_audience]
 
     present =
       Enum.count(keys, fn k ->
@@ -173,7 +180,7 @@ defmodule Cinegraph.Movies.MovieScoring do
         not is_nil(v) and v != 0
       end)
 
-    present / 4.0
+    present / 5.0
   end
 
   @doc """

--- a/lib/cinegraph/predictions/criteria_scoring.ex
+++ b/lib/cinegraph/predictions/criteria_scoring.ex
@@ -1,13 +1,14 @@
 defmodule Cinegraph.Predictions.CriteriaScoring do
   @moduledoc """
-  Implements the 5-criteria scoring system for predicting 1001 Movies list additions.
+  Implements the 6-criteria scoring system for predicting 1001 Movies list additions.
 
-  The 5 criteria with default weights:
-  1. Popular Opinion (35%) - All rating sources combined
-  2. Festival Recognition (30%) 
-  3. Cultural Impact (20%)
-  4. Technical Innovation (10%)
-  5. Auteur Recognition (5%)
+  The 6 criteria with default weights:
+  1. The Mob (17.5%) - Audience ratings: IMDb, TMDb, RT Audience Score
+  2. Ivory Tower (17.5%) - Critic ratings: Metacritic, RT Tomatometer
+  3. Festival Recognition (30%)
+  4. Cultural Impact (20%)
+  5. Technical Innovation (10%)
+  6. Auteur Recognition (5%)
   """
 
   import Ecto.Query
@@ -15,7 +16,8 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
   alias Cinegraph.Movies.Movie
 
   @default_weights %{
-    popular_opinion: 0.35,
+    mob: 0.175,
+    ivory_tower: 0.175,
     festival_recognition: 0.30,
     cultural_impact: 0.20,
     technical_innovation: 0.10,
@@ -69,7 +71,8 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
   """
   def calculate_movie_score(movie, weights \\ @default_weights) do
     scores = %{
-      popular_opinion: score_popular_opinion(movie) || 0.0,
+      mob: score_mob(movie) || 0.0,
+      ivory_tower: score_ivory_tower(movie) || 0.0,
       festival_recognition: score_festival_recognition(movie) || 0.0,
       cultural_impact: score_cultural_impact(movie) || 0.0,
       technical_innovation: score_technical_innovation(movie) || 0.0,
@@ -93,38 +96,36 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
   end
 
   @doc """
-  Score based on popular opinion (all rating sources combined).
+  Score based on mob (audience ratings: IMDb, TMDb, RT Audience Score).
   Returns 0-100 score.
   """
-  def score_popular_opinion(movie) do
+  def score_mob(movie) do
     query =
       from em in "external_metrics",
         where: em.movie_id == ^movie.id,
         where:
           (em.source == "imdb" and em.metric_type == "rating_average") or
             (em.source == "tmdb" and em.metric_type == "rating_average") or
-            (em.source == "metacritic" and em.metric_type == "metascore") or
+            (em.source == "rotten_tomatoes" and em.metric_type == "audience_score"),
+        select: [em.source, em.metric_type, em.value]
+
+    score_mob_from_metrics(Repo.all(query))
+  end
+
+  @doc """
+  Score based on ivory tower (critic ratings: Metacritic, RT Tomatometer).
+  Returns 0-100 score.
+  """
+  def score_ivory_tower(movie) do
+    query =
+      from em in "external_metrics",
+        where: em.movie_id == ^movie.id,
+        where:
+          (em.source == "metacritic" and em.metric_type == "metascore") or
             (em.source == "rotten_tomatoes" and em.metric_type == "tomatometer"),
         select: [em.source, em.metric_type, em.value]
 
-    metrics = Repo.all(query)
-
-    if length(metrics) == 0 do
-      0.0
-    else
-      # Convert all scores to 0-100 scale and average
-      normalized_scores =
-        Enum.map(metrics, fn [source, metric_type, value] ->
-          normalize_rating_score(source, metric_type, value)
-        end)
-        |> Enum.filter(&(&1 > 0))
-
-      if length(normalized_scores) > 0 do
-        Enum.sum(normalized_scores) / length(normalized_scores)
-      else
-        0.0
-      end
-    end
+    score_ivory_tower_from_metrics(Repo.all(query))
   end
 
   @doc """
@@ -541,7 +542,8 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
 
     # Calculate individual scores, ensuring they're all 0-100 range
     scores = %{
-      popular_opinion: min(score_popular_opinion_from_batch(external_metrics) || 0.0, 100.0),
+      mob: min(score_mob_from_metrics(external_metrics) || 0.0, 100.0),
+      ivory_tower: min(score_ivory_tower_from_metrics(external_metrics) || 0.0, 100.0),
       festival_recognition:
         min(score_festival_recognition_from_batch(festival_nominations) || 0.0, 100.0),
       cultural_impact:
@@ -572,34 +574,42 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
     }
   end
 
-  defp score_popular_opinion_from_batch(metrics) do
-    if length(metrics) == 0 do
-      0.0
-    else
-      # Filter to only rating metrics and normalize
-      # Fixed: Use actual metric types from database
-      normalized_scores =
-        metrics
-        |> Enum.filter(fn [source, metric_type, _value] ->
-          case source do
-            "imdb" -> metric_type == "rating_average"
-            "tmdb" -> metric_type == "rating_average"
-            "metacritic" -> metric_type == "metascore"
-            "rotten_tomatoes" -> metric_type == "tomatometer"
-            _ -> false
-          end
-        end)
-        |> Enum.map(fn [source, metric_type, value] ->
-          normalize_rating_score(source, metric_type, value || 0.0)
-        end)
-        |> Enum.filter(&(&1 > 0))
+  defp score_mob_from_metrics(metrics) do
+    normalized_scores =
+      metrics
+      |> Enum.filter(fn [source, metric_type, _value] ->
+        (source == "imdb" and metric_type == "rating_average") or
+          (source == "tmdb" and metric_type == "rating_average") or
+          (source == "rotten_tomatoes" and metric_type == "audience_score")
+      end)
+      |> Enum.map(fn [source, metric_type, value] ->
+        normalize_rating_score(source, metric_type, value || 0.0)
+      end)
+      |> Enum.filter(&(&1 > 0))
 
-      if length(normalized_scores) > 0 do
-        # Average the scores, but cap at 100
-        min(Enum.sum(normalized_scores) / length(normalized_scores), 100.0)
-      else
-        0.0
-      end
+    if length(normalized_scores) > 0 do
+      min(Enum.sum(normalized_scores) / length(normalized_scores), 100.0)
+    else
+      0.0
+    end
+  end
+
+  defp score_ivory_tower_from_metrics(metrics) do
+    normalized_scores =
+      metrics
+      |> Enum.filter(fn [source, metric_type, _value] ->
+        (source == "metacritic" and metric_type == "metascore") or
+          (source == "rotten_tomatoes" and metric_type == "tomatometer")
+      end)
+      |> Enum.map(fn [source, metric_type, value] ->
+        normalize_rating_score(source, metric_type, value || 0.0)
+      end)
+      |> Enum.filter(&(&1 > 0))
+
+    if length(normalized_scores) > 0 do
+      min(Enum.sum(normalized_scores) / length(normalized_scores), 100.0)
+    else
+      0.0
     end
   end
 

--- a/lib/cinegraph_web/live/score_calibration_live.ex
+++ b/lib/cinegraph_web/live/score_calibration_live.ex
@@ -789,7 +789,6 @@ defmodule CinegraphWeb.ScoreCalibrationLive do
     case category do
       "mob" -> "Mob"
       "ivory_tower" -> "IT"
-      "popular_opinion" -> "Pop"
       "industry_recognition" -> "Ind"
       "cultural_impact" -> "Cult"
       "people_quality" -> "Ppl"


### PR DESCRIPTION
### TL;DR

Split the "popular opinion" scoring category into two separate categories: "mob" (audience ratings) and "ivory tower" (critic ratings), adding Rotten Tomatoes audience score to the mob calculation.

### What changed?

- Renamed `popular_opinion` category to `mob` and `ivory_tower` across all scoring configurations
- Added Rotten Tomatoes audience score as a third data source for mob scoring alongside IMDb and TMDb ratings
- Updated mob score calculation to include IMDb ratings, TMDb ratings, and RT audience score (converted from 0-100 to 0-10 scale)
- Ivory tower score now exclusively uses critic ratings: Metacritic metascore and RT tomatometer
- Modified default weights to split the original 20% popular opinion weight into 10% mob + 10% ivory tower
- Updated score confidence calculation to account for 5 rating sources instead of 4
- Added RT audience score joins to all database queries in the scoring service
- Updated SQL fragments to properly calculate averages with null-aware logic for the new three-source mob scoring

### How to test?

- Verify that movies with RT audience scores now show different mob scores compared to before
- Check that ivory tower scores only reflect critic ratings (Metacritic and RT tomatometer)
- Confirm that score confidence values are recalculated based on 5 sources instead of 4
- Test that the scoring configuration UI properly displays "Mob" and "IT" categories instead of "Pop"
- Validate that batch scoring operations correctly separate audience and critic ratings

### Why make this change?

This change provides more granular insight into movie reception by distinguishing between audience preferences (mob) and critical consensus (ivory tower). Adding RT audience score gives a more comprehensive view of popular opinion, while separating critic and audience perspectives allows for better analysis of movies that may be critically acclaimed but not popular with general audiences, or vice versa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* **Enhanced Scoring Model**: Replaced the single "popular opinion" metric with two distinct scoring dimensions—"mob" (aggregating audience ratings from IMDb, TMDb, and Rotten Tomatoes) and "ivory_tower" (combining critic scores from Rotten Tomatoes and Metacritic)—for more nuanced quality assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->