### PR TITLE
last fixes before p3

### DIFF
--- a/lib/cinegraph/movies/movie_scoring.ex
+++ b/lib/cinegraph/movies/movie_scoring.ex
@@ -18,7 +18,7 @@ defmodule Cinegraph.Movies.MovieScoring do
   festival data, person quality, and financial performance.
 
   Uses the standard 6-category scoring system:
-  - The Mob (audience ratings from IMDb and TMDb)
+  - The Mob (audience ratings from IMDb, TMDb, and RT Audience Score)
   - The Ivory Tower (critics scores from Metacritic and RT Tomatometer)
   - Industry Recognition (festival wins and nominations)
   - Cultural Impact (canonical sources and popularity)

--- a/lib/cinegraph/predictions/criteria_scoring.ex
+++ b/lib/cinegraph/predictions/criteria_scoring.ex
@@ -340,6 +340,11 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
     value || 0.0
   end
 
+  defp normalize_rating_score("rotten_tomatoes", "audience_score", value) do
+    # RT Audience Score is already 0-100; clamp to valid range
+    max(0.0, min(100.0, value || 0.0))
+  end
+
   defp normalize_rating_score("rotten_tomatoes", "tomatometer", value) do
     # RT Tomatometer is already 0-100
     value || 0.0


### PR DESCRIPTION
### TL;DR

Added RT Audience Score as a data source for "The Mob" category in movie scoring and implemented proper normalization for this rating type.

### What changed?

- Updated the documentation in `MovieScoring` module to include RT Audience Score alongside IMDb and TMDb ratings in "The Mob" category
- Added a new normalization function for RT Audience Score that clamps values to the valid 0-100 range

### How to test?

- Verify that movies with RT Audience Score data are properly processed in the scoring system
- Test edge cases with RT Audience Score values outside the 0-100 range to ensure they are clamped correctly
- Confirm that "The Mob" category now incorporates RT Audience Score data in addition to existing IMDb and TMDb ratings

### Why make this change?

This expands the data sources used for audience ratings in movie scoring, providing a more comprehensive view of public opinion by incorporating Rotten Tomatoes audience feedback alongside existing IMDb and TMDb ratings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "The Mob" movie documentation to reflect the inclusion of Rotten Tomatoes Audience Score as an additional rating input source.

* **Improvements**
  * Enhanced normalization of Rotten Tomatoes Audience Score values during scoring calculations to ensure consistent value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->