### PR TITLE
more refresh

### DIFF
--- a/lib/cinegraph/sitemap.ex
+++ b/lib/cinegraph/sitemap.ex
@@ -23,7 +23,7 @@ defmodule Cinegraph.Sitemap do
   import Ecto.Query
   require Logger
 
-  @site_url "https://cinegraph.io"
+  @site_url "https://cinegraph.org"
 
   @doc """
   Generates and persists a sitemap for the website.

--- a/lib/cinegraph_web/components/seo.ex
+++ b/lib/cinegraph_web/components/seo.ex
@@ -13,7 +13,7 @@ defmodule CinegraphWeb.SEO do
   import Phoenix.HTML, only: [raw: 1]
 
   @tmdb_image_base "https://image.tmdb.org/t/p"
-  @site_url "https://cinegraph.io"
+  @site_url "https://cinegraph.org"
   @site_name "Cinegraph"
   @default_description "Discover movies, explore film industry relationships, and track awards data."
 

--- a/lib/cinegraph_web/live/awards_live/show_legacy.ex
+++ b/lib/cinegraph_web/live/awards_live/show_legacy.ex
@@ -31,7 +31,7 @@ defmodule CinegraphWeb.AwardsLive.ShowLegacy do
       awards_view_filter_fields: 0
     ]
 
-  @site_url "https://cinegraph.io"
+  @site_url "https://cinegraph.org"
 
   # ============================================================================
   # SearchEventHandlers Callback

--- a/lib/cinegraph_web/live/company_live/show.ex
+++ b/lib/cinegraph_web/live/company_live/show.ex
@@ -19,7 +19,7 @@ defmodule CinegraphWeb.CompanyLive.Show do
       assign_pagination: 2
     ]
 
-  @site_url "https://cinegraph.io"
+  @site_url "https://cinegraph.org"
 
   @impl CinegraphWeb.SearchEventHandlers
   def build_path(socket, params) do

--- a/lib/cinegraph_web/live/list_live/show_legacy.ex
+++ b/lib/cinegraph_web/live/list_live/show_legacy.ex
@@ -26,7 +26,7 @@ defmodule CinegraphWeb.ListLive.ShowLegacy do
       list_view_filter_fields: 0
     ]
 
-  @site_url "https://cinegraph.io"
+  @site_url "https://cinegraph.org"
 
   # ============================================================================
   # SearchEventHandlers Callback

--- a/lib/cinegraph_web/seo_helpers.ex
+++ b/lib/cinegraph_web/seo_helpers.ex
@@ -16,7 +16,7 @@ defmodule CinegraphWeb.SEOHelpers do
   import Phoenix.Component, only: [assign: 3]
   alias CinegraphWeb.SEO
 
-  @site_url "https://cinegraph.io"
+  @site_url "https://cinegraph.org"
   @tmdb_image_base "https://image.tmdb.org/t/p"
 
   @doc """

--- a/lib/mix/tasks/cinegraph.enrich_collection_imagery.ex
+++ b/lib/mix/tasks/cinegraph.enrich_collection_imagery.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Cinegraph.EnrichCollectionImagery do
 
   @shortdoc "Enriches movie list and awards imagery from source websites"
   @requirements ["app.start"]
-  @headers [{"user-agent", "CinegraphBot/1.0 (+https://cinegraph.io)"}]
+  @headers [{"user-agent", "CinegraphBot/1.0 (+https://cinegraph.org)"}]
 
   @impl true
   def run(_args) do

--- a/lib/mix/tasks/sitemap.generate.ex
+++ b/lib/mix/tasks/sitemap.generate.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Sitemap.Generate do
 
   ## Options
 
-      --host    Override the host URL (default: https://cinegraph.io)
+      --host    Override the host URL (default: https://cinegraph.org)
       --stats   Only show URL counts without generating
 
   ## Examples

--- a/test/cinegraph_web/components/seo_test.exs
+++ b/test/cinegraph_web/components/seo_test.exs
@@ -17,13 +17,13 @@ defmodule CinegraphWeb.SEOTest do
             meta_image_width: 1200,
             meta_image_height: 630,
             meta_type: "video.movie",
-            canonical_url: "https://cinegraph.io/movies/the-matrix-1999",
+            canonical_url: "https://cinegraph.org/movies/the-matrix-1999",
             json_ld: %{"@context" => "https://schema.org", "@type" => "Movie"}
           }
         )
 
       assert html =~ ~S|<meta name="description" content="A hacker discovers reality|
-      assert html =~ ~S|<link rel="canonical" href="https://cinegraph.io/movies/the-matrix-1999"|
+      assert html =~ ~S|<link rel="canonical" href="https://cinegraph.org/movies/the-matrix-1999"|
       assert html =~ ~S|<meta property="og:type" content="video.movie"|
       assert html =~ ~S|<meta property="og:title" content="The Matrix (1999)"|
 
@@ -45,7 +45,7 @@ defmodule CinegraphWeb.SEOTest do
             og_description: "Legacy description",
             og_image: "https://example.com/legacy.jpg",
             og_type: "profile",
-            og_url: "https://cinegraph.io/legacy"
+            og_url: "https://cinegraph.org/legacy"
           }
         )
 
@@ -53,7 +53,7 @@ defmodule CinegraphWeb.SEOTest do
       assert html =~ ~S|<meta property="og:description" content="Legacy description"|
       assert html =~ ~S|<meta property="og:image" content="https://example.com/legacy.jpg"|
       assert html =~ ~S|<meta property="og:type" content="profile"|
-      assert html =~ ~S|<meta property="og:url" content="https://cinegraph.io/legacy"|
+      assert html =~ ~S|<meta property="og:url" content="https://cinegraph.org/legacy"|
     end
 
     test "renders a list of JSON-LD schemas" do

--- a/test/cinegraph_web/live/movie_live/show_v2_route_test.exs
+++ b/test/cinegraph_web/live/movie_live/show_v2_route_test.exs
@@ -75,7 +75,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2RouteTest do
       assert html =~ "Old movie page"
       assert html =~ ~p"/movies/#{movie.slug}/legacy"
       assert html =~ movie.title
-      assert html =~ ~s(<link rel="canonical" href="https://cinegraph.io/movies/#{movie.slug}")
+      assert html =~ ~s(<link rel="canonical" href="https://cinegraph.org/movies/#{movie.slug}")
       assert html =~ ~s(<meta property="og:type" content="video.movie")
       assert html =~ ~s(<meta property="og:title" content="Routing Smoke Title)
       assert html =~ ~s(<meta name="twitter:title" content="Routing Smoke Title)

--- a/test/cinegraph_web/live/person_live/show_v2_route_test.exs
+++ b/test/cinegraph_web/live/person_live/show_v2_route_test.exs
@@ -29,7 +29,7 @@ defmodule CinegraphWeb.PersonLive.ShowV2RouteTest do
       assert html =~ ~p"/people/#{person.slug}/movies"
       assert html =~ "Open all films"
       assert html =~ "Canonical V2 Person"
-      assert html =~ ~s(<link rel="canonical" href="https://cinegraph.io/people/#{person.slug}")
+      assert html =~ ~s(<link rel="canonical" href="https://cinegraph.org/people/#{person.slug}")
       assert html =~ ~s(<meta property="og:type" content="profile")
       assert html =~ ~s(<meta property="og:title" content="Canonical V2 Person")
       assert html =~ ~s(<meta name="twitter:title" content="Canonical V2 Person")

--- a/test/cinegraph_web/live/show_page_seo_test.exs
+++ b/test/cinegraph_web/live/show_page_seo_test.exs
@@ -32,7 +32,7 @@ defmodule CinegraphWeb.ShowPageSEOTest do
 
     assert document
            |> Floki.find(
-             ~s(link[rel="canonical"][href="https://cinegraph.io/lists/#{list.slug}"])
+             ~s(link[rel="canonical"][href="https://cinegraph.org/lists/#{list.slug}"])
            )
            |> Enum.any?()
 
@@ -63,7 +63,7 @@ defmodule CinegraphWeb.ShowPageSEOTest do
 
     assert document
            |> Floki.find(
-             ~s(link[rel="canonical"][href="https://cinegraph.io/awards/#{organization.slug}/winners"])
+             ~s(link[rel="canonical"][href="https://cinegraph.org/awards/#{organization.slug}/winners"])
            )
            |> Enum.any?()
 

--- a/test/cinegraph_web/seo_helpers_test.exs
+++ b/test/cinegraph_web/seo_helpers_test.exs
@@ -24,7 +24,7 @@ defmodule CinegraphWeb.SEOHelpersTest do
       assert assigns.page_title == "The Matrix"
       assert assigns.meta_title == "The Matrix (1999)"
       assert assigns.meta_type == "video.movie"
-      assert assigns.canonical_url == "https://cinegraph.io/movies/the-matrix-1999"
+      assert assigns.canonical_url == "https://cinegraph.org/movies/the-matrix-1999"
       assert assigns.meta_image == "https://image.tmdb.org/t/p/w1280/backdrop.jpg"
       assert json_ld_types(assigns) == ["Movie", "BreadcrumbList"]
     end
@@ -56,7 +56,7 @@ defmodule CinegraphWeb.SEOHelpersTest do
       assert assigns.page_title == "Carrie-Anne Moss"
       assert assigns.meta_title == "Carrie-Anne Moss"
       assert assigns.meta_type == "profile"
-      assert assigns.canonical_url == "https://cinegraph.io/people/carrie-anne-moss"
+      assert assigns.canonical_url == "https://cinegraph.org/people/carrie-anne-moss"
       assert assigns.meta_image == "https://image.tmdb.org/t/p/w500/profile.jpg"
       assert json_ld_types(assigns) == ["Person", "BreadcrumbList"]
     end
@@ -94,7 +94,7 @@ defmodule CinegraphWeb.SEOHelpersTest do
       assigns = socket_assigns(assign_curated_list_seo(socket(), list_info, movies))
 
       assert assigns.meta_title == "Criterion Collection"
-      assert assigns.canonical_url == "https://cinegraph.io/lists/criterion-collection"
+      assert assigns.canonical_url == "https://cinegraph.org/lists/criterion-collection"
       assert assigns.meta_image == "https://image.tmdb.org/t/p/w780/seven.jpg"
       assert json_ld_types(assigns) == ["ItemList", "BreadcrumbList"]
     end
@@ -117,13 +117,13 @@ defmodule CinegraphWeb.SEOHelpersTest do
         socket_assigns(assign_awards_seo(socket(), organization, :nominees, movies))
 
       assert all_assigns.meta_title == "Academy Awards"
-      assert all_assigns.canonical_url == "https://cinegraph.io/awards/academy-awards"
+      assert all_assigns.canonical_url == "https://cinegraph.org/awards/academy-awards"
       assert winner_assigns.meta_title == "Academy Awards Winners"
-      assert winner_assigns.canonical_url == "https://cinegraph.io/awards/academy-awards/winners"
+      assert winner_assigns.canonical_url == "https://cinegraph.org/awards/academy-awards/winners"
       assert nominee_assigns.meta_title == "Academy Awards Nominees"
 
       assert nominee_assigns.canonical_url ==
-               "https://cinegraph.io/awards/academy-awards/nominees"
+               "https://cinegraph.org/awards/academy-awards/nominees"
 
       assert json_ld_types(winner_assigns) == ["ItemList", "BreadcrumbList"]
     end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site base URL from `cinegraph.io` to `cinegraph.org`, affecting canonical URLs and search engine metadata across the platform.

* **Tests**
  * Updated test assertions to reflect the new domain configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->