### PR TITLE
final rabbit

### DIFF
--- a/lib/cinegraph_web/live/movie_live/show.ex
+++ b/lib/cinegraph_web/live/movie_live/show.ex
@@ -162,8 +162,7 @@ defmodule CinegraphWeb.MovieLive.Show do
 
         dd = %{
           disparity_score: movie.score_cache.disparity_score,
-          disparity_category: movie.score_cache.disparity_category,
-          unpredictability_score: movie.score_cache.unpredictability_score
+          disparity_category: movie.score_cache.disparity_category
         }
 
         {ds, dd}

--- a/priv/repo/migrations/20260323150000_add_composite_index_to_movie_score_caches.exs
+++ b/priv/repo/migrations/20260323150000_add_composite_index_to_movie_score_caches.exs
@@ -5,12 +5,16 @@ defmodule Cinegraph.Repo.Migrations.AddCompositeIndexToMovieScoreCaches do
   @disable_ddl_transaction true
   @disable_migration_lock true
 
-  def change do
-    # Composite index for list_movies_by_disparity_category/2:
+  def up do
+    # Fully covers list_movies_by_disparity_category/2:
     # WHERE disparity_category = ? ORDER BY disparity_score DESC, id ASC
-    create index(:movie_score_caches, [:disparity_category, :disparity_score],
-             name: :idx_score_caches_category_score,
-             concurrently: true
-           )
+    execute """
+    CREATE INDEX CONCURRENTLY idx_score_caches_category_score
+    ON movie_score_caches (disparity_category ASC, disparity_score DESC, id ASC)
+    """
+  end
+
+  def down do
+    execute "DROP INDEX CONCURRENTLY IF EXISTS idx_score_caches_category_score"
   end
 end


### PR DESCRIPTION
### TL;DR

Removed unpredictability_score from movie display data and improved database index for movie score cache queries.

### What changed?

- Removed `unpredictability_score` field from the movie display data map in the MovieLive.Show module
- Enhanced the composite database index on `movie_score_caches` table to include all three columns (disparity_category, disparity_score, id) with proper sort order using raw SQL
- Updated migration to use explicit `up/0` and `down/0` functions instead of `change/0`

### How to test?

- Navigate to movie detail pages and verify they load correctly without the unpredictability score
- Run the database migration and confirm the new composite index is created successfully
- Test movie listing queries by disparity category to ensure improved performance

### Why make this change?

The unpredictability score was likely no longer needed in the UI display, simplifying the data structure. The database index improvement provides better query performance for `list_movies_by_disparity_category/2` by creating a covering index that matches the exact WHERE clause and ORDER BY requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed `unpredictability_score` from disparity data responses.

* **Chores**
  * Updated database indexing configuration for movie score caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->