### PR TITLE
finalize

### DIFF
--- a/lib/cinegraph/predictions/criteria_scoring.ex
+++ b/lib/cinegraph/predictions/criteria_scoring.ex
@@ -32,7 +32,8 @@ defmodule Cinegraph.Predictions.CriteriaScoring do
   }
 
   @doc """
-  Get the default weights for the 5 criteria.
+  Get the default weights for the 6 criteria
+  (mob, ivory_tower, festival_recognition, cultural_impact, technical_innovation, auteur_recognition).
   """
   def get_default_weights, do: @default_weights
 

--- a/lib/mix/tasks/db.pull_production.ex
+++ b/lib/mix/tasks/db.pull_production.ex
@@ -340,7 +340,7 @@ defmodule Mix.Tasks.Db.PullProduction do
       {:error, reason, code} ->
         IO.write("\r\e[K")
         File.rm(dump_path)
-        error("  ✗ pg_dump via SSH failed (exit #{code}): #{reason}")
+        error("  ✗ pg_dump via SSH failed (exit #{code})#{if reason != "", do: ": #{reason}", else: ""}")
         {:error, "pg_dump via SSH failed"}
     end
   end


### PR DESCRIPTION
### TL;DR

Updated documentation to reflect 6 criteria instead of 5 and improved error message formatting for empty SSH error reasons.

### What changed?

- Updated the docstring in `CriteriaScoring` module to correctly state "6 criteria" instead of "5 criteria" and added the complete list of criteria names
- Modified the error message in the database pull production task to conditionally display the reason only when it's not empty, avoiding awkward formatting with empty error messages

### How to test?

- Verify the documentation accurately reflects the criteria count by checking `Cinegraph.Predictions.CriteriaScoring.get_default_weights/0`
- Test the database pull task with scenarios that produce SSH errors with both empty and non-empty error reasons to confirm proper message formatting

### Why make this change?

The documentation was outdated and didn't match the actual number of criteria being used. The error message formatting improvement prevents displaying unnecessary colons and spaces when SSH errors don't include a specific reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal documentation clarity for scoring criteria
  * Enhanced error message formatting in database operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->