### PR TITLE
fix again

### DIFF
--- a/lib/cinegraph/movies/search.ex
+++ b/lib/cinegraph/movies/search.ex
@@ -80,6 +80,8 @@ defmodule Cinegraph.Movies.Search do
             nil -> nil
             profile -> profile.category_weights
           end
+        else
+          nil
         end
 
       # Apply custom sorting if needed

--- a/lib/cinegraph_web/live/movie_live/advanced_filters.ex
+++ b/lib/cinegraph_web/live/movie_live/advanced_filters.ex
@@ -387,6 +387,15 @@ defmodule CinegraphWeb.MovieLive.AdvancedFilters do
           _ -> value
         end
 
+      key == "disparity" ->
+        case value do
+          "critics_darling" -> "Critics' Darlings"
+          "peoples_champion" -> "People's Champions"
+          "perfect_harmony" -> "Perfect Harmony"
+          "polarizer" -> "The Polarizers"
+          _ -> value
+        end
+
       # Legacy filter values
       key in ["award_status"] ->
         case value do


### PR DESCRIPTION
### TL;DR

Added missing `else` clause to prevent crashes in movie search and implemented display name mapping for disparity filter values.

### What changed?

- Added an `else` clause in the movie search module to handle cases where user profile lookup fails, returning `nil` instead of crashing
- Added display name mapping for disparity filter values, converting internal keys like "critics_darling" to user-friendly labels like "Critics' Darlings"

### How to test?

- Test movie search functionality when user profile lookup fails to ensure it doesn't crash
- Verify that disparity filter options display with proper human-readable names in the advanced filters UI
- Test all four disparity filter values: "Critics' Darlings", "People's Champions", "Perfect Harmony", and "The Polarizers"

### Why make this change?

This fixes a potential crash in the search functionality when user profiles cannot be retrieved and improves the user experience by showing meaningful labels instead of technical keys in the disparity filter dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disparity filter now displays human-readable labels for improved clarity.

* **Refactor**
  * Improved control flow in search functionality for code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->