### PR TITLE
phase 6

### DIFF
--- a/lib/cinegraph/metrics/metric_weight_profile.ex
+++ b/lib/cinegraph/metrics/metric_weight_profile.ex
@@ -21,21 +21,21 @@ defmodule Cinegraph.Metrics.MetricWeightProfile do
     # Example: {"imdb_rating" => 1.0, "oscar_wins" => 2.0, "revenue_worldwide" => 0.8}
 
     # Category multipliers (applied after individual weights)
-    # Using the standard 6-category scoring system:
-    # - mob: Audience ratings (IMDb, TMDb)
+    # Using the standard 6-lens scoring system:
+    # - mob: Audience ratings (IMDb, TMDb, RT Audience)
     # - ivory_tower: Critics scores (RT Tomatometer, Metacritic)
-    # - awards: Industry recognition through festival wins and nominations
-    # - financial: Revenue and budget performance
-    # - cultural: Canonical sources and cultural impact
-    # - people: Quality scores of cast and crew
+    # - industry_recognition: Festival wins and nominations
+    # - financial_performance: Revenue and budget performance
+    # - cultural_impact: Canonical sources and cultural reach
+    # - people_quality: Quality scores of cast and crew
     field :category_weights, :map,
       default: %{
         "mob" => 0.10,
         "ivory_tower" => 0.10,
-        "awards" => 0.20,
-        "financial" => 0.20,
-        "cultural" => 0.20,
-        "people" => 0.20
+        "industry_recognition" => 0.20,
+        "financial_performance" => 0.20,
+        "cultural_impact" => 0.20,
+        "people_quality" => 0.20
       }
 
     # Usage tracking
@@ -80,11 +80,10 @@ defmodule Cinegraph.Metrics.MetricWeightProfile do
         valid_categories = [
           "mob",
           "ivory_tower",
-          "ratings",
-          "awards",
-          "financial",
-          "cultural",
-          "people"
+          "industry_recognition",
+          "financial_performance",
+          "cultural_impact",
+          "people_quality"
         ]
 
         cond do

--- a/lib/cinegraph/metrics/scoring_service.ex
+++ b/lib/cinegraph/metrics/scoring_service.ex
@@ -63,10 +63,10 @@ defmodule Cinegraph.Metrics.ScoringService do
       category_weights: %{
         "mob" => 0.10,
         "ivory_tower" => 0.10,
-        "awards" => 0.20,
-        "cultural" => 0.20,
-        "people" => 0.20,
-        "financial" => 0.20
+        "industry_recognition" => 0.20,
+        "cultural_impact" => 0.20,
+        "people_quality" => 0.20,
+        "financial_performance" => 0.20
       },
       weights: %{},
       active: true,
@@ -92,26 +92,17 @@ defmodule Cinegraph.Metrics.ScoringService do
         half = legacy_popular / 2.0
         {half, half}
       else
-        mob =
-          get_category_weight(profile, "mob", get_category_weight(profile, "ratings", 0.2) / 2)
-
-        ivory =
-          get_category_weight(
-            profile,
-            "ivory_tower",
-            get_category_weight(profile, "ratings", 0.2) / 2
-          )
-
-        {mob, ivory}
+        {get_category_weight(profile, "mob", 0.15),
+         get_category_weight(profile, "ivory_tower", 0.15)}
       end
 
     %{
       mob: mob_weight,
       ivory_tower: ivory_tower_weight,
-      industry_recognition: get_category_weight(profile, "awards", 0.2),
-      cultural_impact: get_category_weight(profile, "cultural", 0.2),
-      people_quality: get_category_weight(profile, "people", 0.2),
-      financial_success: get_category_weight(profile, "financial", 0.0)
+      industry_recognition: get_category_weight(profile, "industry_recognition", 0.2),
+      cultural_impact: get_category_weight(profile, "cultural_impact", 0.2),
+      people_quality: get_category_weight(profile, "people_quality", 0.15),
+      financial_performance: get_category_weight(profile, "financial_performance", 0.15)
     }
   end
 
@@ -123,12 +114,12 @@ defmodule Cinegraph.Metrics.ScoringService do
       name: name,
       description: "Custom weight profile created from discovery UI",
       category_weights: %{
-        "mob" => Map.get(weights, :mob, 0.1),
-        "ivory_tower" => Map.get(weights, :ivory_tower, 0.1),
-        "awards" => Map.get(weights, :industry_recognition, 0.2),
-        "financial" => Map.get(weights, :financial_success, 0.2),
-        "cultural" => Map.get(weights, :cultural_impact, 0.2),
-        "people" => Map.get(weights, :people_quality, 0.2)
+        "mob" => Map.get(weights, :mob, 0.15),
+        "ivory_tower" => Map.get(weights, :ivory_tower, 0.15),
+        "industry_recognition" => Map.get(weights, :industry_recognition, 0.2),
+        "financial_performance" => Map.get(weights, :financial_performance, 0.15),
+        "cultural_impact" => Map.get(weights, :cultural_impact, 0.2),
+        "people_quality" => Map.get(weights, :people_quality, 0.15)
       },
       weights: build_metric_weights_from_discovery(weights),
       active: true,
@@ -260,7 +251,7 @@ defmodule Cinegraph.Metrics.ScoringService do
         industry_recognition: 0.20,
         cultural_impact: 0.20,
         people_quality: 0.20,
-        financial_success: 0.20
+        financial_performance: 0.20
       }
     else
       Map.new(weights, fn {k, v} -> {k, v / total} end)
@@ -459,7 +450,7 @@ defmodule Cinegraph.Metrics.ScoringService do
             pop.value,
             ^weights.people_quality,
             pq.avg_person_quality,
-            ^Map.get(weights, :financial_success, 0.0),
+            ^Map.get(weights, :financial_performance, 0.0),
             b.value,
             r.value,
             r.value,
@@ -539,7 +530,7 @@ defmodule Cinegraph.Metrics.ScoringService do
               "COALESCE(COALESCE(?, 0) / 100.0, 0)",
               pq.avg_person_quality
             ),
-          financial_success:
+          financial_performance:
             fragment(
               """
               COALESCE(CASE
@@ -634,7 +625,7 @@ defmodule Cinegraph.Metrics.ScoringService do
             pop.value,
             ^weights.people_quality,
             pq.avg_person_quality,
-            ^Map.get(weights, :financial_success, 0.0),
+            ^Map.get(weights, :financial_performance, 0.0),
             b.value,
             r.value,
             r.value,
@@ -683,7 +674,7 @@ defmodule Cinegraph.Metrics.ScoringService do
               "COALESCE(COALESCE(MAX(?), 0) / 100.0, 0)",
               pq.avg_person_quality
             ),
-          financial_success:
+          financial_performance:
             fragment(
               """
               COALESCE(CASE
@@ -778,7 +769,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           pop.value,
           ^weights.people_quality,
           pq.avg_person_quality,
-          ^Map.get(weights, :financial_success, 0.0),
+          ^Map.get(weights, :financial_performance, 0.0),
           b.value,
           r.value,
           r.value,
@@ -858,7 +849,7 @@ defmodule Cinegraph.Metrics.ScoringService do
           pop.value,
           ^weights.people_quality,
           pq.avg_person_quality,
-          ^Map.get(weights, :financial_success, 0.0),
+          ^Map.get(weights, :financial_performance, 0.0),
           b.value,
           r.value,
           r.value,
@@ -943,7 +934,7 @@ defmodule Cinegraph.Metrics.ScoringService do
             pop.value,
             ^weights.people_quality,
             pq.avg_person_quality,
-            ^Map.get(weights, :financial_success, 0.0),
+            ^Map.get(weights, :financial_performance, 0.0),
             b.value,
             r.value,
             r.value,
@@ -1023,7 +1014,7 @@ defmodule Cinegraph.Metrics.ScoringService do
             pop.value,
             ^weights.people_quality,
             pq.avg_person_quality,
-            ^Map.get(weights, :financial_success, 0.0),
+            ^Map.get(weights, :financial_performance, 0.0),
             b.value,
             r.value,
             r.value,

--- a/lib/cinegraph_web/resolvers/movie_resolver.ex
+++ b/lib/cinegraph_web/resolvers/movie_resolver.ex
@@ -109,6 +109,35 @@ defmodule CinegraphWeb.Resolvers.MovieResolver do
     end
   end
 
+  def lens_scores(movie, _, %{context: %{loader: loader}}) do
+    loader = Dataloader.load(loader, :db, {:score_cache, %{}}, movie)
+
+    on_load(loader, fn loader ->
+      cache = Dataloader.get(loader, :db, {:score_cache, %{}}, movie)
+
+      result =
+        if cache do
+          %{
+            mob: cache.mob_score,
+            ivory_tower: cache.ivory_tower_score,
+            industry_recognition: cache.industry_recognition_score,
+            cultural_impact: cache.cultural_impact_score,
+            people_quality: cache.people_quality_score,
+            financial_performance: cache.financial_performance_score,
+            overall: cache.overall_score,
+            confidence: cache.score_confidence,
+            disparity_score: cache.disparity_score,
+            disparity_category: cache.disparity_category,
+            unpredictability_score: cache.unpredictability_score
+          }
+        else
+          nil
+        end
+
+      {:ok, result}
+    end)
+  end
+
   # Both cri_score and cri_breakdown use the same Dataloader key so
   # Dataloader deduplicates the DB query when both fields are requested.
   def cri_score(movie, _, %{context: %{loader: loader}}) do

--- a/lib/cinegraph_web/schema/movie_types.ex
+++ b/lib/cinegraph_web/schema/movie_types.ex
@@ -23,6 +23,24 @@ defmodule CinegraphWeb.Schema.MovieTypes do
     field :total_nominations, :integer, description: "Total nominations across all ceremonies"
   end
 
+  @desc "Cached 6-lens scores for a movie"
+  object :lens_scores do
+    field :mob, :float, description: "Audience score (IMDb, TMDb, RT Audience) — 0-10"
+    field :ivory_tower, :float, description: "Critics score (Metacritic, RT Tomatometer) — 0-10"
+    field :industry_recognition, :float, description: "Festival & award recognition — 0-10"
+    field :cultural_impact, :float, description: "Canonical sources & cultural reach — 0-10"
+    field :people_quality, :float, description: "Cast & crew quality — 0-10"
+    field :financial_performance, :float, description: "Box office performance — 0-10"
+    field :overall, :float, description: "Weighted overall score — 0-10"
+    field :confidence, :float, description: "Data confidence — 0-1"
+    field :disparity_score, :float, description: "Mob vs ivory_tower gap"
+
+    field :disparity_category, :string,
+      description: "critics_darling | peoples_champion | perfect_harmony | polarizer"
+
+    field :unpredictability_score, :float, description: "Score volatility — 0-10"
+  end
+
   @desc "Cultural Relevance Index breakdown by dimension"
   object :cri_breakdown do
     field :overall_score, :float
@@ -74,6 +92,10 @@ defmodule CinegraphWeb.Schema.MovieTypes do
 
     field :awards, :movie_awards do
       resolve(&MovieResolver.awards/3)
+    end
+
+    field :lens_scores, :lens_scores do
+      resolve(&MovieResolver.lens_scores/3)
     end
 
     field :cri_score, :float do

--- a/priv/repo/migrations/20260324000000_align_metric_weight_profile_keys.exs
+++ b/priv/repo/migrations/20260324000000_align_metric_weight_profile_keys.exs
@@ -1,0 +1,55 @@
+defmodule Cinegraph.Repo.Migrations.AlignMetricWeightProfileKeys do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE metric_weight_profiles
+    SET category_weights = (
+      category_weights
+      - 'awards' - 'financial' - 'cultural' - 'people'
+      || CASE WHEN category_weights ? 'awards'
+              THEN jsonb_build_object('industry_recognition', category_weights->'awards')
+              ELSE '{}' END
+      || CASE WHEN category_weights ? 'financial'
+              THEN jsonb_build_object('financial_performance', category_weights->'financial')
+              ELSE '{}' END
+      || CASE WHEN category_weights ? 'cultural'
+              THEN jsonb_build_object('cultural_impact', category_weights->'cultural')
+              ELSE '{}' END
+      || CASE WHEN category_weights ? 'people'
+              THEN jsonb_build_object('people_quality', category_weights->'people')
+              ELSE '{}' END
+    )
+    WHERE category_weights ? 'awards'
+       OR category_weights ? 'financial'
+       OR category_weights ? 'cultural'
+       OR category_weights ? 'people'
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE metric_weight_profiles
+    SET category_weights = (
+      category_weights
+      - 'industry_recognition' - 'financial_performance' - 'cultural_impact' - 'people_quality'
+      || CASE WHEN category_weights ? 'industry_recognition'
+              THEN jsonb_build_object('awards', category_weights->'industry_recognition')
+              ELSE '{}' END
+      || CASE WHEN category_weights ? 'financial_performance'
+              THEN jsonb_build_object('financial', category_weights->'financial_performance')
+              ELSE '{}' END
+      || CASE WHEN category_weights ? 'cultural_impact'
+              THEN jsonb_build_object('cultural', category_weights->'cultural_impact')
+              ELSE '{}' END
+      || CASE WHEN category_weights ? 'people_quality'
+              THEN jsonb_build_object('people', category_weights->'people_quality')
+              ELSE '{}' END
+    )
+    WHERE category_weights ? 'industry_recognition'
+       OR category_weights ? 'financial_performance'
+       OR category_weights ? 'cultural_impact'
+       OR category_weights ? 'people_quality'
+    """
+  end
+end

--- a/priv/repo/seeds/metric_weight_profiles.exs
+++ b/priv/repo/seeds/metric_weight_profiles.exs
@@ -10,7 +10,8 @@ Repo.delete_all(from mwp in "metric_weight_profiles", where: field(mwp, :is_syst
 weight_profiles = [
   %{
     name: "Balanced",
-    description: "Balanced weight across all six criteria: mob (15%), ivory tower (15%), awards (20%), financial success (20%), cultural impact (15%), people quality (15%)",
+    description:
+      "Balanced weight across all six criteria: mob (15%), ivory tower (15%), awards (20%), financial success (20%), cultural impact (15%), people quality (15%)",
     weights: %{
       # Mob (audience ratings)
       "imdb_rating" => 1.0,
@@ -47,19 +48,19 @@ weight_profiles = [
     category_weights: %{
       "mob" => 0.15,
       "ivory_tower" => 0.15,
-      "awards" => 0.20,
-      "financial" => 0.20,
-      "cultural" => 0.15,
-      "people" => 0.15
+      "industry_recognition" => 0.20,
+      "financial_performance" => 0.20,
+      "cultural_impact" => 0.15,
+      "people_quality" => 0.15
     },
     active: true,
     is_default: true,
     is_system: true
   },
-
   %{
     name: "Award Winner",
-    description: "Emphasizes festival awards and industry recognition (45% awards, 20% cultural, 12.5% mob, 12.5% ivory tower, 10% people)",
+    description:
+      "Emphasizes festival awards and industry recognition (45% awards, 20% cultural, 12.5% mob, 12.5% ivory tower, 10% people)",
     weights: %{
       # Industry Recognition (45%)
       "oscar_wins" => 3.0,
@@ -87,19 +88,19 @@ weight_profiles = [
     category_weights: %{
       "mob" => 0.125,
       "ivory_tower" => 0.125,
-      "awards" => 0.45,
-      "financial" => 0.00,
-      "cultural" => 0.20,
-      "people" => 0.10
+      "industry_recognition" => 0.45,
+      "financial_performance" => 0.00,
+      "cultural_impact" => 0.20,
+      "people_quality" => 0.10
     },
     active: true,
     is_default: false,
     is_system: true
   },
-
   %{
     name: "Critics Choice",
-    description: "Prioritizes critic-favored platforms (25% mob, 25% ivory tower) with cultural impact (30%), some awards (15%), minimal people (5%)",
+    description:
+      "Prioritizes critic-favored platforms (25% mob, 25% ivory tower) with cultural impact (30%), some awards (15%), minimal people (5%)",
     weights: %{
       # Ivory Tower with critic platforms weighted higher (25%)
       "metacritic_metascore" => 3.0,
@@ -126,19 +127,19 @@ weight_profiles = [
     category_weights: %{
       "mob" => 0.25,
       "ivory_tower" => 0.25,
-      "awards" => 0.15,
-      "financial" => 0.00,
-      "cultural" => 0.30,
-      "people" => 0.05
+      "industry_recognition" => 0.15,
+      "financial_performance" => 0.00,
+      "cultural_impact" => 0.30,
+      "people_quality" => 0.05
     },
     active: true,
     is_default: false,
     is_system: true
   },
-
   %{
     name: "Crowd Pleaser",
-    description: "Focuses on mainstream audience (22.5% mob), cultural reach (35%), ivory tower (22.5%), minimal awards (10%), financial (10%)",
+    description:
+      "Focuses on mainstream audience (22.5% mob), cultural reach (35%), ivory tower (22.5%), minimal awards (10%), financial (10%)",
     weights: %{
       # Mob with mainstream platforms weighted higher (22.5%)
       "imdb_rating" => 2.5,
@@ -164,19 +165,19 @@ weight_profiles = [
     category_weights: %{
       "mob" => 0.225,
       "ivory_tower" => 0.225,
-      "awards" => 0.10,
-      "financial" => 0.10,
-      "cultural" => 0.30,
-      "people" => 0.05
+      "industry_recognition" => 0.10,
+      "financial_performance" => 0.10,
+      "cultural_impact" => 0.30,
+      "people_quality" => 0.05
     },
     active: true,
     is_default: false,
     is_system: true
   },
-
   %{
     name: "Cult Classic",
-    description: "Finds films with dedicated followings: cultural lists (35%), moderate ratings (40% split mob/ivory), some awards (10%), people (15%)",
+    description:
+      "Finds films with dedicated followings: cultural lists (35%), moderate ratings (40% split mob/ivory), some awards (10%), people (15%)",
     weights: %{
       # Cultural Lists (35%)
       "criterion" => 2.5,
@@ -206,19 +207,19 @@ weight_profiles = [
     category_weights: %{
       "mob" => 0.20,
       "ivory_tower" => 0.20,
-      "awards" => 0.10,
-      "financial" => 0.00,
-      "cultural" => 0.35,
-      "people" => 0.15
+      "industry_recognition" => 0.10,
+      "financial_performance" => 0.00,
+      "cultural_impact" => 0.35,
+      "people_quality" => 0.15
     },
     active: true,
     is_default: false,
     is_system: true
   },
-
   %{
     name: "Cinegraph Editorial",
-    description: "Calibrated against 1001 Movies You Must See Before You Die. Emphasizes cultural impact and critical consensus over popularity and financial metrics.",
+    description:
+      "Calibrated against 1001 Movies You Must See Before You Die. Emphasizes cultural impact and critical consensus over popularity and financial metrics.",
     weights: %{
       # Ivory Tower (25%)
       "metacritic_metascore" => 2.0,
@@ -253,10 +254,10 @@ weight_profiles = [
     category_weights: %{
       "mob" => 0.10,
       "ivory_tower" => 0.25,
-      "awards" => 0.20,
-      "cultural" => 0.30,
-      "people" => 0.10,
-      "financial" => 0.05
+      "industry_recognition" => 0.20,
+      "financial_performance" => 0.05,
+      "cultural_impact" => 0.30,
+      "people_quality" => 0.10
     },
     active: true,
     is_default: false,
@@ -272,7 +273,14 @@ Enum.each(weight_profiles, fn profile ->
   weights = profile.category_weights || %{}
 
   relevant_weights =
-    Map.take(weights, ["mob", "ivory_tower", "awards", "cultural", "people", "financial"])
+    Map.take(weights, [
+      "mob",
+      "ivory_tower",
+      "industry_recognition",
+      "financial_performance",
+      "cultural_impact",
+      "people_quality"
+    ])
 
   sum = Map.values(relevant_weights) |> Enum.sum()
 
@@ -281,14 +289,14 @@ Enum.each(weight_profiles, fn profile ->
       IO.puts("WARNING: #{profile.name} category weights sum to #{Float.round(sum, 4)} (> 1.01)")
 
       IO.puts(
-        "  Breakdown: mob=#{weights["mob"]}, ivory_tower=#{weights["ivory_tower"]}, awards=#{weights["awards"]}, cultural=#{weights["cultural"]}, people=#{weights["people"]}, financial=#{weights["financial"]}"
+        "  Breakdown: mob=#{weights["mob"]}, ivory_tower=#{weights["ivory_tower"]}, industry_recognition=#{weights["industry_recognition"]}, cultural_impact=#{weights["cultural_impact"]}, people_quality=#{weights["people_quality"]}, financial_performance=#{weights["financial_performance"]}"
       )
 
     sum < 0.99 ->
       IO.puts("WARNING: #{profile.name} category weights sum to #{Float.round(sum, 4)} (< 0.99)")
 
       IO.puts(
-        "  Breakdown: mob=#{weights["mob"]}, ivory_tower=#{weights["ivory_tower"]}, awards=#{weights["awards"]}, cultural=#{weights["cultural"]}, people=#{weights["people"]}, financial=#{weights["financial"]}"
+        "  Breakdown: mob=#{weights["mob"]}, ivory_tower=#{weights["ivory_tower"]}, industry_recognition=#{weights["industry_recognition"]}, cultural_impact=#{weights["cultural_impact"]}, people_quality=#{weights["people_quality"]}, financial_performance=#{weights["financial_performance"]}"
       )
 
     true ->
@@ -296,7 +304,7 @@ Enum.each(weight_profiles, fn profile ->
   end
 
   # Also warn if financial weights are defined but category weight is 0
-  financial_weight = weights["financial"] || 0.0
+  financial_weight = weights["financial_performance"] || 0.0
 
   if financial_weight == 0.0 do
     profile_weights = profile.weights || %{}
@@ -309,7 +317,7 @@ Enum.each(weight_profiles, fn profile ->
 
     if length(defined_financial) > 0 do
       IO.puts(
-        "INFO: #{profile.name} has financial metric weights defined but financial category weight is 0:"
+        "INFO: #{profile.name} has financial metric weights defined but financial_performance category weight is 0:"
       )
 
       IO.puts("  Unused metrics: #{Enum.join(defined_financial, ", ")}")
@@ -333,7 +341,8 @@ Repo.insert_all(
   entries,
   conflict_target: [:name],
   on_conflict:
-    {:replace, [:description, :weights, :category_weights, :active, :is_default, :is_system, :updated_at]}
+    {:replace,
+     [:description, :weights, :category_weights, :active, :is_default, :is_system, :updated_at]}
 )
 
 IO.puts("Upserted #{length(weight_profiles)} metric weight profiles")

--- a/test/cinegraph_web/schema/movie_query_test.exs
+++ b/test/cinegraph_web/schema/movie_query_test.exs
@@ -169,6 +169,76 @@ defmodule CinegraphWeb.Schema.MovieQueryTest do
     end
   end
 
+  describe "lens_scores field" do
+    test "returns null when no score cache exists" do
+      movie = insert_movie(%{tmdb_id: 60_001, title: "Uncached Movie"})
+
+      query = """
+      query {
+        movie(tmdbId: #{movie.tmdb_id}) {
+          lensScores {
+            mob
+            ivoryTower
+            overall
+            disparityCategory
+          }
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"movie" => result}}} = run_query(query)
+      assert result["lensScores"] == nil
+    end
+
+    test "returns lens scores when score cache exists" do
+      movie = insert_movie(%{tmdb_id: 60_002, title: "Cached Movie"})
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {:ok, _} =
+        %Cinegraph.Movies.MovieScoreCache{}
+        |> Cinegraph.Movies.MovieScoreCache.changeset(%{
+          movie_id: movie.id,
+          mob_score: 7.5,
+          ivory_tower_score: 8.2,
+          industry_recognition_score: 6.0,
+          cultural_impact_score: 5.5,
+          people_quality_score: 7.0,
+          financial_performance_score: 4.0,
+          overall_score: 6.8,
+          score_confidence: 0.85,
+          disparity_score: 0.7,
+          disparity_category: "critics_darling",
+          unpredictability_score: 2.1,
+          calculated_at: now,
+          calculation_version: "1.0"
+        })
+        |> Repo.insert()
+
+      query = """
+      query {
+        movie(tmdbId: #{movie.tmdb_id}) {
+          lensScores {
+            mob
+            ivoryTower
+            overall
+            confidence
+            disparityCategory
+          }
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"movie" => result}}} = run_query(query)
+      scores = result["lensScores"]
+      assert scores["mob"] == 7.5
+      assert scores["ivoryTower"] == 8.2
+      assert scores["overall"] == 6.8
+      assert scores["confidence"] == 0.85
+      assert scores["disparityCategory"] == "critics_darling"
+    end
+  end
+
   describe "authentication" do
     setup do
       Application.put_env(:cinegraph, :api_key, "secret-key")


### PR DESCRIPTION
### TL;DR

Renamed scoring category keys from abbreviated names (`awards`, `financial`, `cultural`, `people`) to descriptive names (`industry_recognition`, `financial_performance`, `cultural_impact`, `people_quality`) and added a new GraphQL `lens_scores` field for movies.

### What changed?

- Updated category weight keys in `MetricWeightProfile` schema and validation to use descriptive names
- Renamed `financial_success` to `financial_performance` throughout the scoring service
- Added database migration to transform existing category weight keys in stored profiles
- Updated seed data to use new category naming convention
- Added new GraphQL `lens_scores` field that exposes cached 6-lens scoring data for movies
- Updated default weight values for `mob` and `ivory_tower` categories from 0.10 to 0.15

### How to test?

1. Run the database migration to ensure existing metric weight profiles are updated correctly
2. Query the new `lens_scores` field on any movie with cached scoring data:
   ```graphql
   query {
     movie(tmdbId: 123) {
       lensScores {
         mob
         ivoryTower
         industryRecognition
         culturalImpact
         peopleQuality
         financialPerformance
         overall
         confidence
       }
     }
   }
   ```
3. Verify that scoring calculations still work with the renamed category keys

### Why make this change?

The abbreviated category names (`awards`, `financial`, etc.) were unclear and inconsistent with the actual scoring lens names used elsewhere in the system. The descriptive names (`industry_recognition`, `financial_performance`) better reflect what each category measures and align with the "6-lens scoring system" terminology. The new `lens_scores` GraphQL field provides direct access to cached scoring data without requiring separate queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lens_scores` field to movie queries, enabling access to detailed scoring breakdowns including mob, ivory tower, industry recognition, cultural impact, people quality, financial performance, overall score, confidence, and disparity metrics.

* **Refactor**
  * Updated scoring category names for improved clarity: "awards" → "industry recognition", "financial" → "financial performance", "cultural" → "cultural impact", "people" → "people quality".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->