### PR TITLE
Handle slugless movie show routes

### DIFF
--- a/lib/cinegraph_web/components/neutral_v2_components.ex
+++ b/lib/cinegraph_web/components/neutral_v2_components.ex
@@ -1419,7 +1419,7 @@ defmodule CinegraphWeb.NeutralV2Components do
         <div class="flex gap-2 overflow-x-auto">
           <.link
             :for={m <- @c.movies}
-            navigate={UrlHelpers.movie_href(m.slug, m.id)}
+            {movie_link_attrs(m)}
             class="shrink-0 text-center no-underline text-inherit hover:opacity-75"
             title={m.title}
           >
@@ -1456,6 +1456,12 @@ defmodule CinegraphWeb.NeutralV2Components do
   end
 
   defp format_revenue(n), do: to_string(n)
+
+  defp movie_link_attrs(%{slug: slug, id: id}) when is_binary(slug) and slug != "" do
+    %{navigate: UrlHelpers.movie_href(slug, id)}
+  end
+
+  defp movie_link_attrs(%{id: id}), do: %{href: UrlHelpers.movie_href(nil, id)}
 
   @doc """
   Vertical right-rail "On this page" TOC. Each entry is a map with `:id`,

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -82,8 +82,14 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
 
   # ─── Data loading (mirrors V1 patterns) ────────────────────────────
 
-  defp load_movie(slug) do
-    movie = Movies.get_movie_by_slug!(slug)
+  defp load_movie(id_or_slug) do
+    case fetch_movie_by_slug_or_id(id_or_slug) do
+      {:ok, movie} -> load_movie_data(movie)
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  defp load_movie_data(movie) do
     movie = Repo.replica().preload(movie, :score_cache)
     movie = Map.merge(movie, Metrics.get_movie_aggregates(movie.id))
 
@@ -158,6 +164,21 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
        related_movies: related,
        director_other_films: director_other_films
      }}
+  rescue
+    Ecto.NoResultsError -> {:error, :not_found}
+  end
+
+  defp fetch_movie_by_slug_or_id(id_or_slug) do
+    {:ok, Movies.get_movie_by_slug!(id_or_slug)}
+  rescue
+    Ecto.NoResultsError -> fetch_movie_by_id(id_or_slug)
+  end
+
+  defp fetch_movie_by_id(id_or_slug) do
+    case Integer.parse(id_or_slug) do
+      {id, ""} -> {:ok, Movies.get_movie!(id)}
+      _ -> {:error, :not_found}
+    end
   rescue
     Ecto.NoResultsError -> {:error, :not_found}
   end
@@ -519,6 +540,19 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
     ]
   end
 
+  defp legacy_escape_pill(assigns) do
+    ~H"""
+    <%!-- Legacy v1 escape hatch — temporary during the V2 soak period (#792).
+         Same placement and styling as the index pill in IndexV2. --%>
+    <.link
+      navigate={~p"/movies/#{@movie.slug || @movie.id}/legacy"}
+      class="fixed bottom-4 right-4 z-30 inline-flex items-center gap-2 rounded-full bg-mist-950 px-4 py-2 text-xs font-medium text-mist-100 shadow-lg hover:bg-mist-800"
+    >
+      ← Old movie page
+    </.link>
+    """
+  end
+
   # ─── Render ────────────────────────────────────────────────────────
 
   @impl true
@@ -578,8 +612,8 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
           <div class="flex-1 min-w-0 text-white">
             <div class="text-[12px] font-semibold text-white/70 tracking-[.06em] uppercase mb-3">
               {year_of(@movie.release_date)}
-              <span :if={@movie.runtime}> ·        {format_runtime(@movie.runtime)}</span>
-              <span :if={content_rating(@movie)}> ·        {content_rating(@movie)}</span>
+              <span :if={@movie.runtime}> ·         {format_runtime(@movie.runtime)}</span>
+              <span :if={content_rating(@movie)}> ·         {content_rating(@movie)}</span>
               <span
                 :if={disparity_label(@disparity_data[:disparity_category])}
                 class="ml-3 text-amber-300 font-display italic normal-case tracking-normal"
@@ -1004,7 +1038,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
               >
                 <div class="text-[11px] font-semibold text-mist-500 tracking-[.06em] uppercase">
                   {l.list_authority || "List"}
-                  <span :if={l.list_year}> ·        {l.list_year}</span>
+                  <span :if={l.list_year}> ·         {l.list_year}</span>
                 </div>
                 <div class="mt-1 font-display italic text-[18px] text-mist-950 leading-tight">
                   {l.list_name}
@@ -1266,14 +1300,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
       </div>
     </div>
 
-    <%!-- Legacy v1 escape hatch — temporary during the V2 soak period (#792).
-         Same placement and styling as the index pill in IndexV2. --%>
-    <.link
-      navigate={~p"/movies/#{@movie.slug || @movie.id}/legacy"}
-      class="fixed bottom-4 right-4 z-30 inline-flex items-center gap-2 rounded-full bg-mist-950 px-4 py-2 text-xs font-medium text-mist-100 shadow-lg hover:bg-mist-800"
-    >
-      ← Old movie page
-    </.link>
+    <.legacy_escape_pill movie={@movie} />
     """
   end
 end

--- a/test/cinegraph_web/live/movie_live/show_v2_route_test.exs
+++ b/test/cinegraph_web/live/movie_live/show_v2_route_test.exs
@@ -41,7 +41,19 @@ defmodule CinegraphWeb.MovieLive.ShowV2RouteTest do
       {:ok, _view, html} = live(conn, ~p"/movies/#{movie.slug}")
       # V2-specific marker: the bottom-right escape-hatch pill (#792)
       assert html =~ "Old movie page"
-      assert html =~ "fixed bottom-4 right-4"
+      assert html =~ ~p"/movies/#{movie.slug}/legacy"
+      assert html =~ movie.title
+    end
+
+    test "falls back to numeric ID routes for movies without slugs", %{conn: conn, movie: movie} do
+      movie =
+        movie
+        |> Ecto.Changeset.change(slug: nil)
+        |> Repo.update!()
+
+      {:ok, _view, html} = live(conn, ~p"/movies/#{movie.id}")
+      assert html =~ "Old movie page"
+      assert html =~ ~p"/movies/#{movie.id}/legacy"
       assert html =~ movie.title
     end
   end
@@ -50,6 +62,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2RouteTest do
     test "still renders the V2 show page", %{conn: conn, movie: movie} do
       {:ok, _view, html} = live(conn, ~p"/movies-v2/#{movie.slug}")
       assert html =~ "Old movie page"
+      assert html =~ ~p"/movies/#{movie.slug}/legacy"
       assert html =~ movie.title
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of movie navigation links to work correctly when certain movie metadata is unavailable.

* **New Features**
  * Added a legacy movie page link to the movie detail view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->