### PR TITLE
new table

### DIFF
--- a/lib/cinegraph/metrics/disparity_calculator.ex
+++ b/lib/cinegraph/metrics/disparity_calculator.ex
@@ -1,0 +1,92 @@
+defmodule Cinegraph.Metrics.DisparityCalculator do
+  @moduledoc """
+  Pure calculations for disparity and unpredictability scores.
+  No DB calls — all inputs come from MovieScoring.calculate_movie_scores/1.
+  """
+
+  # Thresholds from issue #615
+  @significant_disparity 2.0
+  @harmony_threshold 0.5
+  @high_score_threshold 7.5
+  @low_score_threshold 5.5
+
+  @doc "Calculate |mob - ivory_tower| on 0–10 scale."
+  def calculate_disparity(mob, ivory_tower), do: abs(mob - ivory_tower)
+
+  @doc """
+  Classify the disparity into a named category.
+  Returns nil when disparity is not significant enough to categorize.
+  """
+  def classify_disparity(mob, ivory_tower, disparity) do
+    cond do
+      ivory_tower > @high_score_threshold and mob < @low_score_threshold and
+          disparity > @significant_disparity ->
+        "critics_darling"
+
+      mob > @high_score_threshold and ivory_tower < @low_score_threshold and
+          disparity > @significant_disparity ->
+        "peoples_champion"
+
+      mob > @high_score_threshold and ivory_tower > @high_score_threshold and
+          disparity < @harmony_threshold ->
+        "perfect_harmony"
+
+      disparity > @significant_disparity ->
+        "polarizer"
+
+      true ->
+        nil
+    end
+  end
+
+  @doc "Population stddev of all 6 lens scores (0–10 scale each)."
+  def calculate_unpredictability(%{
+        mob: mob,
+        ivory_tower: ivory,
+        industry_recognition: industry,
+        cultural_impact: cultural,
+        people_quality: people,
+        financial_performance: financial
+      }) do
+    scores = [mob, ivory, industry, cultural, people, financial]
+    population_stddev(scores)
+  end
+
+  @doc """
+  Given the output of MovieScoring.calculate_movie_scores/1,
+  returns %{disparity_score, disparity_category, unpredictability_score}.
+  Returns nil disparity values when both mob and ivory_tower scores are 0 (no data).
+  """
+  def calculate_all(%{components: c}) do
+    mob = c.mob
+    ivory = c.ivory_tower
+
+    {disparity, category} =
+      if mob == 0.0 and ivory == 0.0 do
+        {nil, nil}
+      else
+        d = calculate_disparity(mob, ivory)
+        {Float.round(d, 2), classify_disparity(mob, ivory, d)}
+      end
+
+    unpredictability = Float.round(calculate_unpredictability(c), 2)
+
+    %{
+      disparity_score: disparity,
+      disparity_category: category,
+      unpredictability_score: unpredictability
+    }
+  end
+
+  defp population_stddev(scores) do
+    n = length(scores)
+
+    if n < 2 do
+      0.0
+    else
+      mean = Enum.sum(scores) / n
+      variance = Enum.sum(Enum.map(scores, fn x -> (x - mean) ** 2 end)) / n
+      :math.sqrt(variance)
+    end
+  end
+end

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -1101,6 +1101,36 @@ defmodule Cinegraph.Movies do
     :ok
   end
 
+  @doc "List movies in a disparity category, ordered by disparity score descending."
+  def list_movies_by_disparity_category(category, opts \\ []) do
+    limit = Elixir.Keyword.get(opts, :limit, 50)
+    offset = Elixir.Keyword.get(opts, :offset, 0)
+
+    from(m in Movie,
+      join: s in assoc(m, :score_cache),
+      where: s.disparity_category == ^category,
+      order_by: [desc: s.disparity_score],
+      limit: ^limit,
+      offset: ^offset,
+      preload: [score_cache: s]
+    )
+    |> Repo.all()
+  end
+
+  @doc "List movies with the largest critic/audience gap."
+  def top_disparity_movies(opts \\ []) do
+    limit = Elixir.Keyword.get(opts, :limit, 50)
+
+    from(m in Movie,
+      join: s in assoc(m, :score_cache),
+      where: not is_nil(s.disparity_score),
+      order_by: [desc: s.disparity_score],
+      limit: ^limit,
+      preload: [score_cache: s]
+    )
+    |> Repo.all()
+  end
+
   # Helper to escape SQL LIKE wildcards
   defp escape_like_wildcards(str) do
     str

--- a/lib/cinegraph/movies/movie.ex
+++ b/lib/cinegraph/movies/movie.ex
@@ -18,7 +18,8 @@ defmodule Cinegraph.Movies.Movie do
              :movie_release_dates,
              :external_metrics,
              :external_recommendations,
-             :cri_score
+             :cri_score,
+             :score_cache
            ]}
 
   @derive {
@@ -113,6 +114,7 @@ defmodule Cinegraph.Movies.Movie do
     # External data associations  
     has_many :external_metrics, Cinegraph.Movies.ExternalMetric, foreign_key: :movie_id
     has_one :cri_score, Cinegraph.Cultural.CRIScore, foreign_key: :movie_id
+    has_one :score_cache, Cinegraph.Movies.MovieScoreCache, foreign_key: :movie_id
 
     has_many :external_recommendations, Cinegraph.Movies.MovieRecommendation,
       foreign_key: :source_movie_id

--- a/lib/cinegraph/movies/movie_score_cache.ex
+++ b/lib/cinegraph/movies/movie_score_cache.ex
@@ -1,0 +1,53 @@
+defmodule Cinegraph.Movies.MovieScoreCache do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: true}
+  schema "movie_score_caches" do
+    belongs_to :movie, Cinegraph.Movies.Movie
+
+    # 6 lens scores (0–10)
+    field :mob_score, :float
+    field :ivory_tower_score, :float
+    field :industry_recognition_score, :float
+    field :cultural_impact_score, :float
+    field :people_quality_score, :float
+    field :financial_performance_score, :float
+
+    # Derived
+    field :overall_score, :float
+    field :score_confidence, :float
+    field :disparity_score, :float
+    field :disparity_category, :string
+    field :unpredictability_score, :float
+
+    # Cache metadata
+    field :calculated_at, :utc_datetime
+    field :calculation_version, :string
+
+    timestamps()
+  end
+
+  def changeset(score_cache, attrs) do
+    score_cache
+    |> cast(attrs, [
+      :movie_id,
+      :mob_score,
+      :ivory_tower_score,
+      :industry_recognition_score,
+      :cultural_impact_score,
+      :people_quality_score,
+      :financial_performance_score,
+      :overall_score,
+      :score_confidence,
+      :disparity_score,
+      :disparity_category,
+      :unpredictability_score,
+      :calculated_at,
+      :calculation_version
+    ])
+    |> validate_required([:movie_id, :calculated_at, :calculation_version])
+    |> foreign_key_constraint(:movie_id)
+    |> unique_constraint(:movie_id)
+  end
+end

--- a/lib/cinegraph/workers/movie_score_cache_worker.ex
+++ b/lib/cinegraph/workers/movie_score_cache_worker.ex
@@ -1,0 +1,58 @@
+defmodule Cinegraph.Workers.MovieScoreCacheWorker do
+  use Oban.Worker, queue: :default, max_attempts: 3
+
+  alias Cinegraph.{Repo, Movies.Movie, Movies.MovieScoreCache, Movies.MovieScoring,
+                   Metrics.DisparityCalculator}
+
+  @calculation_version "1"
+
+  @impl true
+  def perform(%Oban.Job{args: %{"movie_id" => movie_id}}) do
+    movie = Repo.get!(Movie, movie_id)
+    scores = MovieScoring.calculate_movie_scores(movie)
+    disparity_attrs = DisparityCalculator.calculate_all(scores)
+
+    attrs = %{
+      movie_id: movie_id,
+      mob_score: scores.components.mob,
+      ivory_tower_score: scores.components.ivory_tower,
+      industry_recognition_score: scores.components.industry_recognition,
+      cultural_impact_score: scores.components.cultural_impact,
+      people_quality_score: scores.components.people_quality,
+      financial_performance_score: scores.components.financial_performance,
+      overall_score: scores.overall_score,
+      score_confidence: scores.score_confidence,
+      disparity_score: disparity_attrs.disparity_score,
+      disparity_category: disparity_attrs.disparity_category,
+      unpredictability_score: disparity_attrs.unpredictability_score,
+      calculated_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      calculation_version: @calculation_version
+    }
+
+    cache = Repo.get_by(MovieScoreCache, movie_id: movie_id) || %MovieScoreCache{}
+
+    cache
+    |> MovieScoreCache.changeset(attrs)
+    |> Repo.insert_or_update()
+    |> case do
+      {:ok, _} -> :ok
+      {:error, cs} -> {:error, inspect(cs.errors)}
+    end
+  end
+
+  @doc """
+  Enqueue score cache calculations for all movies in batches of 500.
+  Run from IEx: Cinegraph.Workers.MovieScoreCacheWorker.queue_all()
+  """
+  def queue_all(opts \\ []) do
+    batch_size = Elixir.Keyword.get(opts, :batch_size, 500)
+
+    Movie
+    |> Repo.all(select: [:id])
+    |> Enum.chunk_every(batch_size)
+    |> Enum.each(fn batch ->
+      jobs = Enum.map(batch, fn %{id: id} -> new(%{"movie_id" => id}) end)
+      Oban.insert_all(jobs)
+    end)
+  end
+end

--- a/lib/cinegraph_web/live/disparity_explorer_live.ex
+++ b/lib/cinegraph_web/live/disparity_explorer_live.ex
@@ -1,0 +1,86 @@
+defmodule CinegraphWeb.DisparityExplorerLive do
+  use CinegraphWeb, :live_view
+
+  alias Cinegraph.Movies
+
+  @tabs [
+    %{id: "critics_darling", label: "Critics' Darlings", icon: "🎭"},
+    %{id: "peoples_champion", label: "People's Champions", icon: "🔥"},
+    %{id: "perfect_harmony", label: "Perfect Harmony", icon: "✨"},
+    %{id: "polarizer", label: "The Polarizers", icon: "⚡"}
+  ]
+
+  @per_page 24
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:tabs, @tabs)
+     |> assign(:active_tab, "critics_darling")
+     |> assign(:page, 1)
+     |> assign(:movies, [])
+     |> assign(:total_count, 0)
+     |> load_movies("critics_darling", 1)}
+  end
+
+  @impl true
+  def handle_params(%{"tab" => tab}, _url, socket)
+      when tab in ~w(critics_darling peoples_champion perfect_harmony polarizer) do
+    {:noreply,
+     socket
+     |> assign(:active_tab, tab)
+     |> assign(:page, 1)
+     |> load_movies(tab, 1)}
+  end
+
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("switch_tab", %{"tab" => tab}, socket) do
+    {:noreply,
+     socket
+     |> assign(:active_tab, tab)
+     |> assign(:page, 1)
+     |> load_movies(tab, 1)
+     |> push_patch(to: ~p"/explore/disparity?tab=#{tab}")}
+  end
+
+  @impl true
+  def handle_event("load_more", _params, socket) do
+    next_page = socket.assigns.page + 1
+
+    {:noreply,
+     socket
+     |> assign(:page, next_page)
+     |> load_more_movies(socket.assigns.active_tab, next_page)}
+  end
+
+  defp load_movies(socket, category, _page) do
+    movies = Movies.list_movies_by_disparity_category(category, limit: @per_page)
+    assign(socket, :movies, movies)
+  end
+
+  defp load_more_movies(socket, category, page) do
+    offset = (page - 1) * @per_page
+
+    new_movies =
+      Movies.list_movies_by_disparity_category(category, limit: @per_page, offset: offset)
+
+    assign(socket, :movies, socket.assigns.movies ++ new_movies)
+  end
+
+  defp disparity_label("critics_darling"), do: "Critics' Darling"
+  defp disparity_label("peoples_champion"), do: "People's Champion"
+  defp disparity_label("perfect_harmony"), do: "Perfect Harmony"
+  defp disparity_label("polarizer"), do: "The Polarizer"
+  defp disparity_label(_), do: "—"
+
+  defp disparity_badge_class("critics_darling"), do: "bg-purple-600/80 text-white"
+  defp disparity_badge_class("peoples_champion"), do: "bg-orange-500/80 text-white"
+  defp disparity_badge_class("perfect_harmony"), do: "bg-teal-500/80 text-white"
+  defp disparity_badge_class("polarizer"), do: "bg-yellow-500/80 text-gray-900"
+  defp disparity_badge_class(_), do: "bg-gray-500/80 text-white"
+end

--- a/lib/cinegraph_web/live/disparity_explorer_live.html.heex
+++ b/lib/cinegraph_web/live/disparity_explorer_live.html.heex
@@ -1,0 +1,112 @@
+<div class="min-h-screen bg-gray-950">
+  <!-- Header -->
+  <div class="bg-gray-900 border-b border-gray-800">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div class="mb-2">
+        <.link navigate={~p"/movies"} class="text-white/50 hover:text-white/80 text-sm transition-colors">
+          ← Movies
+        </.link>
+      </div>
+      <h1 class="text-3xl font-bold text-white">Disparity Explorer</h1>
+      <p class="text-white/60 mt-2">
+        Where critics and audiences see the same film through very different eyes.
+      </p>
+    </div>
+  </div>
+
+  <!-- Tab Navigation -->
+  <div class="bg-gray-900 border-b border-gray-800 sticky top-0 z-10">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <nav class="-mb-px flex space-x-1 overflow-x-auto scrollbar-hide">
+        <%= for tab <- @tabs do %>
+          <button
+            phx-click="switch_tab"
+            phx-value-tab={tab.id}
+            class={[
+              "whitespace-nowrap py-4 px-4 border-b-2 font-medium text-sm transition-colors flex items-center gap-2",
+              if(@active_tab == tab.id,
+                do: "border-white text-white",
+                else: "border-transparent text-white/50 hover:text-white/80 hover:border-white/30"
+              )
+            ]}
+          >
+            <span>{tab.icon}</span>
+            <span>{tab.label}</span>
+          </button>
+        <% end %>
+      </nav>
+    </div>
+  </div>
+
+  <!-- Movie Grid -->
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <%= if @movies == [] do %>
+      <div class="text-center py-16">
+        <p class="text-white/40 text-lg">No movies found in this category yet.</p>
+        <p class="text-white/30 text-sm mt-2">Scores need to be calculated first — run <code class="text-white/50">MovieScoreCacheWorker.queue_all()</code></p>
+      </div>
+    <% else %>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        <%= for movie <- @movies do %>
+          <% cache = movie.score_cache %>
+          <.link navigate={~p"/movies/#{movie.slug || movie.id}"} class="group block">
+            <div class="relative bg-gray-800 rounded-lg overflow-hidden hover:ring-2 hover:ring-white/30 transition-all">
+              <!-- Poster -->
+              <%= if movie.poster_path do %>
+                <img
+                  src={"https://image.tmdb.org/t/p/w300#{movie.poster_path}"}
+                  alt={movie.title}
+                  class="w-full aspect-[2/3] object-cover"
+                  loading="lazy"
+                />
+              <% else %>
+                <div class="w-full aspect-[2/3] bg-gray-700 flex items-center justify-center">
+                  <span class="text-white/30 text-xs text-center px-2">{movie.title}</span>
+                </div>
+              <% end %>
+
+              <!-- Category badge -->
+              <div class="absolute top-2 left-2">
+                <span class={["text-xs font-semibold px-2 py-0.5 rounded-full", disparity_badge_class(cache && cache.disparity_category)]}>
+                  <%= if cache, do: disparity_label(cache.disparity_category), else: "—" %>
+                </span>
+              </div>
+            </div>
+
+            <!-- Movie info below card -->
+            <div class="mt-2 px-1">
+              <p class="text-white text-xs font-medium line-clamp-2 group-hover:text-white/80">
+                {movie.title}
+              </p>
+              <p class="text-white/40 text-xs mt-0.5">
+                {movie.release_year}
+              </p>
+              <%= if cache && cache.disparity_score do %>
+                <div class="flex items-center gap-1 mt-1">
+                  <span class="text-white/50 text-xs">Gap:</span>
+                  <span class="text-white text-xs font-semibold"><%= Float.round(cache.disparity_score, 1) %></span>
+                </div>
+                <div class="flex items-center gap-2 mt-0.5">
+                  <span class="text-orange-400 text-xs">🔥 <%= cache.mob_score && Float.round(cache.mob_score, 1) || "—" %></span>
+                  <span class="text-purple-400 text-xs">🎭 <%= cache.ivory_tower_score && Float.round(cache.ivory_tower_score, 1) || "—" %></span>
+                </div>
+              <% end %>
+            </div>
+          </.link>
+        <% end %>
+      </div>
+
+      <!-- Load More -->
+      <%= if length(@movies) >= 24 do %>
+        <div class="text-center mt-10">
+          <button
+            phx-click="load_more"
+            class="px-6 py-2.5 bg-white/10 hover:bg-white/20 text-white rounded-lg text-sm transition-colors"
+          >
+            Load more
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/lib/cinegraph_web/live/movie_live/show.ex
+++ b/lib/cinegraph_web/live/movie_live/show.ex
@@ -10,6 +10,7 @@ defmodule CinegraphWeb.MovieLive.Show do
   alias Cinegraph.Metrics.ApiLookupMetric
   alias Cinegraph.Movies.MovieScoring
   alias Cinegraph.Movies.MovieCollaborations
+  alias Cinegraph.Metrics.DisparityCalculator
   alias Cinegraph.Repo
 
   require Logger
@@ -154,6 +155,11 @@ defmodule CinegraphWeb.MovieLive.Show do
 
     # Calculate real Cinegraph scores using the context module
     score_data = MovieScoring.calculate_movie_scores(movie)
+    disparity_data = DisparityCalculator.calculate_all(score_data)
+
+    # Preload score cache and build unified display scores (cache wins over live calc)
+    movie = Repo.preload(movie, :score_cache)
+    display_scores = build_display_scores(movie.score_cache, score_data)
 
     # Load credits (cast and crew)
     credits = Movies.get_movie_credits(id)
@@ -224,6 +230,8 @@ defmodule CinegraphWeb.MovieLive.Show do
     |> Map.put(:missing_data, missing_data)
     |> Map.put(:key_collaborations, key_collaborations)
     |> Map.put(:score_data, score_data)
+    |> Map.put(:display_scores, display_scores)
+    |> Map.put(:disparity_data, disparity_data)
     |> Map.put(:related_movies, related_movies)
     |> Map.put(:collaboration_timelines, collaboration_timelines)
   end
@@ -514,6 +522,36 @@ defmodule CinegraphWeb.MovieLive.Show do
       name -> name
     end
   end
+
+  defp build_display_scores(nil, score_data) do
+    c = score_data.components
+
+    %{
+      mob: c.mob,
+      ivory_tower: c.ivory_tower,
+      industry_recognition: c.industry_recognition,
+      cultural_impact: c.cultural_impact,
+      people_quality: c.people_quality,
+      financial_performance: c.financial_performance,
+      overall: score_data.overall_score
+    }
+  end
+
+  defp build_display_scores(cache, _score_data) do
+    %{
+      mob: cache.mob_score || 0.0,
+      ivory_tower: cache.ivory_tower_score || 0.0,
+      industry_recognition: cache.industry_recognition_score || 0.0,
+      cultural_impact: cache.cultural_impact_score || 0.0,
+      people_quality: cache.people_quality_score || 0.0,
+      financial_performance: cache.financial_performance_score || 0.0,
+      overall: cache.overall_score || 0.0
+    }
+  end
+
+  def format_lens_score(nil), do: "—"
+  def format_lens_score(val) when val == 0, do: "—"
+  def format_lens_score(val), do: to_string(val)
 
   defp format_error(:not_found), do: "Movie not found in TMDb"
   defp format_error({:error, reason}), do: format_error(reason)

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -167,23 +167,24 @@
 <!-- Main Score -->
         <div class="text-center mb-6">
           <div class="text-5xl font-bold text-white mb-2">
-            <% score_data = Map.get(@movie, :score_data) %>
-            <%= if score_data do %>
-              {score_data.overall_score}
+            <% display_scores = Map.get(@movie, :display_scores) %>
+            <%= if display_scores do %>
+              {format_lens_score(display_scores.overall)}
             <% else %>
               N/A
             <% end %>
           </div>
           <div class="text-white/60 text-sm">Overall Quality</div>
         </div>
-        
-<!-- 5-Category Breakdown -->
-        <% score_data = Map.get(@movie, :score_data) %>
-        <%= if score_data do %>
+
+<!-- 6-Lens Breakdown -->
+        <% display_scores = Map.get(@movie, :display_scores) %>
+        <%= if display_scores do %>
           <div class="space-y-3">
             <!-- The Mob -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
+                <span class="mr-1 text-sm">🔥</span>
                 <span class="text-white/80 text-sm">The Mob</span>
                 <div class="relative ml-1">
                   <svg
@@ -208,19 +209,20 @@
               <div class="flex items-center">
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
-                    class="h-2 bg-blue-400 rounded-full"
-                    style={"width: #{(score_data.components[:mob] || 0) * 10}%"}
+                    class="h-2 bg-orange-400 rounded-full"
+                    style={"width: #{display_scores.mob * 10}%"}
                   >
                   </div>
                 </div>
                 <span class="text-white text-sm w-8">
-                  {score_data.components[:mob] || 0}
+                  {format_lens_score(display_scores.mob)}
                 </span>
               </div>
             </div>
             <!-- The Ivory Tower -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
+                <span class="mr-1 text-sm">🎭</span>
                 <span class="text-white/80 text-sm">The Ivory Tower</span>
                 <div class="relative ml-1">
                   <svg
@@ -246,21 +248,22 @@
               <div class="flex items-center">
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
-                    class="h-2 bg-purple-400 rounded-full"
-                    style={"width: #{(score_data.components[:ivory_tower] || 0) * 10}%"}
+                    class="h-2 bg-purple-600 rounded-full"
+                    style={"width: #{display_scores.ivory_tower * 10}%"}
                   >
                   </div>
                 </div>
                 <span class="text-white text-sm w-8">
-                  {score_data.components[:ivory_tower] || 0}
+                  {format_lens_score(display_scores.ivory_tower)}
                 </span>
               </div>
             </div>
-            
-<!-- Industry Recognition -->
+
+<!-- The Inner Circle -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
-                <span class="text-white/80 text-sm">Industry Recognition</span>
+                <span class="mr-1 text-sm">🏆</span>
+                <span class="text-white/80 text-sm">The Inner Circle</span>
                 <div class="relative ml-1">
                   <svg
                     class="w-3.5 h-3.5 text-white/40 group-hover:text-white/60 transition-colors cursor-help"
@@ -277,7 +280,7 @@
                     />
                   </svg>
                   <div class="hidden group-hover:block absolute z-10 w-64 p-2 mt-1 text-xs bg-gray-900 text-white rounded-lg shadow-lg left-0">
-                    <strong>Industry Recognition:</strong>
+                    <strong>The Inner Circle:</strong>
                     Awards and nominations from major film festivals (Cannes, Venice, Berlin, etc.)
                   </div>
                 </div>
@@ -285,20 +288,21 @@
               <div class="flex items-center">
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
-                    class="h-2 bg-yellow-400 rounded-full"
-                    style={"width: #{score_data.components.industry_recognition * 10}%"}
+                    class="h-2 bg-yellow-500 rounded-full"
+                    style={"width: #{display_scores.industry_recognition * 10}%"}
                   >
                   </div>
                 </div>
                 <span class="text-white text-sm w-8">
-                  {score_data.components.industry_recognition}
+                  {format_lens_score(display_scores.industry_recognition)}
                 </span>
               </div>
             </div>
-            
+
 <!-- Cultural Impact -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
+                <span class="mr-1 text-sm">📡</span>
                 <span class="text-white/80 text-sm">Cultural Impact</span>
                 <div class="relative ml-1">
                   <svg
@@ -324,21 +328,22 @@
               <div class="flex items-center">
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
-                    class="h-2 bg-purple-400 rounded-full"
-                    style={"width: #{score_data.components.cultural_impact * 10}%"}
+                    class="h-2 bg-teal-400 rounded-full"
+                    style={"width: #{display_scores.cultural_impact * 10}%"}
                   >
                   </div>
                 </div>
                 <span class="text-white text-sm w-8">
-                  {score_data.components.cultural_impact}
+                  {format_lens_score(display_scores.cultural_impact)}
                 </span>
               </div>
             </div>
-            
-<!-- People Quality -->
+
+<!-- The Auteurs -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
-                <span class="text-white/80 text-sm">People Quality</span>
+                <span class="mr-1 text-sm">🎬</span>
+                <span class="text-white/80 text-sm">The Auteurs</span>
                 <div class="relative ml-1">
                   <svg
                     class="w-3.5 h-3.5 text-white/40 group-hover:text-white/60 transition-colors cursor-help"
@@ -355,7 +360,7 @@
                     />
                   </svg>
                   <div class="hidden group-hover:block absolute z-10 w-64 p-2 mt-1 text-xs bg-gray-900 text-white rounded-lg shadow-lg left-0">
-                    <strong>People Quality:</strong>
+                    <strong>The Auteurs:</strong>
                     Caliber of director, actors, and key crew based on their overall career achievements
                   </div>
                 </div>
@@ -363,19 +368,20 @@
               <div class="flex items-center">
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
-                    class="h-2 bg-red-400 rounded-full"
-                    style={"width: #{score_data.components.people_quality * 10}%"}
+                    class="h-2 bg-amber-400 rounded-full"
+                    style={"width: #{display_scores.people_quality * 10}%"}
                   >
                   </div>
                 </div>
-                <span class="text-white text-sm w-8">{score_data.components.people_quality}</span>
+                <span class="text-white text-sm w-8">{format_lens_score(display_scores.people_quality)}</span>
               </div>
             </div>
-            
-<!-- Financial Performance -->
+
+<!-- The Box Office -->
             <div class="flex items-center justify-between group">
               <div class="flex items-center">
-                <span class="text-white/80 text-sm">Financial Performance</span>
+                <span class="mr-1 text-sm">💵</span>
+                <span class="text-white/80 text-sm">The Box Office</span>
                 <div class="relative ml-1">
                   <svg
                     class="w-3.5 h-3.5 text-white/40 group-hover:text-white/60 transition-colors cursor-help"
@@ -392,7 +398,7 @@
                     />
                   </svg>
                   <div class="hidden group-hover:block absolute z-10 w-64 p-2 mt-1 text-xs bg-gray-900 text-white rounded-lg shadow-lg left-0">
-                    <strong>Financial Performance:</strong>
+                    <strong>The Box Office:</strong>
                     Box office revenue and return on investment (60% revenue scale, 40% ROI ratio)
                   </div>
                 </div>
@@ -401,16 +407,36 @@
                 <div class="w-16 h-2 bg-white/20 rounded-full mr-2">
                   <div
                     class="h-2 bg-green-400 rounded-full"
-                    style={"width: #{score_data.components.financial_performance * 10}%"}
+                    style={"width: #{display_scores.financial_performance * 10}%"}
                   >
                   </div>
                 </div>
                 <span class="text-white text-sm w-8">
-                  {score_data.components.financial_performance}
+                  {format_lens_score(display_scores.financial_performance)}
                 </span>
               </div>
             </div>
           </div>
+
+<!-- Disparity Callout -->
+          <% disparity = Map.get(@movie, :disparity_data) %>
+          <%= if disparity && disparity.disparity_score && disparity.disparity_score > 1.5 do %>
+            <div class="mt-4 p-3 rounded-lg bg-white/10 border border-white/20 text-center">
+              <p class="text-white/90 text-xs font-medium">
+                Critics and audiences disagree —
+                <span class="font-bold"><%= Float.round(disparity.disparity_score, 1) %></span> gap
+              </p>
+              <p class="text-white/60 text-xs mt-1">
+                <%= case disparity.disparity_category do
+                  "critics_darling" -> "Critics' Darling"
+                  "peoples_champion" -> "People's Champion"
+                  "perfect_harmony" -> "Perfect Harmony"
+                  "polarizer" -> "The Polarizer"
+                  _ -> ""
+                end %>
+              </p>
+            </div>
+          <% end %>
         <% else %>
           <p class="text-white/60 text-sm text-center">Score data unavailable</p>
         <% end %>

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -131,6 +131,9 @@ defmodule CinegraphWeb.Router do
     #   /awards/:year             - All awards from a specific year
     # ========================================================================
 
+    # Disparity Explorer
+    live "/explore/disparity", DisparityExplorerLive, :index
+
     # Curated Lists routes
     live "/lists", ListLive.Index, :index
     live "/lists/:slug", ListLive.Show, :show

--- a/priv/repo/migrations/20260323140000_create_movie_score_caches.exs
+++ b/priv/repo/migrations/20260323140000_create_movie_score_caches.exs
@@ -1,0 +1,36 @@
+defmodule Cinegraph.Repo.Migrations.CreateMovieScoreCaches do
+  use Ecto.Migration
+
+  def change do
+    create table(:movie_score_caches) do
+      add :movie_id, references(:movies, on_delete: :delete_all), null: false
+
+      # 6 lens scores (0–10)
+      add :mob_score, :float
+      add :ivory_tower_score, :float
+      add :industry_recognition_score, :float
+      add :cultural_impact_score, :float
+      add :people_quality_score, :float
+      add :financial_performance_score, :float
+
+      # Derived
+      add :overall_score, :float
+      add :score_confidence, :float
+      add :disparity_score, :float
+      add :disparity_category, :string
+      add :unpredictability_score, :float
+
+      # Cache metadata
+      add :calculated_at, :utc_datetime, null: false
+      add :calculation_version, :string, null: false, default: "1"
+
+      timestamps()
+    end
+
+    create unique_index(:movie_score_caches, [:movie_id])
+    create index(:movie_score_caches, [:disparity_category])
+    create index(:movie_score_caches, [:disparity_score])
+    create index(:movie_score_caches, [:unpredictability_score])
+    create index(:movie_score_caches, [:overall_score])
+  end
+end

--- a/test/cinegraph/metrics/disparity_calculator_test.exs
+++ b/test/cinegraph/metrics/disparity_calculator_test.exs
@@ -1,0 +1,107 @@
+defmodule Cinegraph.Metrics.DisparityCalculatorTest do
+  use ExUnit.Case, async: true
+
+  alias Cinegraph.Metrics.DisparityCalculator
+
+  describe "calculate_disparity/2" do
+    test "returns absolute difference" do
+      assert DisparityCalculator.calculate_disparity(8.5, 4.0) == 4.5
+      assert DisparityCalculator.calculate_disparity(4.0, 8.5) == 4.5
+      assert DisparityCalculator.calculate_disparity(5.0, 5.0) == 0.0
+    end
+  end
+
+  describe "classify_disparity/3" do
+    test "critics_darling when ivory_tower high and mob low" do
+      # ivory > 7.5, mob < 5.5, disparity > 2.0
+      assert DisparityCalculator.classify_disparity(4.0, 8.5, 4.5) == "critics_darling"
+    end
+
+    test "peoples_champion when mob high and ivory_tower low" do
+      # mob > 7.5, ivory < 5.5, disparity > 2.0
+      assert DisparityCalculator.classify_disparity(8.5, 4.0, 4.5) == "peoples_champion"
+    end
+
+    test "perfect_harmony when both high and disparity tiny" do
+      # mob > 7.5, ivory > 7.5, disparity < 0.5
+      assert DisparityCalculator.classify_disparity(8.0, 8.2, 0.2) == "perfect_harmony"
+    end
+
+    test "polarizer when disparity large but doesn't fit other categories" do
+      # e.g. mid-range scores but large gap
+      assert DisparityCalculator.classify_disparity(6.0, 3.0, 3.0) == "polarizer"
+    end
+
+    test "nil when disparity is not significant" do
+      assert DisparityCalculator.classify_disparity(6.0, 5.5, 0.5) == nil
+    end
+  end
+
+  describe "calculate_unpredictability/1" do
+    test "all equal scores returns 0.0" do
+      components = %{
+        mob: 5.0,
+        ivory_tower: 5.0,
+        industry_recognition: 5.0,
+        cultural_impact: 5.0,
+        people_quality: 5.0,
+        financial_performance: 5.0
+      }
+
+      assert DisparityCalculator.calculate_unpredictability(components) == 0.0
+    end
+
+    test "alternating 0/10 returns ~5.0 stddev" do
+      components = %{
+        mob: 0.0,
+        ivory_tower: 10.0,
+        industry_recognition: 0.0,
+        cultural_impact: 10.0,
+        people_quality: 0.0,
+        financial_performance: 10.0
+      }
+
+      result = DisparityCalculator.calculate_unpredictability(components)
+      assert_in_delta result, 5.0, 0.01
+    end
+  end
+
+  describe "calculate_all/1" do
+    test "both-zero case returns nil disparity and category" do
+      scores = %{
+        components: %{
+          mob: 0.0,
+          ivory_tower: 0.0,
+          industry_recognition: 0.0,
+          cultural_impact: 0.0,
+          people_quality: 0.0,
+          financial_performance: 0.0
+        }
+      }
+
+      result = DisparityCalculator.calculate_all(scores)
+      assert result.disparity_score == nil
+      assert result.disparity_category == nil
+      assert result.unpredictability_score == 0.0
+    end
+
+    test "normal case returns expected map structure" do
+      scores = %{
+        components: %{
+          mob: 4.0,
+          ivory_tower: 8.5,
+          industry_recognition: 7.0,
+          cultural_impact: 6.0,
+          people_quality: 5.0,
+          financial_performance: 3.0
+        }
+      }
+
+      result = DisparityCalculator.calculate_all(scores)
+      assert result.disparity_score == 4.5
+      assert result.disparity_category == "critics_darling"
+      assert is_float(result.unpredictability_score)
+      assert result.unpredictability_score > 0.0
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Adds a disparity scoring system to measure the gap between critic and audience ratings, with a new explorer interface to browse movies by disparity categories.

### What changed?

- **New disparity calculation module** (`DisparityCalculator`) that computes the absolute difference between mob and ivory tower scores and classifies movies into categories: Critics' Darlings, People's Champions, Perfect Harmony, and Polarizers
- **Score caching system** with `MovieScoreCache` schema and background worker to pre-calculate and store all movie scores including disparity metrics
- **Disparity Explorer interface** at `/explore/disparity` with tabbed navigation to browse movies by disparity category
- **Enhanced movie detail pages** now display disparity information when there's a significant gap between critic and audience scores
- **New database queries** to fetch movies by disparity category and top disparity movies
- **Updated movie scoring display** to use cached scores when available, falling back to live calculations

### How to test?

1. Run the migration to create the `movie_score_caches` table
2. Execute `Cinegraph.Workers.MovieScoreCacheWorker.queue_all()` in IEx to populate score caches
3. Visit `/explore/disparity` to browse movies by disparity categories
4. Check individual movie pages to see disparity callouts for movies with significant critic/audience gaps
5. Run the test suite with `mix test test/cinegraph/metrics/disparity_calculator_test.exs`

### Why make this change?

This addresses the need to surface interesting patterns in how different audiences perceive films. By quantifying and categorizing the gap between critic and audience scores, users can discover movies that are beloved by critics but not audiences (and vice versa), or find films that achieve rare universal acclaim. The caching system ensures these calculations are performant at scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Disparity Explorer page to browse and filter movies by critic-audience rating gap
  * Movie detail pages now display disparity categories (e.g., critics' darling, people's champion) and gap metrics
  * Extended scoring breakdown to show disparity insights alongside other lens scores
  * Implemented score caching for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->