### PR TITLE
Implement availability audit and region-aware watch refreshes

### DIFF
--- a/lib/cinegraph/health/availability_audit.ex
+++ b/lib/cinegraph/health/availability_audit.ex
@@ -1,0 +1,435 @@
+defmodule Cinegraph.Health.AvailabilityAudit do
+  @moduledoc """
+  Operational audit for movie watch availability coverage and freshness.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Cinegraph.Movies.{
+    Availability,
+    Movie,
+    MovieAvailabilityRefresh,
+    WatchProvider,
+    WatchProviderRegion
+  }
+
+  alias Cinegraph.Repo
+
+  @availability_workers [
+    "Cinegraph.Workers.MovieAvailabilityRefreshWorker",
+    "Cinegraph.Workers.WatchProviderCatalogRefreshWorker",
+    "Cinegraph.Workers.AvailabilityRefreshSweeper"
+  ]
+
+  @queue_states ~w(available scheduled executing retryable completed discarded cancelled)
+
+  def audit(opts \\ []) do
+    region = opts |> Keyword.get(:region, Availability.default_region()) |> normalize_region()
+    limit = opts |> Keyword.get(:limit, 10) |> normalize_positive_integer(10)
+    stale_days = opts |> Keyword.get(:stale_days, 30) |> normalize_positive_integer(30)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    stale_cutoff = DateTime.add(now, -stale_days * 86_400, :second)
+
+    %{
+      generated_at: DateTime.to_iso8601(now),
+      region: region,
+      summary: summary(region),
+      coverage: coverage(region),
+      freshness: freshness(region, now, stale_cutoff),
+      errors: errors(region, limit),
+      catalog: catalog(now),
+      queues: queues(),
+      examples: examples(region, limit, now),
+      recommended_commands: recommended_commands(region)
+    }
+  end
+
+  defp summary(region) do
+    %{
+      full_movies_with_tmdb: full_movies_with_tmdb_count(),
+      movies_with_raw_watch_providers: raw_watch_provider_count(),
+      movies_with_any_normalized_availability: any_normalized_count(),
+      movies_with_region_refresh: region_refresh_count(region),
+      movies_with_non_default_region_availability: non_default_region_count()
+    }
+  end
+
+  defp coverage(region) do
+    total = full_movies_with_tmdb_count()
+
+    %{
+      raw_tmdb_pct: pct(raw_watch_provider_count(), total),
+      normalized_pct: pct(any_normalized_count(), total),
+      region_refresh_pct: pct(region_refresh_count(region), total),
+      multi_region_normalized_pct: pct(non_default_region_count(), total)
+    }
+  end
+
+  defp freshness(region, now, stale_cutoff) do
+    base =
+      from(r in MovieAvailabilityRefresh,
+        where: r.region == ^region,
+        where: r.source == "tmdb"
+      )
+
+    %{
+      stale_days: div(DateTime.diff(now, stale_cutoff, :second), 86_400),
+      stale_refresh_rows:
+        Repo.replica().one(from(r in base, where: r.stale_after < ^now, select: count(r.id))) || 0,
+      old_refresh_rows:
+        Repo.replica().one(
+          from(r in base, where: r.fetched_at < ^stale_cutoff, select: count(r.id))
+        ) || 0,
+      oldest_stale_after: iso(Repo.replica().one(from(r in base, select: min(r.stale_after)))),
+      newest_fetched_at: iso(Repo.replica().one(from(r in base, select: max(r.fetched_at))))
+    }
+  end
+
+  defp errors(region, limit) do
+    base =
+      from(r in MovieAvailabilityRefresh,
+        where: r.region == ^region,
+        where: r.source == "tmdb",
+        where: r.status == "error"
+      )
+
+    grouped =
+      from(r in base,
+        group_by: r.error_reason,
+        order_by: [desc: count(r.id)],
+        limit: ^limit,
+        select: %{error_reason: r.error_reason, count: count(r.id)}
+      )
+      |> Repo.replica().all()
+      |> Enum.map(fn row -> %{row | error_reason: display_error_reason(row.error_reason)} end)
+
+    %{
+      current_error_rows: Repo.replica().one(from(r in base, select: count(r.id))) || 0,
+      grouped_by_reason: grouped
+    }
+  end
+
+  defp catalog(now) do
+    cutoff = DateTime.add(now, -7 * 86_400, :second)
+
+    provider_count = Repo.replica().one(from(p in WatchProvider, select: count(p.id))) || 0
+    region_count = Repo.replica().one(from(r in WatchProviderRegion, select: count(r.id))) || 0
+
+    oldest_provider_seen_at =
+      Repo.replica().one(from(p in WatchProvider, select: min(p.last_seen_at)))
+
+    newest_provider_seen_at =
+      Repo.replica().one(from(p in WatchProvider, select: max(p.last_seen_at)))
+
+    oldest_region_seen_at =
+      Repo.replica().one(from(r in WatchProviderRegion, select: min(r.last_seen_at)))
+
+    newest_region_seen_at =
+      Repo.replica().one(from(r in WatchProviderRegion, select: max(r.last_seen_at)))
+
+    stale_provider_count =
+      Repo.replica().one(
+        from(p in WatchProvider,
+          where: is_nil(p.last_seen_at) or p.last_seen_at < ^cutoff,
+          select: count(p.id)
+        )
+      ) || 0
+
+    stale_region_count =
+      Repo.replica().one(
+        from(r in WatchProviderRegion,
+          where: is_nil(r.last_seen_at) or r.last_seen_at < ^cutoff,
+          select: count(r.id)
+        )
+      ) || 0
+
+    %{
+      provider_count: provider_count,
+      region_count: region_count,
+      oldest_provider_seen_at: iso(oldest_provider_seen_at),
+      newest_provider_seen_at: iso(newest_provider_seen_at),
+      oldest_region_seen_at: iso(oldest_region_seen_at),
+      newest_region_seen_at: iso(newest_region_seen_at),
+      stale_provider_count: stale_provider_count,
+      stale_region_count: stale_region_count,
+      missing_catalog: provider_count == 0 or region_count == 0
+    }
+  end
+
+  defp queues do
+    rows =
+      from(j in Oban.Job,
+        where: j.worker in ^@availability_workers,
+        where: j.state in ^@queue_states,
+        group_by: [j.worker, j.state],
+        select: {j.worker, j.state, count(j.id)}
+      )
+      |> Repo.replica().all()
+
+    Map.new(@availability_workers, fn worker ->
+      counts =
+        @queue_states
+        |> Map.new(fn state ->
+          count =
+            rows
+            |> Enum.find_value(0, fn
+              {^worker, ^state, count} -> count
+              _ -> nil
+            end)
+
+          {state, count}
+        end)
+
+      {worker, counts}
+    end)
+  end
+
+  defp examples(region, limit, now) do
+    %{
+      raw_but_not_normalized: raw_but_not_normalized_examples(region, limit),
+      raw_multi_region_but_default_only_normalized:
+        raw_multi_region_default_only_examples(region, limit),
+      missing_region_refresh: missing_region_refresh_examples(region, limit),
+      stale_refreshes: stale_examples(region, limit, now),
+      error_refreshes: error_examples(region, limit)
+    }
+  end
+
+  defp raw_but_not_normalized_examples(region, limit) do
+    reason = "raw watch_providers present but #{region}/tmdb refresh row missing"
+
+    from(m in full_movies_with_tmdb(),
+      where: fragment("? \\? 'watch_providers'", m.tmdb_data),
+      where:
+        not exists(
+          from(r in MovieAvailabilityRefresh,
+            where: r.movie_id == parent_as(:movie).id,
+            where: r.region == ^region,
+            where: r.source == "tmdb"
+          )
+        ),
+      order_by: [asc: m.id],
+      limit: ^limit,
+      select: %{
+        id: m.id,
+        title: m.title,
+        reason: ^reason
+      }
+    )
+    |> Repo.replica().all()
+  end
+
+  defp raw_multi_region_default_only_examples(region, limit) do
+    reason = "raw payload has multiple regions but only #{region} normalized"
+
+    from(m in full_movies_with_tmdb(),
+      where: fragment("jsonb_typeof(? #> '{watch_providers,results}') = 'object'", m.tmdb_data),
+      where:
+        fragment(
+          "(SELECT count(*) FROM jsonb_object_keys(? #> '{watch_providers,results}')) > 1",
+          m.tmdb_data
+        ),
+      where:
+        exists(
+          from(r in MovieAvailabilityRefresh,
+            where: r.movie_id == parent_as(:movie).id,
+            where: r.region == ^region,
+            where: r.source == "tmdb"
+          )
+        ),
+      where:
+        not exists(
+          from(r in MovieAvailabilityRefresh,
+            where: r.movie_id == parent_as(:movie).id,
+            where: r.region != ^region,
+            where: r.source == "tmdb"
+          )
+        ),
+      order_by: [asc: m.id],
+      limit: ^limit,
+      select: %{
+        id: m.id,
+        title: m.title,
+        reason: ^reason
+      }
+    )
+    |> Repo.replica().all()
+  end
+
+  defp missing_region_refresh_examples(region, limit) do
+    reason = "#{region}/tmdb availability refresh row missing"
+
+    from(m in full_movies_with_tmdb(),
+      where:
+        not exists(
+          from(r in MovieAvailabilityRefresh,
+            where: r.movie_id == parent_as(:movie).id,
+            where: r.region == ^region,
+            where: r.source == "tmdb"
+          )
+        ),
+      order_by: [asc: m.id],
+      limit: ^limit,
+      select: %{
+        id: m.id,
+        title: m.title,
+        reason: ^reason
+      }
+    )
+    |> Repo.replica().all()
+  end
+
+  defp stale_examples(region, limit, now) do
+    from(r in MovieAvailabilityRefresh,
+      join: m in Movie,
+      on: m.id == r.movie_id,
+      where: r.region == ^region,
+      where: r.source == "tmdb",
+      where: r.stale_after < ^now,
+      order_by: [asc: r.stale_after],
+      limit: ^limit,
+      select: %{
+        id: m.id,
+        title: m.title,
+        stale_after: r.stale_after,
+        reason: "availability stale"
+      }
+    )
+    |> Repo.replica().all()
+    |> Enum.map(&serialize_dates/1)
+  end
+
+  defp error_examples(region, limit) do
+    from(r in MovieAvailabilityRefresh,
+      join: m in Movie,
+      on: m.id == r.movie_id,
+      where: r.region == ^region,
+      where: r.source == "tmdb",
+      where: r.status == "error",
+      order_by: [desc: r.fetched_at],
+      limit: ^limit,
+      select: %{
+        id: m.id,
+        title: m.title,
+        error_reason: r.error_reason,
+        reason: "availability refresh error"
+      }
+    )
+    |> Repo.replica().all()
+    |> Enum.map(fn row -> %{row | error_reason: display_error_reason(row.error_reason)} end)
+  end
+
+  defp recommended_commands(region) do
+    [
+      "mix cinegraph.prod.drift availability --json",
+      "mix cinegraph.prod.audit.availability --json --region #{region}",
+      "mix cinegraph.prod.movies.backfill_availability --dry-run --limit 100 --json",
+      "mix cinegraph.prod.queues --json",
+      "mix cinegraph.prod.audit.queue_failures --worker Cinegraph.Workers.MovieAvailabilityRefreshWorker --json",
+      "mix cinegraph.prod.audit.queue_failures --worker Cinegraph.Workers.WatchProviderCatalogRefreshWorker --json"
+    ]
+  end
+
+  defp full_movies_with_tmdb do
+    from(m in Movie, as: :movie, where: m.import_status == "full", where: not is_nil(m.tmdb_id))
+  end
+
+  defp full_movies_with_tmdb_count do
+    Repo.replica().one(from(m in full_movies_with_tmdb(), select: count(m.id))) || 0
+  end
+
+  defp raw_watch_provider_count do
+    Repo.replica().one(
+      from(m in full_movies_with_tmdb(),
+        where: fragment("? \\? 'watch_providers'", m.tmdb_data),
+        select: count(m.id)
+      )
+    ) || 0
+  end
+
+  defp any_normalized_count do
+    Repo.replica().one(
+      from(m in full_movies_with_tmdb(),
+        where:
+          exists(
+            from(r in MovieAvailabilityRefresh,
+              where: r.movie_id == parent_as(:movie).id,
+              where: r.source == "tmdb"
+            )
+          ),
+        select: count(m.id)
+      )
+    ) || 0
+  end
+
+  defp region_refresh_count(region) do
+    Repo.replica().one(
+      from(m in full_movies_with_tmdb(),
+        where:
+          exists(
+            from(r in MovieAvailabilityRefresh,
+              where: r.movie_id == parent_as(:movie).id,
+              where: r.region == ^region,
+              where: r.source == "tmdb"
+            )
+          ),
+        select: count(m.id)
+      )
+    ) || 0
+  end
+
+  defp non_default_region_count do
+    default_region = Availability.default_region()
+
+    Repo.replica().one(
+      from(m in full_movies_with_tmdb(),
+        where:
+          exists(
+            from(r in MovieAvailabilityRefresh,
+              where: r.movie_id == parent_as(:movie).id,
+              where: r.region != ^default_region,
+              where: r.source == "tmdb"
+            )
+          ),
+        select: count(m.id)
+      )
+    ) || 0
+  end
+
+  defp pct(_count, 0), do: 0.0
+  defp pct(count, total), do: Float.round(count * 100.0 / total, 2)
+
+  defp normalize_region(region) when is_binary(region) do
+    region
+    |> String.trim()
+    |> String.upcase()
+    |> case do
+      <<region::binary-size(2)>> -> region
+      _ -> Availability.default_region()
+    end
+  end
+
+  defp normalize_region(_), do: Availability.default_region()
+
+  defp normalize_positive_integer(value, _default) when is_integer(value) and value > 0, do: value
+  defp normalize_positive_integer(_, default), do: default
+
+  defp serialize_dates(map) do
+    Map.new(map, fn
+      {key, %DateTime{} = value} -> {key, DateTime.to_iso8601(value)}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp iso(nil), do: nil
+  defp iso(%DateTime{} = value), do: DateTime.to_iso8601(value)
+
+  defp display_error_reason(nil), do: nil
+
+  defp display_error_reason(reason) when is_binary(reason) do
+    case Jason.decode(reason) do
+      {:ok, decoded} when is_binary(decoded) -> decoded
+      _ -> reason
+    end
+  end
+end

--- a/lib/cinegraph/health/drift/availability.ex
+++ b/lib/cinegraph/health/drift/availability.ex
@@ -39,12 +39,9 @@ defmodule Cinegraph.Health.Drift.Availability do
 
       missing =
         from(m in base,
-          where:
-            fragment(
-              "NOT EXISTS (SELECT 1 FROM movie_availability_refreshes r WHERE r.movie_id = ? AND r.region = ? AND r.source = 'tmdb')",
-              m.id,
-              ^region
-            )
+          left_join: r in MovieAvailabilityRefresh,
+          on: r.movie_id == m.id and r.region == ^region and r.source == "tmdb",
+          where: is_nil(r.id)
         )
 
       total = Repo.replica().one(from(m in base, select: count(m.id))) || 0

--- a/lib/cinegraph/maintenance/refresh_availability.ex
+++ b/lib/cinegraph/maintenance/refresh_availability.ex
@@ -160,17 +160,14 @@ defmodule Cinegraph.Maintenance.RefreshAvailability do
     end)
   end
 
-  defp maybe_put_regions(job, :all), do: job
-
   defp maybe_put_regions(%Ecto.Changeset{} = changeset, regions) do
     args = Ecto.Changeset.get_field(changeset, :args) || %{}
     Ecto.Changeset.put_change(changeset, :args, Map.put(args, "regions", regions))
   end
 
-  defp refresh_regions_arg(:all), do: :all
   defp refresh_regions_arg(regions), do: normalize_regions(regions)
 
-  defp normalize_regions(:all), do: [Availability.default_region()]
+  defp normalize_regions(:all), do: Availability.supported_regions()
 
   defp normalize_regions(regions) when is_binary(regions) do
     regions

--- a/lib/cinegraph/movies/availability.ex
+++ b/lib/cinegraph/movies/availability.ex
@@ -99,6 +99,13 @@ defmodule Cinegraph.Movies.Availability do
 
   def configured_regions, do: @default_regions
   def default_region, do: @default_region
+  def supported_regions, do: @region_names |> Map.keys() |> Enum.sort()
+
+  def supported_region?(region) when is_binary(region) do
+    Map.has_key?(@region_names, normalize_region(region))
+  end
+
+  def supported_region?(_region), do: false
 
   @doc """
   Syncs the watch-provider catalog from TMDb for the selected regions.

--- a/lib/cinegraph/movies/availability_backfill.ex
+++ b/lib/cinegraph/movies/availability_backfill.ex
@@ -111,7 +111,7 @@ defmodule Cinegraph.Movies.AvailabilityBackfill do
       if dry_run? do
         classify_dry_run(stats, payload, movie_regions)
       else
-        store_movie(movie, stats, payload, regions, source)
+        store_movie(movie, stats, payload, movie_regions, source)
       end
     end
   end

--- a/lib/cinegraph/workers/movie_availability_refresh_worker.ex
+++ b/lib/cinegraph/workers/movie_availability_refresh_worker.ex
@@ -8,7 +8,7 @@ defmodule Cinegraph.Workers.MovieAvailabilityRefreshWorker do
     max_attempts: 5,
     unique: [
       fields: [:args],
-      keys: [:movie_id, :regions, :force],
+      keys: [:movie_id, :regions],
       period: 3600,
       states: [:available, :scheduled, :executing, :retryable]
     ]

--- a/lib/cinegraph_web/admin_health/actions.ex
+++ b/lib/cinegraph_web/admin_health/actions.ex
@@ -131,6 +131,6 @@ defmodule CinegraphWeb.AdminHealth.Actions do
       "AdminHealth.Actions enqueue partial failure: #{ok_count} ok, #{length(errors)} errors"
     )
 
-    {:ok, ok_count}
+    {:error, %{ok: ok_count, errors: errors}}
   end
 end

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -38,7 +38,6 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
     "en" => "US",
     "fr" => "FR",
     "de" => "DE",
-    "es" => "ES",
     "it" => "IT",
     "pt" => "PT",
     "ja" => "JP",
@@ -979,7 +978,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
           <ShowV2Availability.where_to_watch
             availability_freshness={@availability_freshness}
             availability_region_label={@availability_region_label}
-            availability_refresh_queued={@availability_refresh_queued?}
+            availability_refresh_queued={@availability_refresh_queued}
             availability_regions={@availability_regions}
             availability_region_options={@availability_region_options}
             availability_region={@availability_region}

--- a/lib/cinegraph_web/live/movie_live/show_v2_availability.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2_availability.ex
@@ -24,7 +24,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2Availability do
       availability_region_options: region_options,
       availability_groups: Availability.list_movie_availability(movie.id, region),
       availability_freshness: Availability.availability_freshness(movie.id, region),
-      availability_refresh_queued?: Availability.availability_refresh_queued?(movie.id, region)
+      availability_refresh_queued: Availability.availability_refresh_queued?(movie.id, region)
     }
   end
 

--- a/lib/cinegraph_web/resolvers/movie_resolver.ex
+++ b/lib/cinegraph_web/resolvers/movie_resolver.ex
@@ -7,7 +7,16 @@ defmodule CinegraphWeb.Resolvers.MovieResolver do
   import Absinthe.Resolution.Helpers, only: [on_load: 2]
 
   alias Cinegraph.Repo
-  alias Cinegraph.Movies.{Availability, Movie, Credit, ExternalMetric, MovieVideo}
+
+  alias Cinegraph.Movies.{
+    Availability,
+    Credit,
+    ExternalMetric,
+    Movie,
+    MovieAvailabilityRefresh,
+    MovieVideo,
+    MovieWatchProvider
+  }
 
   @availability_group_order ~w(flatrate free ads rent buy)
 
@@ -171,32 +180,169 @@ defmodule CinegraphWeb.Resolvers.MovieResolver do
     {:ok, videos}
   end
 
-  def availability(movie, args, _) do
-    regions = Availability.available_regions(movie.id)
-    region = select_availability_region(Map.get(args, :region), regions)
-    region_options = Availability.region_options(regions)
-    region_label = region_options |> Map.new() |> Map.get(region, region)
-    groups = Availability.list_movie_availability(movie.id, region)
-    freshness = Availability.availability_freshness(movie.id, region)
+  def availability(movie, args, %{context: %{loader: loader}}) do
+    batch_key = {:movie_availability, Map.get(args, :region)}
+    loader = Dataloader.load(loader, :availability, batch_key, movie.id)
 
-    {:ok,
-     %{
-       region: region,
-       region_label: region_label,
-       status: availability_status(freshness),
-       tmdb_link: freshness && freshness.tmdb_link,
-       fetched_at: iso8601(freshness && freshness.fetched_at),
-       stale_after: iso8601(freshness && freshness.stale_after),
-       is_stale: stale?(freshness),
-       refresh_queued: Availability.availability_refresh_queued?(movie.id, region),
-       groups: availability_groups(groups),
-       available_regions: availability_region_options(region_options)
-     }}
+    on_load(loader, fn loader ->
+      {:ok, Dataloader.get(loader, :availability, batch_key, movie.id)}
+    end)
+  end
+
+  def availability(movie, args, _) do
+    {:ok, load_availability({:movie_availability, Map.get(args, :region)}, [movie.id])[movie.id]}
+  end
+
+  def load_availability({:movie_availability, requested_region}, movie_ids) do
+    movie_ids = Enum.to_list(movie_ids)
+    source = "tmdb"
+    regions_by_movie = available_regions_by_movie(movie_ids, source)
+
+    selected_by_movie =
+      Map.new(movie_ids, fn movie_id ->
+        regions = Map.get(regions_by_movie, movie_id, [Availability.default_region()])
+        {movie_id, select_availability_region(requested_region, regions)}
+      end)
+
+    selected_regions = selected_by_movie |> Map.values() |> Enum.uniq()
+
+    option_regions =
+      (selected_regions ++ Enum.flat_map(regions_by_movie, fn {_movie_id, regions} -> regions end))
+      |> Enum.uniq()
+
+    labels = option_regions |> Availability.region_options(source: source) |> Map.new()
+    freshness_by_key = availability_freshness_by_key(movie_ids, selected_regions, source)
+    groups_by_key = availability_groups_by_key(movie_ids, selected_regions, source)
+    queued_by_key = availability_queued_by_key(movie_ids, selected_by_movie)
+
+    Map.new(movie_ids, fn movie_id ->
+      region = Map.fetch!(selected_by_movie, movie_id)
+      regions = Map.get(regions_by_movie, movie_id, [Availability.default_region()])
+
+      region_options =
+        if region in regions do
+          regions
+        else
+          [region | regions]
+        end
+
+      freshness = Map.get(freshness_by_key, {movie_id, region})
+
+      {movie_id,
+       %{
+         region: region,
+         region_label: Map.get(labels, region, region),
+         status: availability_status(freshness),
+         tmdb_link: freshness && freshness.tmdb_link,
+         fetched_at: iso8601(freshness && freshness.fetched_at),
+         stale_after: iso8601(freshness && freshness.stale_after),
+         is_stale: stale?(freshness),
+         refresh_queued: Map.get(queued_by_key, {movie_id, region}, false),
+         groups: availability_groups(Map.get(groups_by_key, {movie_id, region}, %{})),
+         available_regions:
+           availability_region_options(Enum.map(region_options, &{&1, Map.get(labels, &1, &1)}))
+       }}
+    end)
   end
 
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
+
+  defp available_regions_by_movie(movie_ids, source) do
+    availability_regions =
+      from(mwp in MovieWatchProvider,
+        where: mwp.movie_id in ^movie_ids,
+        where: mwp.source == ^source,
+        select: {mwp.movie_id, mwp.region}
+      )
+      |> Repo.all()
+
+    refresh_regions =
+      from(r in MovieAvailabilityRefresh,
+        where: r.movie_id in ^movie_ids,
+        where: r.source == ^source,
+        select: {r.movie_id, r.region}
+      )
+      |> Repo.all()
+
+    (availability_regions ++ refresh_regions)
+    |> Enum.group_by(fn {movie_id, _region} -> movie_id end, fn {_movie_id, region} -> region end)
+    |> Map.new(fn {movie_id, regions} -> {movie_id, regions |> Enum.uniq() |> Enum.sort()} end)
+  end
+
+  defp availability_freshness_by_key(movie_ids, regions, source) do
+    from(r in MovieAvailabilityRefresh,
+      where: r.movie_id in ^movie_ids,
+      where: r.region in ^regions,
+      where: r.source == ^source
+    )
+    |> Repo.all()
+    |> Map.new(fn row -> {{row.movie_id, row.region}, row} end)
+  end
+
+  defp availability_groups_by_key(movie_ids, regions, source) do
+    rows =
+      from(mwp in MovieWatchProvider,
+        where: mwp.movie_id in ^movie_ids,
+        where: mwp.region in ^regions,
+        where: mwp.source == ^source,
+        order_by: [
+          asc: mwp.movie_id,
+          asc: mwp.region,
+          asc: mwp.monetization_type,
+          asc_nulls_last: mwp.display_priority,
+          asc: mwp.id
+        ],
+        preload: [:watch_provider]
+      )
+      |> Repo.all()
+
+    rows
+    |> Enum.group_by(&{&1.movie_id, &1.region})
+    |> Map.new(fn {key, grouped_rows} ->
+      groups =
+        MovieWatchProvider.valid_monetization_types()
+        |> Map.new(fn type ->
+          type_rows =
+            grouped_rows
+            |> Enum.filter(&(&1.monetization_type == type))
+            |> Enum.sort_by(&{is_nil(&1.display_priority), &1.display_priority || 999_999})
+
+          {type, type_rows}
+        end)
+
+      {key, groups}
+    end)
+  end
+
+  defp availability_queued_by_key(movie_ids, selected_by_movie) do
+    movie_id_strings = Enum.map(movie_ids, &to_string/1)
+
+    jobs =
+      from(j in Oban.Job,
+        where: j.worker == "Cinegraph.Workers.MovieAvailabilityRefreshWorker",
+        where: j.state in ["available", "scheduled", "executing", "retryable"],
+        where: fragment("?->>'movie_id'", j.args) in ^movie_id_strings,
+        select: j.args
+      )
+      |> Repo.all()
+
+    Map.new(selected_by_movie, fn {movie_id, region} ->
+      queued? =
+        Enum.any?(jobs, fn args ->
+          to_string(args["movie_id"]) == to_string(movie_id) and job_matches_region?(args, region)
+        end)
+
+      {{movie_id, region}, queued?}
+    end)
+  end
+
+  defp job_matches_region?(%{"regions" => regions}, region) when is_list(regions) do
+    region in Enum.map(regions, &to_string/1)
+  end
+
+  defp job_matches_region?(_args, _region), do: true
 
   defp fetch_movie(field, value) do
     case Repo.get_by(Movie, [{field, value}]) do
@@ -228,10 +374,11 @@ defmodule CinegraphWeb.Resolvers.MovieResolver do
   defp select_availability_region(region, regions) when is_binary(region) do
     normalized = region |> String.trim() |> String.upcase()
 
-    if normalized == "" do
-      select_availability_region(nil, regions)
-    else
-      normalized
+    cond do
+      normalized == "" -> select_availability_region(nil, regions)
+      normalized in regions -> normalized
+      Availability.supported_region?(normalized) -> normalized
+      true -> select_availability_region(nil, regions)
     end
   end
 

--- a/lib/cinegraph_web/schema.ex
+++ b/lib/cinegraph_web/schema.ex
@@ -23,6 +23,10 @@ defmodule CinegraphWeb.Schema do
     loader =
       Dataloader.new()
       |> Dataloader.add_source(:db, Dataloader.Ecto.new(Cinegraph.Repo))
+      |> Dataloader.add_source(
+        :availability,
+        Dataloader.KV.new(&MovieResolver.load_availability/2, async?: false)
+      )
 
     Map.put(ctx, :loader, loader)
   end

--- a/lib/mix/tasks/cinegraph/audit/availability.ex
+++ b/lib/mix/tasks/cinegraph/audit/availability.ex
@@ -1,0 +1,85 @@
+defmodule Mix.Tasks.Cinegraph.Audit.Availability do
+  @moduledoc """
+  Audit Where to Watch availability coverage, freshness, catalog health, and queues.
+
+  ## Usage
+
+      mix cinegraph.audit.availability
+      mix cinegraph.audit.availability --json
+      mix cinegraph.audit.availability --limit 25 --region PL --stale-days 14
+  """
+  use Mix.Task
+
+  alias Cinegraph.Health.AvailabilityAudit
+
+  @shortdoc "Audit watch availability coverage and freshness"
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          json: :boolean,
+          limit: :integer,
+          region: :string,
+          stale_days: :integer,
+          "stale-days": :integer
+        ]
+      )
+
+    raise_invalid_options!(invalid)
+
+    audit_opts = audit_opts(opts)
+    result = AvailabilityAudit.audit(audit_opts)
+
+    if Keyword.get(opts, :json, false) do
+      result |> Jason.encode!(pretty: true) |> IO.puts()
+    else
+      print_summary(result)
+    end
+  end
+
+  defp audit_opts(opts) do
+    opts
+    |> Keyword.take([:limit, :region, :stale_days])
+    |> Keyword.merge(stale_days_option(opts))
+  end
+
+  defp stale_days_option(opts) do
+    case Keyword.get(opts, :"stale-days") do
+      nil -> []
+      value -> [stale_days: value]
+    end
+  end
+
+  defp print_summary(result) do
+    Mix.shell().info(
+      "Availability audit — region #{result.region}, generated #{result.generated_at}"
+    )
+
+    Mix.shell().info("")
+    Mix.shell().info("summary:")
+    Enum.each(result.summary, fn {key, value} -> Mix.shell().info("  #{key}: #{value}") end)
+    Mix.shell().info("")
+    Mix.shell().info("coverage:")
+    Enum.each(result.coverage, fn {key, value} -> Mix.shell().info("  #{key}: #{value}%") end)
+    Mix.shell().info("")
+    Mix.shell().info("freshness:")
+
+    Enum.each(result.freshness, fn {key, value} ->
+      Mix.shell().info("  #{key}: #{inspect(value)}")
+    end)
+
+    Mix.shell().info("")
+    Mix.shell().info("errors:")
+    Mix.shell().info("  current_error_rows: #{result.errors.current_error_rows}")
+    Mix.shell().info("")
+    Mix.shell().info("recommended commands:")
+    Enum.each(result.recommended_commands, fn command -> Mix.shell().info("  #{command}") end)
+  end
+
+  defp raise_invalid_options!([]), do: :ok
+  defp raise_invalid_options!(invalid), do: Mix.raise("invalid option(s): #{inspect(invalid)}")
+end

--- a/lib/mix/tasks/cinegraph/drift.ex
+++ b/lib/mix/tasks/cinegraph/drift.ex
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Cinegraph.Drift do
       mix cinegraph.drift movies [--json] [--year YYYY]   (PR 4)
       mix cinegraph.drift festivals [--json] [--org SLUG] (PR 4)
       mix cinegraph.drift ratings [--json]                (PR 4)
+      mix cinegraph.drift availability [--json] [--limit N]
 
   ## Options
 
@@ -49,8 +50,13 @@ defmodule Mix.Tasks.Cinegraph.Drift do
       "ratings" ->
         runner_opts |> validate_opts!(:ratings) |> run_ratings(json?)
 
+      "availability" ->
+        runner_opts |> validate_opts!(:availability) |> run_availability(json?)
+
       other ->
-        usage_error("unknown domain '#{other}' — try people|movies|festivals|ratings")
+        usage_error(
+          "unknown domain '#{other}' — try people|movies|festivals|ratings|availability"
+        )
     end
   end
 
@@ -68,7 +74,8 @@ defmodule Mix.Tasks.Cinegraph.Drift do
     people: [:limit],
     movies: [:limit, :year],
     festivals: [:limit, :org],
-    ratings: [:limit]
+    ratings: [:limit],
+    availability: [:limit]
   }
 
   defp validate_opts!(opts, domain) do
@@ -98,6 +105,9 @@ defmodule Mix.Tasks.Cinegraph.Drift do
 
   defp run_ratings(opts, json?),
     do: run_domain(:ratings, &Cinegraph.Health.Drift.Ratings.all/1, opts, json?)
+
+  defp run_availability(opts, json?),
+    do: run_domain(:availability, &Cinegraph.Health.Drift.Availability.all/1, opts, json?)
 
   defp run_domain(domain, runner, opts, json?) do
     results = runner.(opts)
@@ -198,6 +208,7 @@ defmodule Mix.Tasks.Cinegraph.Drift do
     Mix.shell().info("  mix cinegraph.drift movies    [--json] [--limit N] [--year YYYY]")
     Mix.shell().info("  mix cinegraph.drift festivals [--json] [--limit N] [--org SLUG]")
     Mix.shell().info("  mix cinegraph.drift ratings   [--json] [--limit N]")
+    Mix.shell().info("  mix cinegraph.drift availability [--json] [--limit N]")
     System.halt(1)
   end
 end

--- a/lib/mix/tasks/cinegraph/prod/audit/availability.ex
+++ b/lib/mix/tasks/cinegraph/prod/audit/availability.ex
@@ -1,0 +1,69 @@
+defmodule Mix.Tasks.Cinegraph.Prod.Audit.Availability do
+  @moduledoc """
+  Run the watch availability audit against production via `kamal app exec`.
+
+  ## Usage
+
+      mix cinegraph.prod.audit.availability
+      mix cinegraph.prod.audit.availability --json
+      mix cinegraph.prod.audit.availability --limit 25 --region PL --stale-days 14
+  """
+  use Mix.Task
+
+  alias Cinegraph.ProdRpc
+
+  @shortdoc "Audit production watch availability coverage and freshness"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          json: :boolean,
+          limit: :integer,
+          region: :string,
+          stale_days: :integer,
+          "stale-days": :integer
+        ]
+      )
+
+    raise_invalid_options!(invalid)
+
+    expr = build_expression(opts)
+
+    case ProdRpc.eval_json(expr) do
+      {:ok, audit} -> ProdRpc.print(audit, opts)
+      {:error, reason} -> ProdRpc.print_error(reason)
+    end
+  end
+
+  @doc false
+  def build_expression(opts) do
+    ~s|IO.puts(Jason.encode!(Cinegraph.Health.AvailabilityAudit.audit(#{build_opts_kw(opts)})))|
+  end
+
+  defp build_opts_kw(opts) do
+    parts =
+      opts
+      |> Keyword.drop([:json])
+      |> normalize_stale_days()
+      |> Enum.map(fn
+        {:limit, n} when is_integer(n) -> "limit: #{n}"
+        {:region, region} when is_binary(region) -> "region: #{inspect(region)}"
+        {:stale_days, n} when is_integer(n) -> "stale_days: #{n}"
+      end)
+      |> Enum.join(", ")
+
+    "[#{parts}]"
+  end
+
+  defp normalize_stale_days(opts) do
+    case Keyword.pop(opts, :"stale-days") do
+      {nil, opts} -> opts
+      {value, opts} -> Keyword.put(opts, :stale_days, value)
+    end
+  end
+
+  defp raise_invalid_options!([]), do: :ok
+  defp raise_invalid_options!(invalid), do: Mix.raise("invalid option(s): #{inspect(invalid)}")
+end

--- a/lib/mix/tasks/cinegraph/prod/drift.ex
+++ b/lib/mix/tasks/cinegraph/prod/drift.ex
@@ -11,6 +11,7 @@ defmodule Mix.Tasks.Cinegraph.Prod.Drift do
       mix cinegraph.prod.drift movies    [--json] [--limit N] [--year YYYY]
       mix cinegraph.prod.drift festivals [--json] [--limit N] [--org SLUG]
       mix cinegraph.prod.drift ratings   [--json] [--limit N]
+      mix cinegraph.prod.drift availability [--json] [--limit N]
 
   Requires the `kamal` CLI on PATH. See MAINTENANCE.md → "Audits & ad-hoc
   reports".
@@ -28,7 +29,8 @@ defmodule Mix.Tasks.Cinegraph.Prod.Drift do
     "people" => {"Cinegraph.Health.Drift.People", [:limit]},
     "movies" => {"Cinegraph.Health.Drift.Movies", [:limit, :year]},
     "festivals" => {"Cinegraph.Health.Drift.Festivals", [:limit, :org]},
-    "ratings" => {"Cinegraph.Health.Drift.Ratings", [:limit]}
+    "ratings" => {"Cinegraph.Health.Drift.Ratings", [:limit]},
+    "availability" => {"Cinegraph.Health.Drift.Availability", [:limit]}
   }
 
   @impl Mix.Task
@@ -44,14 +46,19 @@ defmodule Mix.Tasks.Cinegraph.Prod.Drift do
 
     {module, allowed} =
       case Map.fetch(@domain_options, domain) do
-        {:ok, v} -> v
-        :error -> usage_error("unknown domain '#{domain}' — try people|movies|festivals|ratings")
+        {:ok, v} ->
+          v
+
+        :error ->
+          usage_error(
+            "unknown domain '#{domain}' — try people|movies|festivals|ratings|availability"
+          )
       end
 
     runner_opts = Keyword.drop(opts, [:json])
     validate_opts!(runner_opts, domain, allowed)
 
-    expr = ~s|IO.puts(Jason.encode!(#{module}.all(#{build_opts_kw(runner_opts)})))|
+    expr = build_expression(module, runner_opts)
 
     case ProdRpc.eval_json(expr) do
       {:ok, drift} -> ProdRpc.print(drift, opts)
@@ -70,6 +77,11 @@ defmodule Mix.Tasks.Cinegraph.Prod.Drift do
       |> Enum.join(", ")
 
     "[#{parts}]"
+  end
+
+  @doc false
+  def build_expression(module, opts) when is_binary(module) do
+    ~s|IO.puts(Jason.encode!(#{module}.all(#{build_opts_kw(opts)})))|
   end
 
   defp reject_invalid_switches!([]), do: :ok
@@ -100,6 +112,7 @@ defmodule Mix.Tasks.Cinegraph.Prod.Drift do
     Mix.shell().info("  mix cinegraph.prod.drift movies    [--json] [--limit N] [--year YYYY]")
     Mix.shell().info("  mix cinegraph.prod.drift festivals [--json] [--limit N] [--org SLUG]")
     Mix.shell().info("  mix cinegraph.prod.drift ratings   [--json] [--limit N]")
+    Mix.shell().info("  mix cinegraph.prod.drift availability [--json] [--limit N]")
     System.halt(1)
   end
 end

--- a/lib/mix/tasks/cinegraph/prod/movies/backfill_availability.ex
+++ b/lib/mix/tasks/cinegraph/prod/movies/backfill_availability.ex
@@ -1,0 +1,102 @@
+defmodule Mix.Tasks.Cinegraph.Prod.Movies.BackfillAvailability do
+  @moduledoc """
+  Backfill production watch availability from stored TMDb JSON via ProdRpc.
+
+  ## Usage
+
+      mix cinegraph.prod.movies.backfill_availability --dry-run --json
+      mix cinegraph.prod.movies.backfill_availability --dry-run --limit 100
+      mix cinegraph.prod.movies.backfill_availability --limit 100 --after-id 500000 --batch-size 1000
+      mix cinegraph.prod.movies.backfill_availability --regions US,GB --dry-run
+  """
+  use Mix.Task
+
+  alias Cinegraph.ProdRpc
+
+  @shortdoc "Backfill production watch availability from stored TMDb JSON"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          json: :boolean,
+          dry_run: :boolean,
+          "dry-run": :boolean,
+          limit: :integer,
+          after_id: :integer,
+          "after-id": :integer,
+          batch_size: :integer,
+          "batch-size": :integer,
+          regions: :string
+        ]
+      )
+
+    raise_invalid_options!(invalid)
+
+    expr = build_expression(opts)
+
+    case ProdRpc.eval_json(expr) do
+      {:ok, stats} -> ProdRpc.print(stats, opts)
+      {:error, reason} -> ProdRpc.print_error(reason)
+    end
+  end
+
+  @doc false
+  def build_expression(opts) do
+    ~s|{:ok, stats} = Cinegraph.Movies.AvailabilityBackfill.run(#{build_opts_kw(opts)}); IO.puts(Jason.encode!(stats))|
+  end
+
+  defp build_opts_kw(opts) do
+    opts = normalize_aliases(opts)
+
+    parts =
+      [
+        opt_integer(opts, :limit),
+        opt_integer(opts, :after_id),
+        opt_integer(opts, :batch_size),
+        opt_regions(opts),
+        opt_dry_run(opts)
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(", ")
+
+    "[#{parts}]"
+  end
+
+  defp normalize_aliases(opts) do
+    opts
+    |> normalize_alias(:"dry-run", :dry_run)
+    |> normalize_alias(:"after-id", :after_id)
+    |> normalize_alias(:"batch-size", :batch_size)
+    |> Keyword.drop([:json])
+  end
+
+  defp normalize_alias(opts, from, to) do
+    case Keyword.pop(opts, from) do
+      {nil, opts} -> opts
+      {value, opts} -> Keyword.put(opts, to, value)
+    end
+  end
+
+  defp opt_integer(opts, key) do
+    case Keyword.get(opts, key) do
+      value when is_integer(value) -> "#{key}: #{value}"
+      _ -> nil
+    end
+  end
+
+  defp opt_regions(opts) do
+    case Keyword.get(opts, :regions) do
+      value when is_binary(value) -> "regions: #{inspect(value)}"
+      _ -> "regions: Cinegraph.Movies.Availability.configured_regions()"
+    end
+  end
+
+  defp opt_dry_run(opts) do
+    if Keyword.get(opts, :dry_run, false), do: "dry_run: true", else: nil
+  end
+
+  defp raise_invalid_options!([]), do: :ok
+  defp raise_invalid_options!(invalid), do: Mix.raise("invalid option(s): #{inspect(invalid)}")
+end

--- a/lib/mix/tasks/cinegraph/refresh/availability.ex
+++ b/lib/mix/tasks/cinegraph/refresh/availability.ex
@@ -1,0 +1,42 @@
+defmodule Mix.Tasks.Cinegraph.Refresh.Availability do
+  @moduledoc """
+  Enqueue a forced watch availability refresh for one or more movies by id.
+
+  ## Usage
+
+      mix cinegraph.refresh.availability 1187
+      mix cinegraph.refresh.availability 1187 1188 1189
+  """
+  use Mix.Task
+
+  alias CinegraphWeb.AdminHealth.Actions
+
+  @shortdoc "Queue availability refresh for one or more movies by id"
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    if args == [] do
+      Mix.raise("Usage: mix cinegraph.refresh.availability <movie_id> [<movie_id>...]")
+    end
+
+    ids = Enum.map(args, &parse_id!/1)
+
+    case Actions.queue_availability_refresh(ids) do
+      {:ok, n} ->
+        Mix.shell().info("Enqueued #{n} MovieAvailabilityRefreshWorker job(s) on queue :tmdb")
+
+      {:error, errors} ->
+        Mix.shell().error("Enqueue failed: #{inspect(errors)}")
+        exit({:shutdown, 1})
+    end
+  end
+
+  defp parse_id!(arg) do
+    case Integer.parse(arg) do
+      {n, ""} when n > 0 -> n
+      _ -> Mix.raise("Invalid movie id: #{inspect(arg)} (must be a positive integer)")
+    end
+  end
+end

--- a/test/cinegraph/health/availability_audit_test.exs
+++ b/test/cinegraph/health/availability_audit_test.exs
@@ -1,0 +1,147 @@
+defmodule Cinegraph.Health.AvailabilityAuditTest do
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Health.AvailabilityAudit
+
+  alias Cinegraph.Movies.{
+    Availability,
+    Movie,
+    WatchProvider,
+    WatchProviderRegion
+  }
+
+  alias Cinegraph.Repo
+  alias Cinegraph.Workers.MovieAvailabilityRefreshWorker
+
+  test "audit/1 reports coverage, freshness, catalog, queues, examples, and commands" do
+    Repo.delete_all(Oban.Job)
+
+    normalized = insert_movie!(%{title: "Normalized Movie", tmdb_data: raw_watch_payload()})
+    raw_only = insert_movie!(%{title: "Raw Only Movie", tmdb_data: raw_watch_payload()})
+    default_only = insert_movie!(%{title: "Default Only Movie", tmdb_data: raw_watch_payload()})
+    missing = insert_movie!(%{title: "Missing Movie"})
+
+    assert {:ok, _} =
+             Availability.store_tmdb_watch_providers(
+               normalized,
+               %{
+                 "results" => %{
+                   "US" => %{"rent" => [provider(8, "Netflix")]},
+                   "GB" => %{"buy" => [provider(2, "Apple TV")]}
+                 }
+               },
+               fetched_at: ~U[2026-01-01 00:00:00Z],
+               stale_after: ~U[2026-01-31 00:00:00Z]
+             )
+
+    assert {:ok, _} =
+             Availability.store_tmdb_watch_providers(
+               default_only,
+               %{"results" => %{"US" => %{"rent" => [provider(9, "Prime Video")]}}},
+               fetched_at: ~U[2026-04-01 00:00:00Z],
+               stale_after: ~U[2026-05-01 00:00:00Z]
+             )
+
+    assert {:ok, _} = Availability.record_availability_error(normalized, ["US"], "tmdb_down")
+
+    insert_catalog!()
+
+    %{"movie_id" => normalized.id, "force" => true}
+    |> MovieAvailabilityRefreshWorker.new()
+    |> Oban.insert!()
+
+    audit = AvailabilityAudit.audit(region: "US", limit: 5, stale_days: 30)
+
+    assert audit.region == "US"
+    assert audit.summary.full_movies_with_tmdb == 4
+    assert audit.summary.movies_with_raw_watch_providers == 3
+    assert audit.summary.movies_with_any_normalized_availability == 2
+    assert audit.summary.movies_with_region_refresh == 2
+    assert audit.summary.movies_with_non_default_region_availability == 1
+
+    assert audit.coverage.raw_tmdb_pct == 75.0
+    assert audit.coverage.normalized_pct == 50.0
+    assert audit.freshness.stale_refresh_rows >= 1
+    assert audit.errors.current_error_rows == 1
+    assert [%{error_reason: "tmdb_down", count: 1}] = audit.errors.grouped_by_reason
+
+    assert audit.catalog.provider_count >= 1
+    assert audit.catalog.region_count >= 1
+    refute audit.catalog.missing_catalog
+
+    assert get_in(audit.queues, ["Cinegraph.Workers.MovieAvailabilityRefreshWorker", "available"]) ==
+             1
+
+    assert Enum.any?(audit.examples.raw_but_not_normalized, &(&1.id == raw_only.id))
+
+    assert Enum.any?(
+             audit.examples.raw_multi_region_but_default_only_normalized,
+             &(&1.id == default_only.id)
+           )
+
+    assert Enum.any?(audit.examples.missing_region_refresh, &(&1.id == raw_only.id))
+    assert Enum.any?(audit.examples.missing_region_refresh, &(&1.id == missing.id))
+    assert Enum.any?(audit.examples.error_refreshes, &(&1.id == normalized.id))
+
+    assert Enum.any?(audit.recommended_commands, &String.contains?(&1, "prod.audit.availability"))
+    assert Jason.encode!(audit)
+  end
+
+  defp insert_movie!(attrs) do
+    defaults = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: "Availability Audit Movie",
+      original_title: "Availability Audit Movie",
+      import_status: "full",
+      tmdb_data: %{}
+    }
+
+    %Movie{}
+    |> Movie.changeset(Map.merge(defaults, attrs))
+    |> Repo.insert!()
+  end
+
+  defp insert_catalog! do
+    %WatchProvider{}
+    |> WatchProvider.changeset(%{
+      source: "tmdb",
+      source_provider_id: "8",
+      tmdb_provider_id: 8,
+      name: "Netflix",
+      last_seen_at: ~U[2026-05-01 00:00:00Z],
+      active: true
+    })
+    |> Repo.insert!(on_conflict: :nothing)
+
+    %WatchProviderRegion{}
+    |> WatchProviderRegion.changeset(%{
+      source: "tmdb",
+      iso_3166_1: "US",
+      english_name: "United States",
+      native_name: "United States",
+      last_seen_at: ~U[2026-05-01 00:00:00Z],
+      active: true
+    })
+    |> Repo.insert!(on_conflict: :nothing)
+  end
+
+  defp raw_watch_payload do
+    %{
+      "watch_providers" => %{
+        "results" => %{
+          "US" => %{"rent" => [provider(8, "Netflix")]},
+          "GB" => %{"buy" => [provider(2, "Apple TV")]}
+        }
+      }
+    }
+  end
+
+  defp provider(id, name) do
+    %{
+      "provider_id" => id,
+      "provider_name" => name,
+      "display_priority" => id,
+      "logo_path" => "/#{id}.jpg"
+    }
+  end
+end

--- a/test/cinegraph/maintenance/refresh_availability_test.exs
+++ b/test/cinegraph/maintenance/refresh_availability_test.exs
@@ -29,7 +29,8 @@ defmodule Cinegraph.Maintenance.RefreshAvailabilityTest do
 
       [job] = Repo.all(Oban.Job)
       assert job.worker == "Cinegraph.Workers.MovieAvailabilityRefreshWorker"
-      refute Map.has_key?(job.args, "regions")
+      assert "US" in job.args["regions"]
+      assert "GB" in job.args["regions"]
       assert job.args["force"] == false
     end
 

--- a/test/mix/tasks/cinegraph_availability_ops_test.exs
+++ b/test/mix/tasks/cinegraph_availability_ops_test.exs
@@ -1,0 +1,116 @@
+defmodule Mix.Tasks.CinegraphAvailabilityOpsTest do
+  use Cinegraph.DataCase, async: false
+
+  import Ecto.Query
+  import ExUnit.CaptureIO
+
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Repo
+
+  setup do
+    Mix.Task.reenable("cinegraph.drift")
+    Mix.Task.reenable("cinegraph.audit.availability")
+    Mix.Task.reenable("cinegraph.refresh.availability")
+    Mix.Task.reenable("app.start")
+    :ok
+  end
+
+  test "local drift task supports availability domain as JSON" do
+    output =
+      capture_io(fn ->
+        Mix.Tasks.Cinegraph.Drift.run(["availability", "--json", "--limit", "1"])
+      end)
+
+    assert output =~ "availability_missing"
+    assert output =~ "availability_stale"
+    assert output =~ "availability_fetch_errors"
+    assert output =~ "availability_provider_catalog_stale"
+  end
+
+  test "prod drift task supports availability expression" do
+    expr =
+      Mix.Tasks.Cinegraph.Prod.Drift.build_expression(
+        "Cinegraph.Health.Drift.Availability",
+        limit: 3
+      )
+
+    assert expr ==
+             "IO.puts(Jason.encode!(Cinegraph.Health.Drift.Availability.all([limit: 3])))"
+  end
+
+  test "prod availability audit builds safe ProdRpc expression" do
+    expr =
+      Mix.Tasks.Cinegraph.Prod.Audit.Availability.build_expression(
+        json: true,
+        limit: 3,
+        region: "PL",
+        "stale-days": 14
+      )
+
+    assert expr =~ "Cinegraph.Health.AvailabilityAudit.audit"
+    assert expr =~ "limit: 3"
+    assert expr =~ ~s|region: "PL"|
+    assert expr =~ "stale_days: 14"
+  end
+
+  test "prod availability backfill builds dry-run resumable expression" do
+    expr =
+      Mix.Tasks.Cinegraph.Prod.Movies.BackfillAvailability.build_expression(
+        json: true,
+        dry_run: true,
+        limit: 100,
+        after_id: 500,
+        batch_size: 50,
+        regions: "US,GB"
+      )
+
+    assert expr ==
+             ~s|{:ok, stats} = Cinegraph.Movies.AvailabilityBackfill.run([limit: 100, after_id: 500, batch_size: 50, regions: "US,GB", dry_run: true]); IO.puts(Jason.encode!(stats))|
+  end
+
+  test "prod availability backfill defaults to all configured regions" do
+    expr =
+      Mix.Tasks.Cinegraph.Prod.Movies.BackfillAvailability.build_expression(
+        json: true,
+        dry_run: true
+      )
+
+    assert expr ==
+             ~s|{:ok, stats} = Cinegraph.Movies.AvailabilityBackfill.run([regions: Cinegraph.Movies.Availability.configured_regions(), dry_run: true]); IO.puts(Jason.encode!(stats))|
+  end
+
+  test "refresh availability task validates ids and enqueues forced jobs" do
+    Repo.delete_all(Oban.Job)
+    movie = insert_movie!()
+
+    output =
+      capture_io(fn ->
+        Mix.Tasks.Cinegraph.Refresh.Availability.run([Integer.to_string(movie.id)])
+      end)
+
+    assert output =~ "Enqueued 1 MovieAvailabilityRefreshWorker job"
+
+    [job] =
+      Repo.all(
+        from(j in Oban.Job,
+          where: j.worker == "Cinegraph.Workers.MovieAvailabilityRefreshWorker"
+        )
+      )
+
+    assert job.worker == "Cinegraph.Workers.MovieAvailabilityRefreshWorker"
+    assert job.args["movie_id"] == movie.id
+    assert job.args["force"] == true
+    refute Map.has_key?(job.args, "regions")
+  end
+
+  defp insert_movie! do
+    %Movie{}
+    |> Movie.changeset(%{
+      tmdb_id: System.unique_integer([:positive]),
+      title: "Refresh Availability Movie",
+      original_title: "Refresh Availability Movie",
+      import_status: "full"
+    })
+    |> Repo.insert!()
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audit command (`cinegraph audit availability`) to inspect watch provider coverage, freshness metrics, and error status across regions
  * Added refresh command (`cinegraph refresh availability`) to manually trigger watch availability updates for specific movies
  * Added production audit variant for remote environments (`cinegraph prod audit availability`)
  * Enhanced region handling for watch provider data with improved validation and normalization

* **Bug Fixes**
  * Improved availability data loading logic for better region selection and availability grouping

* **Chores**
  * Added comprehensive test coverage for audit and refresh operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->