### PR TITLE
tiny up

### DIFF
--- a/lib/cinegraph_web/components/layouts/root.html.heex
+++ b/lib/cinegraph_web/components/layouts/root.html.heex
@@ -82,6 +82,9 @@
               <.link navigate={~p"/movies/discover"} class="text-zinc-700 hover:text-zinc-900">
                 Discovery
               </.link>
+              <.link navigate={~p"/explore/disparity"} class="text-zinc-700 hover:text-zinc-900">
+                Disparity
+              </.link>
             </nav>
           </div>
         </div>

--- a/priv/repo/migrations/20260323150000_add_composite_index_to_movie_score_caches.exs
+++ b/priv/repo/migrations/20260323150000_add_composite_index_to_movie_score_caches.exs
@@ -7,10 +7,11 @@ defmodule Cinegraph.Repo.Migrations.AddCompositeIndexToMovieScoreCaches do
 
   def up do
     # Fully covers list_movies_by_disparity_category/2:
-    # WHERE disparity_category = ? ORDER BY disparity_score DESC, id ASC
+    # WHERE disparity_category = ? ORDER BY disparity_score DESC, m.id ASC
+    # movie_id is the FK to movies.id — the column used for the tiebreaker sort
     execute """
     CREATE INDEX CONCURRENTLY idx_score_caches_category_score
-    ON movie_score_caches (disparity_category ASC, disparity_score DESC, id ASC)
+    ON movie_score_caches (disparity_category ASC, disparity_score DESC, movie_id ASC)
     """
   end
 


### PR DESCRIPTION
### TL;DR

Added a "Disparity" navigation link and fixed a database index to use the correct column for sorting.

### What changed?

- Added a new "Disparity" navigation link in the root layout that points to `/explore/disparity`
- Updated the composite database index on `movie_score_caches` to use `movie_id` instead of `id` for the tiebreaker sort column

### How to test?

- Verify the new "Disparity" link appears in the navigation menu and navigates to the correct route
- Check that the database index migration runs successfully and improves query performance for disparity-related movie listings

### Why make this change?

The navigation link provides user access to the disparity exploration feature. The index correction ensures the database query optimization aligns with the actual column used for tiebreaker sorting in the `list_movies_by_disparity_category/2` function, where `movie_id` (the foreign key to movies.id) is used rather than the cache table's own `id` column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Disparity" navigation link to the main menu for accessing disparity exploration features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->