### PR TITLE
rabbit

### DIFF
--- a/lib/cinegraph/movies/movie_score_cache.ex
+++ b/lib/cinegraph/movies/movie_score_cache.ex
@@ -56,7 +56,6 @@ defmodule Cinegraph.Movies.MovieScoreCache do
       :financial_performance_score,
       :overall_score,
       :score_confidence,
-      :unpredictability_score,
       :calculated_at,
       :calculation_version
     ])

--- a/lib/cinegraph_web/live/disparity_explorer_live.ex
+++ b/lib/cinegraph_web/live/disparity_explorer_live.ex
@@ -44,6 +44,7 @@ defmodule CinegraphWeb.DisparityExplorerLive do
      socket
      |> assign(:active_tab, tab)
      |> assign(:page, 1)
+     |> assign(:movies, [])
      |> push_patch(to: ~p"/explore/disparity?tab=#{tab}")}
   end
 

--- a/lib/cinegraph_web/live/movie_live/show.ex
+++ b/lib/cinegraph_web/live/movie_live/show.ex
@@ -154,7 +154,7 @@ defmodule CinegraphWeb.MovieLive.Show do
     metrics = Metrics.get_movie_aggregates(id)
 
     # Preload score cache first — skip live calculation when cache is warm
-    movie = Repo.preload(movie, :score_cache)
+    movie = Repo.replica().preload(movie, :score_cache)
 
     {display_scores, disparity_data} =
       if movie.score_cache do

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -420,7 +420,7 @@
 
 <!-- Disparity Callout -->
           <% disparity = Map.get(@movie, :disparity_data) %>
-          <%= if disparity && disparity.disparity_score && disparity.disparity_category && disparity.disparity_score > 1.5 do %>
+          <%= if disparity && disparity.disparity_category in ["critics_darling", "peoples_champion", "polarizer"] do %>
             <div class="mt-4 p-3 rounded-lg bg-white/10 border border-white/20 text-center">
               <p class="text-white/90 text-xs font-medium">
                 Critics and audiences disagree —

--- a/priv/repo/migrations/20260323150000_add_composite_index_to_movie_score_caches.exs
+++ b/priv/repo/migrations/20260323150000_add_composite_index_to_movie_score_caches.exs
@@ -1,11 +1,16 @@
 defmodule Cinegraph.Repo.Migrations.AddCompositeIndexToMovieScoreCaches do
   use Ecto.Migration
 
+  # concurrently: true requires non-transactional DDL
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def change do
     # Composite index for list_movies_by_disparity_category/2:
     # WHERE disparity_category = ? ORDER BY disparity_score DESC, id ASC
     create index(:movie_score_caches, [:disparity_category, :disparity_score],
-             name: :idx_score_caches_category_score
+             name: :idx_score_caches_category_score,
+             concurrently: true
            )
   end
 end


### PR DESCRIPTION
### TL;DR

Removed `unpredictability_score` field from movie score cache, improved disparity callout logic, and added concurrent database indexing.

### What changed?

- Removed `unpredictability_score` from the `MovieScoreCache` select fields
- Updated disparity callout display logic to check for specific categories (`critics_darling`, `peoples_champion`, `polarizer`) instead of numeric score threshold
- Added empty movies list initialization when switching tabs in the disparity explorer
- Changed movie preloading to use replica database connection
- Modified database migration to create composite index concurrently with proper transaction settings

### How to test?

- Verify movie detail pages load correctly without unpredictability score references
- Check that disparity callouts appear only for movies with the specified disparity categories
- Test tab switching in the disparity explorer to ensure movies list resets properly
- Confirm the database migration runs without blocking other operations

### Why make this change?

The unpredictability score field was likely deprecated or unused, requiring cleanup from the caching layer. The disparity callout logic was refined to be more precise by targeting specific meaningful categories rather than relying on arbitrary numeric thresholds. The concurrent index creation prevents database locks during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed movies list not resetting properly when switching tabs in the disparity explorer.

* **Improvements**
  * Updated disparity callout visibility to display for additional disparity types based on category classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->