### PR TITLE
prediction final

### DIFF
--- a/lib/cinegraph/calibration/recall_calculator.ex
+++ b/lib/cinegraph/calibration/recall_calculator.ex
@@ -40,12 +40,15 @@ defmodule Cinegraph.Calibration.RecallCalculator do
         {:error, :list_not_found}
 
       ref_list ->
-        references = Calibration.list_references(ref_list.id, include_unmatched: false, limit: 9999)
+        references =
+          Calibration.list_references(ref_list.id, include_unmatched: false, limit: 9999)
 
         if references == [] do
           {:error, :no_matched_references}
         else
-          profile = ScoringService.get_profile(profile_name) || ScoringService.get_default_profile()
+          profile =
+            ScoringService.get_profile(profile_name) || ScoringService.get_default_profile()
+
           do_measure(references, profile, threshold)
         end
     end
@@ -54,8 +57,8 @@ defmodule Cinegraph.Calibration.RecallCalculator do
   defp do_measure(references, profile, threshold) do
     by_decade_refs = group_by_decade(references)
 
-    # Per-decade recall (parallel, max 3 concurrent DB queries)
-    decade_results =
+    # Per-decade recall (parallel, max 1 concurrent DB query)
+    decade_results_result =
       by_decade_refs
       |> Task.async_stream(
         fn {decade, refs} ->
@@ -64,25 +67,31 @@ defmodule Cinegraph.Calibration.RecallCalculator do
         max_concurrency: 1,
         timeout: 300_000
       )
-      |> Enum.reduce(%{}, fn
-        {:ok, result}, acc -> Map.put(acc, result.decade, result)
-        {:exit, _reason}, acc -> acc
+      |> Enum.reduce_while({:ok, %{}}, fn
+        {:ok, result}, {:ok, acc} -> {:cont, {:ok, Map.put(acc, result.decade, result)}}
+        {:exit, reason}, _acc -> {:halt, {:error, reason}}
       end)
 
-    total_found = Enum.sum(Enum.map(decade_results, fn {_, r} -> r.found end))
-    total_reference = length(references)
+    case decade_results_result do
+      {:error, reason} ->
+        {:error, reason}
 
-    lens_correlations = calculate_lens_correlations(references, profile)
-    systematic_gaps = find_systematic_gaps(references, decade_results)
+      {:ok, decade_results} ->
+        total_found = Enum.sum(Enum.map(decade_results, fn {_, r} -> r.found end))
+        total_reference = length(references)
 
-    %{
-      overall_recall: if(total_reference > 0, do: total_found / total_reference, else: 0.0),
-      total_found: total_found,
-      total_reference: total_reference,
-      by_decade: decade_results,
-      lens_correlations: lens_correlations,
-      systematic_gaps: systematic_gaps
-    }
+        lens_correlations = calculate_lens_correlations(references, profile)
+        systematic_gaps = find_systematic_gaps(references, decade_results)
+
+        %{
+          overall_recall: if(total_reference > 0, do: total_found / total_reference, else: 0.0),
+          total_found: total_found,
+          total_reference: total_reference,
+          by_decade: decade_results,
+          lens_correlations: lens_correlations,
+          systematic_gaps: systematic_gaps
+        }
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -101,12 +110,14 @@ defmodule Cinegraph.Calibration.RecallCalculator do
   end
 
   defp get_reference_year(%{movie: %Movie{release_date: %Date{year: year}}}), do: year
+
   defp get_reference_year(%{movie: %Movie{release_date: date}}) when not is_nil(date) do
     case date do
       %{year: year} -> year
       _ -> nil
     end
   end
+
   defp get_reference_year(%{external_year: year}) when is_integer(year), do: year
   defp get_reference_year(_), do: nil
 
@@ -117,12 +128,14 @@ defmodule Cinegraph.Calibration.RecallCalculator do
   defp compute_decade_recall(decade, refs, profile, threshold) do
     year_start = decade * 10
     year_end = year_start + 9
+    start_date = Date.new!(year_start, 1, 1)
+    end_date = Date.new!(year_end, 12, 31)
 
     total_in_db =
       from(m in Movie,
         where: not is_nil(m.release_date),
-        where: fragment("EXTRACT(year FROM ?)::int", m.release_date) >= ^year_start,
-        where: fragment("EXTRACT(year FROM ?)::int", m.release_date) <= ^year_end
+        where: m.release_date >= ^start_date,
+        where: m.release_date <= ^end_date
       )
       |> Repo.aggregate(:count, timeout: 120_000)
 
@@ -131,8 +144,8 @@ defmodule Cinegraph.Calibration.RecallCalculator do
     top_ids =
       from(m in Movie,
         where: not is_nil(m.release_date),
-        where: fragment("EXTRACT(year FROM ?)::int", m.release_date) >= ^year_start,
-        where: fragment("EXTRACT(year FROM ?)::int", m.release_date) <= ^year_end
+        where: m.release_date >= ^start_date,
+        where: m.release_date <= ^end_date
       )
       |> ScoringService.apply_scoring(profile, %{min_score: nil})
       |> limit(^threshold_count)
@@ -177,7 +190,7 @@ defmodule Cinegraph.Calibration.RecallCalculator do
     else
       scored =
         from(m in Movie, where: m.id in ^ref_movie_ids)
-        |> ScoringService.apply_scoring(profile)
+        |> ScoringService.apply_scoring(profile, %{min_score: nil})
         |> Repo.all()
 
       lenses = [
@@ -262,7 +275,8 @@ defmodule Cinegraph.Calibration.RecallCalculator do
       %{
         category: "decade",
         count: r.total - r.found,
-        description: "#{r.decade_label}: #{Float.round(r.recall * 100, 0)}% recall (#{r.found}/#{r.total})"
+        description:
+          "#{r.decade_label}: #{Float.round(r.recall * 100, 0)}% recall (#{r.found}/#{r.total})"
       }
     end)
   end

--- a/lib/cinegraph/workers/recall_calibration_worker.ex
+++ b/lib/cinegraph/workers/recall_calibration_worker.ex
@@ -16,15 +16,35 @@ defmodule Cinegraph.Workers.RecallCalibrationWorker do
   @pubsub_topic "recall_calibration"
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"list_slug" => list_slug, "profile_name" => profile_name, "threshold" => threshold}}) do
+  def perform(%Oban.Job{
+        id: job_id,
+        args: %{
+          "list_slug" => list_slug,
+          "profile_name" => profile_name,
+          "threshold" => threshold
+        }
+      }) do
     Logger.info("RecallCalibrationWorker starting: #{list_slug} / #{profile_name} @ #{threshold}")
 
-    broadcast(%{status: :running, list_slug: list_slug, profile_name: profile_name})
+    broadcast(%{
+      status: :running,
+      job_id: job_id,
+      list_slug: list_slug,
+      profile_name: profile_name
+    })
 
     case Cinegraph.Calibration.measure_recall(list_slug, profile_name, threshold: threshold) do
       {:error, reason} = err ->
         Logger.warning("RecallCalibrationWorker failed: #{inspect(reason)}")
-        broadcast(%{status: :error, error: inspect(reason), list_slug: list_slug, profile_name: profile_name})
+
+        broadcast(%{
+          status: :error,
+          job_id: job_id,
+          error: inspect(reason),
+          list_slug: list_slug,
+          profile_name: profile_name
+        })
+
         err
 
       results ->
@@ -37,6 +57,7 @@ defmodule Cinegraph.Workers.RecallCalibrationWorker do
 
         broadcast(%{
           status: :complete,
+          job_id: job_id,
           results: results,
           list_slug: list_slug,
           profile_name: profile_name,

--- a/lib/cinegraph_web/live/predictions_live/index.ex
+++ b/lib/cinegraph_web/live/predictions_live/index.ex
@@ -34,6 +34,7 @@ defmodule CinegraphWeb.PredictionsLive.Index do
 
       # Check if cache is empty or needs refresh based on enhanced status
       cache_empty = predictions_result.predictions == []
+
       cache_needs_refresh =
         Map.get(cache_status, :needs_refresh, true) ||
           stale_cache?(predictions_result.predictions)
@@ -512,9 +513,7 @@ defmodule CinegraphWeb.PredictionsLive.Index do
 
   # Returns true if the cached predictions were built with the old popular_opinion key,
   # indicating the cache needs to be refreshed with the current scoring model.
-  defp stale_cache?(predictions) when is_list(predictions) and length(predictions) > 0 do
-    sample = List.first(predictions)
-
+  defp stale_cache?([sample | _]) do
     criteria =
       get_in(sample, [:prediction, :criteria_scores]) ||
         get_in(sample, ["prediction", "criteria_scores"]) ||

--- a/lib/mix/tasks/calibrate.ex
+++ b/lib/mix/tasks/calibrate.ex
@@ -64,7 +64,13 @@ defmodule Mix.Tasks.Calibrate do
 
       results ->
         if json? do
-          IO.puts(Jason.encode!(results, pretty: true))
+          # `by_decade` has integer keys; stringify them so Jason can encode the map
+          results_for_json =
+            Map.update!(results, :by_decade, fn by_decade ->
+              Map.new(by_decade, fn {k, v} -> {to_string(k), v} end)
+            end)
+
+          IO.puts(Jason.encode!(results_for_json, pretty: true))
         else
           print_results(results, profile_name, threshold)
         end
@@ -95,7 +101,10 @@ defmodule Mix.Tasks.Calibrate do
       pct = Float.round(r.recall * 100, 1)
       bar = build_bar(r.recall, 20)
       flag = if r.recall < 0.60, do: " ⚠", else: if(r.recall >= 0.75, do: " ✓", else: "")
-      Mix.shell().info("  #{String.pad_leading(r.decade_label, 6)}  #{bar}  #{String.pad_leading("#{pct}%", 6)}  (#{r.found}/#{r.total})#{flag}")
+
+      Mix.shell().info(
+        "  #{String.pad_leading(r.decade_label, 6)}  #{bar}  #{String.pad_leading("#{pct}%", 6)}  (#{r.found}/#{r.total})#{flag}"
+      )
     end)
 
     # Lens correlations
@@ -125,11 +134,20 @@ defmodule Mix.Tasks.Calibrate do
     Mix.shell().info("")
 
     target_met = results.overall_recall >= 0.75
-    decade_floor_met = Enum.all?(results.by_decade, fn {_, r} -> r.total == 0 or r.recall >= 0.60 end)
+
+    decade_floor_met =
+      Enum.all?(results.by_decade, fn {_, r} -> r.total == 0 or r.recall >= 0.60 end)
 
     Mix.shell().info("Targets:")
-    Mix.shell().info("  Overall ≥ 75%:           #{if target_met, do: "✅ PASS (#{overall_pct}%)", else: "❌ FAIL (#{overall_pct}%)"}")
-    Mix.shell().info("  All decades ≥ 60%:       #{if decade_floor_met, do: "✅ PASS", else: "❌ FAIL — see ⚠ decades above"}")
+
+    Mix.shell().info(
+      "  Overall ≥ 75%:           #{if target_met, do: "✅ PASS (#{overall_pct}%)", else: "❌ FAIL (#{overall_pct}%)"}"
+    )
+
+    Mix.shell().info(
+      "  All decades ≥ 60%:       #{if decade_floor_met, do: "✅ PASS", else: "❌ FAIL — see ⚠ decades above"}"
+    )
+
     Mix.shell().info("")
   end
 


### PR DESCRIPTION
### TL;DR

Improved error handling in recall calibration by adding proper error propagation and fixed database queries to use date comparisons instead of SQL fragments.

### What changed?

- Enhanced error handling in `RecallCalculator.do_measure/3` by using `reduce_while` to properly propagate task failures instead of silently ignoring them
- Replaced SQL fragment-based year extraction with direct date range comparisons using `Date.new!` for better performance and clarity
- Added `job_id` to worker broadcast messages for better job tracking
- Fixed JSON encoding in the calibrate mix task by converting integer keys to strings in the `by_decade` map
- Applied consistent scoring parameters by adding `%{min_score: nil}` to `ScoringService.apply_scoring` calls

### How to test?

- Run recall calibration jobs and verify they properly report errors instead of silently failing
- Execute the `mix calibrate` task with `--json` flag to ensure proper JSON output
- Test calibration with various reference lists to confirm database queries work correctly with the new date-based filtering

### Why make this change?

The previous implementation had silent error handling that made debugging difficult when calibration tasks failed. The SQL fragment approach was less efficient and harder to maintain than direct date comparisons. Adding job IDs to broadcasts improves job tracking, and fixing JSON encoding ensures the CLI tool works properly with structured output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during recall calculation processing—failures now halt with proper error reporting instead of silently continuing.

* **Improvements**
  * Enhanced JSON output formatting with JSON-compatible key serialization.
  * Refined console output formatting for calibration result displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->