### PR TITLE
Add Video Clerk recommendations and IMDb pagination audits

### DIFF
--- a/lib/cinegraph/cultural/canonical_importer.ex
+++ b/lib/cinegraph/cultural/canonical_importer.ex
@@ -50,8 +50,6 @@ defmodule Cinegraph.Cultural.CanonicalImporter do
                 page_results =
                   movie_data
                   |> Enum.map(fn movie ->
-                    # Adjust position for pagination
-                    movie = %{movie | position: (page - 1) * 250 + movie.position}
                     process_canonical_movie(movie, source_key, list_name, options, metadata)
                   end)
 

--- a/lib/cinegraph/health/imdb_list_pagination_audit.ex
+++ b/lib/cinegraph/health/imdb_list_pagination_audit.ex
@@ -1,0 +1,417 @@
+defmodule Cinegraph.Health.ImdbListPaginationAudit do
+  @moduledoc """
+  Non-mutating diagnostics for IMDb list pagination/window behavior.
+
+  This module fetches candidate IMDb list windows through the configured IMDb
+  HTTP client and reports whether the rendered windows look contiguous and safe
+  to import. It intentionally does not enqueue jobs or update movie/list rows.
+  """
+
+  alias Cinegraph.Movies.MovieLists
+  alias Cinegraph.Scrapers.Http.Client, as: HttpClient
+
+  @default_starts [1, 76, 151, 226, 301, 376]
+  @sample_size 3
+
+  @doc """
+  Audit an IMDb list's rendered pagination windows.
+  """
+  def audit(opts \\ []) do
+    opts = normalize_opts(opts)
+    {list_key, list_id} = resolve_list!(opts)
+    starts = Keyword.get(opts, :starts, @default_starts)
+    fetch_opts = fetch_opts(opts)
+    fetcher = Keyword.get(opts, :fetcher, &HttpClient.fetch/3)
+
+    raw_windows =
+      starts
+      |> Enum.map(fn start ->
+        url = build_window_url(list_id, start)
+        probe_window(url, start, fetch_opts, fetcher)
+      end)
+      |> annotate_windows()
+
+    windows = Enum.map(raw_windows, &Map.delete(&1, :_ids))
+
+    %{
+      generated_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
+      list_key: list_key,
+      list_id: list_id,
+      tested_urls: Enum.map(windows, & &1.url),
+      windows: windows,
+      summary: summarize(raw_windows)
+    }
+  end
+
+  @doc false
+  def default_starts, do: @default_starts
+
+  @doc false
+  def build_window_url(list_id, start) do
+    "https://www.imdb.com/list/#{list_id}/?sort=list_order,asc&start=#{start}&mode=detail"
+  end
+
+  @doc false
+  def parse_window_html(html, start) when is_binary(html) do
+    document = Floki.parse_document!(html)
+    {items, layout} = find_movie_items(document)
+
+    movies =
+      items
+      |> Enum.with_index()
+      |> Enum.map(fn {item, index} -> parse_item(item, start, index) end)
+      |> Enum.reject(&is_nil/1)
+
+    %{
+      parser_layout: layout,
+      movies: movies
+    }
+  end
+
+  defp normalize_opts(opts) do
+    opts
+    |> normalize_alias(:"list-id", :list_id)
+    |> normalize_alias(:"page-wait", :page_wait)
+    |> normalize_alias(:"ajax-wait", :ajax_wait)
+    |> normalize_alias(:"scroll-interval", :scroll_interval)
+    |> normalize_starts()
+  end
+
+  defp normalize_alias(opts, from, to) do
+    case Keyword.pop(opts, from) do
+      {nil, opts} -> opts
+      {value, opts} -> Keyword.put(opts, to, value)
+    end
+  end
+
+  defp normalize_starts(opts) do
+    case Keyword.get(opts, :starts) do
+      nil ->
+        opts
+
+      starts when is_binary(starts) ->
+        Keyword.put(opts, :starts, parse_starts!(starts))
+
+      starts when is_list(starts) ->
+        Keyword.put(opts, :starts, Enum.map(starts, &parse_start!/1))
+
+      other ->
+        raise ArgumentError,
+              "starts must be a comma-separated string or list, got: #{inspect(other)}"
+    end
+  end
+
+  defp parse_starts!(starts) do
+    starts
+    |> String.split(",", trim: true)
+    |> Enum.map(&parse_start!/1)
+  end
+
+  defp parse_start!(value) when is_integer(value) and value > 0, do: value
+
+  defp parse_start!(value) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {integer, ""} when integer > 0 -> integer
+      _ -> raise ArgumentError, "invalid start value: #{inspect(value)}"
+    end
+  end
+
+  defp parse_start!(value), do: raise(ArgumentError, "invalid start value: #{inspect(value)}")
+
+  defp resolve_list!(opts) do
+    case {Keyword.get(opts, :list), Keyword.get(opts, :list_id)} do
+      {nil, nil} ->
+        raise ArgumentError, "provide either --list or --list-id"
+
+      {list_key, nil} when is_binary(list_key) ->
+        case MovieLists.get_config(list_key) do
+          {:ok, %{list_id: list_id}} when is_binary(list_id) and list_id != "" ->
+            {list_key, list_id}
+
+          {:ok, _config} ->
+            raise ArgumentError, "list #{inspect(list_key)} does not have an IMDb list_id"
+
+          {:error, reason} ->
+            raise ArgumentError, reason
+        end
+
+      {nil, list_id} when is_binary(list_id) ->
+        validate_list_id!(list_id)
+        {nil, list_id}
+
+      {_list_key, list_id} when is_binary(list_id) ->
+        validate_list_id!(list_id)
+        {Keyword.get(opts, :list), list_id}
+    end
+  end
+
+  defp validate_list_id!(list_id) do
+    unless Regex.match?(~r/^ls\d+$/, list_id) do
+      raise ArgumentError, "list_id must look like an IMDb ls id, got: #{inspect(list_id)}"
+    end
+  end
+
+  defp fetch_opts(opts) do
+    [
+      mode: :javascript,
+      page_wait: Keyword.get(opts, :page_wait, 5_000),
+      ajax_wait: Keyword.get(opts, :ajax_wait, true),
+      scroll: Keyword.get(opts, :scroll, false),
+      scroll_interval: Keyword.get(opts, :scroll_interval)
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp probe_window(url, start, fetch_opts, fetcher) do
+    crawlbase_options = %{
+      page_wait: Keyword.get(fetch_opts, :page_wait),
+      ajax_wait: Keyword.get(fetch_opts, :ajax_wait),
+      scroll: Keyword.get(fetch_opts, :scroll, false),
+      scroll_interval: Keyword.get(fetch_opts, :scroll_interval)
+    }
+
+    case fetcher.(url, :imdb, fetch_opts) do
+      {:ok, html} ->
+        success_window(url, start, html, crawlbase_options)
+
+      {:ok, html, _metadata} ->
+        success_window(url, start, html, crawlbase_options)
+
+      {:error, reason} ->
+        %{
+          url: url,
+          start: start,
+          fetch_status: "error",
+          error: inspect(reason),
+          movie_count: 0,
+          first_rank: nil,
+          last_rank: nil,
+          first_imdb_id: nil,
+          last_imdb_id: nil,
+          sample_titles: [],
+          duplicate_ids: [],
+          rank_gap_from_previous: nil,
+          parser_layout: "none",
+          crawlbase_options: crawlbase_options
+        }
+    end
+  end
+
+  defp success_window(url, start, html, crawlbase_options) do
+    parsed = parse_window_html(html, start)
+    movies = parsed.movies
+
+    %{
+      url: url,
+      start: start,
+      fetch_status: "ok",
+      movie_count: length(movies),
+      first_rank: rank_at(movies, :first),
+      last_rank: rank_at(movies, :last),
+      first_imdb_id: imdb_id_at(movies, :first),
+      last_imdb_id: imdb_id_at(movies, :last),
+      sample_titles: sample_titles(movies),
+      duplicate_ids: [],
+      rank_gap_from_previous: nil,
+      parser_layout: parsed.parser_layout,
+      crawlbase_options: crawlbase_options,
+      _ids: Enum.map(movies, & &1.imdb_id)
+    }
+  end
+
+  defp find_movie_items(document) do
+    selectors = [
+      {".lister-item", "lister"},
+      {".ipc-metadata-list-summary-item", "ipc"},
+      {".titleColumn", "title_column"},
+      {".cli-item", "cli"},
+      {".list-item", "list_item"},
+      {".movie-item", "movie_item"}
+    ]
+
+    Enum.find_value(selectors, {[], "none"}, fn {selector, layout} ->
+      items = Floki.find(document, selector)
+      if items == [], do: nil, else: {items, layout}
+    end)
+  end
+
+  defp parse_item(item, start, index) do
+    href =
+      item
+      |> Floki.find("a[href*='/title/tt']")
+      |> List.first()
+      |> then(fn
+        nil -> nil
+        link -> Floki.attribute(link, "href") |> List.first()
+      end)
+
+    imdb_id = extract_imdb_id(href)
+
+    if imdb_id do
+      title = extract_title(item)
+      displayed_rank = extract_displayed_rank(item)
+
+      %{
+        imdb_id: imdb_id,
+        title: title,
+        rank: displayed_rank || start + index,
+        rank_source: if(displayed_rank, do: "displayed", else: "fallback")
+      }
+    end
+  end
+
+  defp extract_imdb_id(nil), do: nil
+
+  defp extract_imdb_id(href) do
+    case Regex.run(~r/\/title\/(tt\d+)/, href) do
+      [_, imdb_id] -> imdb_id
+      _ -> nil
+    end
+  end
+
+  defp extract_title(item) do
+    title_text =
+      item
+      |> Floki.find("h3")
+      |> Floki.text()
+      |> String.trim()
+
+    title_text =
+      if title_text == "" do
+        item
+        |> Floki.find("a[href*='/title/tt']")
+        |> List.first()
+        |> case do
+          nil -> ""
+          link -> Floki.text(link)
+        end
+        |> String.trim()
+      else
+        title_text
+      end
+
+    title_text
+    |> String.replace(~r/^\s*\d+[\.)]\s*/, "")
+    |> String.trim()
+  end
+
+  defp extract_displayed_rank(item) do
+    rank_texts = [
+      Floki.find(item, ".lister-item-index") |> Floki.text(),
+      Floki.find(item, "h3") |> Floki.text(),
+      Floki.find(item, ".ipc-title__text") |> Floki.text()
+    ]
+
+    rank_texts
+    |> Enum.find_value(fn text ->
+      case Regex.run(~r/^\s*(\d+)[\.)]/, String.trim(text || "")) do
+        [_, rank] -> String.to_integer(rank)
+        _ -> nil
+      end
+    end)
+  end
+
+  defp rank_at([], _), do: nil
+  defp rank_at(movies, :first), do: List.first(movies).rank
+  defp rank_at(movies, :last), do: List.last(movies).rank
+
+  defp imdb_id_at([], _), do: nil
+  defp imdb_id_at(movies, :first), do: List.first(movies).imdb_id
+  defp imdb_id_at(movies, :last), do: List.last(movies).imdb_id
+
+  defp sample_titles(movies) do
+    movies
+    |> Enum.take(@sample_size)
+    |> Enum.map(& &1.title)
+  end
+
+  defp annotate_windows(windows) do
+    {_seen, _previous_rank, annotated} =
+      Enum.reduce(windows, {MapSet.new(), nil, []}, fn window, {seen, previous_rank, acc} ->
+        ids = window_ids(window)
+
+        duplicates =
+          (repeated_ids(ids) ++ Enum.filter(ids, &MapSet.member?(seen, &1))) |> Enum.uniq()
+
+        rank_gap =
+          cond do
+            previous_rank == nil or window.first_rank == nil -> nil
+            true -> window.first_rank - previous_rank - 1
+          end
+
+        annotated_window = %{window | duplicate_ids: duplicates, rank_gap_from_previous: rank_gap}
+        next_seen = Enum.reduce(ids, seen, &MapSet.put(&2, &1))
+        next_previous_rank = window.last_rank || previous_rank
+
+        {next_seen, next_previous_rank, [annotated_window | acc]}
+      end)
+
+    Enum.reverse(annotated)
+  end
+
+  defp window_ids(%{fetch_status: "ok"} = window) do
+    # Re-fetching parsed movies would be wasteful; the first/last fields are
+    # not enough for cross-window duplicates, so keep IDs in a private key until
+    # summary is built.
+    Map.get(window, :_ids, [])
+  end
+
+  defp window_ids(_window), do: []
+
+  defp repeated_ids(ids) do
+    ids
+    |> Enum.frequencies()
+    |> Enum.filter(fn {_id, count} -> count > 1 end)
+    |> Enum.map(fn {id, _count} -> id end)
+  end
+
+  defp summarize(windows) do
+    successful = Enum.filter(windows, &(&1.fetch_status == "ok"))
+    non_empty = Enum.filter(successful, &(&1.movie_count > 0))
+    all_ids = Enum.flat_map(windows, &window_ids/1)
+    has_duplicates = Enum.any?(windows, &(&1.duplicate_ids != []))
+    all_windows_ok = successful != [] and length(successful) == length(windows)
+    all_windows_non_empty = length(non_empty) == length(windows)
+
+    has_gaps =
+      Enum.any?(
+        windows,
+        &(is_integer(&1.rank_gap_from_previous) and &1.rank_gap_from_previous != 0)
+      )
+
+    safe_to_import =
+      all_windows_ok and all_windows_non_empty and not has_gaps and not has_duplicates
+
+    %{
+      total_unique_ids: all_ids |> MapSet.new() |> MapSet.size(),
+      position_ranges: position_ranges(non_empty),
+      has_gaps: has_gaps,
+      has_duplicates: has_duplicates,
+      recommended_page_size: recommended_page_size(non_empty),
+      recommended_url_strategy:
+        if(safe_to_import, do: "start_offset", else: "start_offset_unverified"),
+      safe_to_import: safe_to_import
+    }
+  end
+
+  defp position_ranges(windows) do
+    Enum.map(windows, fn window ->
+      %{
+        start: window.start,
+        first_rank: window.first_rank,
+        last_rank: window.last_rank,
+        movie_count: window.movie_count
+      }
+    end)
+  end
+
+  defp recommended_page_size([]), do: nil
+
+  defp recommended_page_size(windows) do
+    windows
+    |> Enum.map(& &1.movie_count)
+    |> Enum.frequencies()
+    |> Enum.max_by(fn {count, frequency} -> {frequency, count} end)
+    |> elem(0)
+  end
+end

--- a/lib/cinegraph/maintenance/refresh_canonical_lists.ex
+++ b/lib/cinegraph/maintenance/refresh_canonical_lists.ex
@@ -21,6 +21,7 @@ defmodule Cinegraph.Maintenance.RefreshCanonicalLists do
     * `:stale_days` - include lists stale by this many days
     * `:all` - include all active IMDb lists
     * `:limit` - positive integer cap
+    * `:exclude_source_keys` - source_keys to skip before applying the limit
     * `:dry_run` - report only
     * `:trigger` - string stored in job args
   """
@@ -33,6 +34,7 @@ defmodule Cinegraph.Maintenance.RefreshCanonicalLists do
     lists =
       audit.lists
       |> select_lists(opts)
+      |> reject_source_keys(Keyword.get(opts, :exclude_source_keys, []))
       |> apply_limit(Keyword.get(opts, :limit))
 
     dry_run? = Keyword.get(opts, :dry_run, false)
@@ -89,6 +91,17 @@ defmodule Cinegraph.Maintenance.RefreshCanonicalLists do
 
   defp apply_limit(_rows, other) do
     raise ArgumentError, ":limit must be a positive integer or nil, got: #{inspect(other)}"
+  end
+
+  defp reject_source_keys(rows, []), do: rows
+
+  defp reject_source_keys(rows, source_keys) when is_list(source_keys) do
+    source_keys = MapSet.new(source_keys)
+    Enum.reject(rows, &MapSet.member?(source_keys, &1.source_key))
+  end
+
+  defp reject_source_keys(_rows, other) do
+    raise ArgumentError, ":exclude_source_keys must be a list, got: #{inspect(other)}"
   end
 
   # Keep per-job inserts so Oban uniqueness is honored and conflicts can be

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -136,6 +136,30 @@ defmodule Cinegraph.Movies do
   end
 
   @doc """
+  Returns a small shelf of full movies from a canonical list ordered by source position.
+  """
+  def list_canonical_shelf_movies(source_key, limit \\ 12)
+      when is_binary(source_key) and is_integer(limit) do
+    position =
+      dynamic(
+        [m],
+        fragment(
+          "NULLIF(?->?->>'list_position', '')::int",
+          m.canonical_sources,
+          ^source_key
+        )
+      )
+
+    from(m in Movie,
+      where: m.import_status == "full",
+      where: fragment("? \\? ?", m.canonical_sources, ^source_key),
+      order_by: ^[asc_nulls_last: position, asc: :release_date, asc: :title],
+      limit: ^limit
+    )
+    |> Repo.replica().all()
+  end
+
+  @doc """
   Returns the list of soft imported movies.
   These are movies that didn't meet quality criteria but are tracked.
   """

--- a/lib/cinegraph/scrapers/http/adapters/crawlbase.ex
+++ b/lib/cinegraph/scrapers/http/adapters/crawlbase.ex
@@ -59,8 +59,10 @@ defmodule Cinegraph.Scrapers.Http.Adapters.Crawlbase do
     recv_timeout = Keyword.get(opts, :recv_timeout, @default_recv_timeout)
     page_wait = Keyword.get(opts, :page_wait, @default_page_wait)
     ajax_wait = Keyword.get(opts, :ajax_wait, true)
+    scroll = Keyword.get(opts, :scroll, false)
+    scroll_interval = Keyword.get(opts, :scroll_interval)
 
-    request_url = build_request_url(url, mode, page_wait, ajax_wait)
+    request_url = build_request_url(url, mode, page_wait, ajax_wait, scroll, scroll_interval)
 
     http_opts = [
       timeout: timeout,
@@ -107,7 +109,7 @@ defmodule Cinegraph.Scrapers.Http.Adapters.Crawlbase do
     end
   end
 
-  defp build_request_url(url, mode, page_wait, ajax_wait) do
+  defp build_request_url(url, mode, page_wait, ajax_wait, scroll, scroll_interval) do
     token = get_token_for_mode(mode)
 
     query_params = %{
@@ -121,6 +123,14 @@ defmodule Cinegraph.Scrapers.Http.Adapters.Crawlbase do
         |> Map.put("page_wait", to_string(page_wait))
         |> then(fn params ->
           if ajax_wait, do: Map.put(params, "ajax_wait", "true"), else: params
+        end)
+        |> then(fn params ->
+          if scroll, do: Map.put(params, "scroll", "true"), else: params
+        end)
+        |> then(fn params ->
+          if scroll_interval,
+            do: Map.put(params, "scroll_interval", to_string(scroll_interval)),
+            else: params
         end)
       else
         query_params

--- a/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
+++ b/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
@@ -262,8 +262,8 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
       |> String.trim()
       |> String.to_integer()
 
-    # Calculate pages (250 items per page)
-    div(total - 1, 250) + 1
+    # IMDb list pages currently expose 100 titles per start offset.
+    div(total - 1, 100) + 1
   end
 
   @doc """
@@ -314,11 +314,11 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
     # Count movies on first page
     movie_count = count_movies_on_page(document)
 
-    if movie_count >= 250 do
+    if movie_count >= 100 do
       # For known lists, use hardcoded values
       # This is a fallback - in production, we'd want better detection
       # Default for 1001 Movies list
-      6
+      11
     else
       1
     end
@@ -485,9 +485,8 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
   end
 
   defp has_next_page?(html) do
-    # For IMDb lists, check if we have the expected number of items
-    # The 1001 Movies list has 1260 movies total, with 250 per page
-    # So there should be 6 pages total (250 * 5 + 10)
+    # For IMDb lists, check if we have the expected number of items.
+    # Modern IMDb list URLs page by `start=` in 100-title windows.
 
     # Check if there's a "Next" button or if we haven't reached the end
     document = Floki.parse_document!(html)
@@ -526,7 +525,7 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
       # If no explicit next button, check if we got a full page of results
       # which might indicate there are more pages
       movie_count = count_movies_on_page(document)
-      movie_count >= 250
+      movie_count >= 100
     end
   end
 
@@ -539,11 +538,8 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
   end
 
   defp build_imdb_list_url(list_id, page) do
-    if page == 1 do
-      "https://www.imdb.com/list/#{list_id}/"
-    else
-      "https://www.imdb.com/list/#{list_id}/?page=#{page}"
-    end
+    start_index = (page - 1) * 100 + 1
+    "https://www.imdb.com/list/#{list_id}/?sort=list_order,asc&start=#{start_index}&mode=detail"
   end
 
   defp fetch_html(url) do
@@ -594,9 +590,8 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
 
       Logger.info("Found #{length(list_items)} potential movie items")
 
-      # Calculate base position based on page number
-      # Page 1: positions 1-250, Page 2: positions 251-500, etc.
-      base_position = (page - 1) * 250
+      # Calculate base position based on IMDb's 100-title `start=` windows.
+      base_position = (page - 1) * 100
 
       movies =
         list_items

--- a/lib/cinegraph/video_clerk.ex
+++ b/lib/cinegraph/video_clerk.ex
@@ -1,0 +1,313 @@
+defmodule Cinegraph.VideoClerk do
+  @moduledoc """
+  Explainable, non-collaborative movie recommendations for the Video Clerk.
+  """
+
+  import Ecto.Query
+
+  alias Cinegraph.Movies.{Credit, Movie, MovieScoreCache, Person}
+  alias Cinegraph.Repo
+
+  @default_limit 4
+  @candidate_limit 300
+
+  @doc """
+  Recommend one primary movie and alternates from one to three seed movie ids.
+  """
+  def recommend(seed_ids, opts \\ []) when is_list(seed_ids) do
+    limit = opts |> Keyword.get(:limit, @default_limit) |> max(1)
+
+    seed_ids =
+      seed_ids
+      |> Enum.filter(&is_integer/1)
+      |> Enum.uniq()
+      |> Enum.take(3)
+
+    seeds = load_seed_movies(seed_ids)
+
+    if seeds == [] do
+      empty_result([])
+    else
+      fingerprint = fingerprint(seeds)
+
+      candidates = candidate_movies(seeds, fingerprint)
+      person_overlap_by_movie = candidate_person_overlap_map(candidates, fingerprint.person_ids)
+
+      scored =
+        candidates
+        |> Enum.reject(&(&1.id in seed_ids))
+        |> Enum.map(&score_candidate(&1, fingerprint, person_overlap_by_movie))
+        |> Enum.reject(&(&1.score <= 0))
+        |> Enum.sort_by(&{&1.score, release_year_sort(&1.movie)}, :desc)
+        |> Enum.take(limit)
+        |> Enum.map(&shape_result/1)
+
+      %{
+        primary: List.first(scored),
+        alternates: Enum.drop(scored, 1),
+        seed_movies: seeds,
+        route_labels: route_labels(scored),
+        evidence_summary: evidence_summary(scored)
+      }
+    end
+  end
+
+  defp empty_result(seeds) do
+    %{primary: nil, alternates: [], seed_movies: seeds, route_labels: [], evidence_summary: []}
+  end
+
+  defp load_seed_movies([]), do: []
+
+  defp load_seed_movies(seed_ids) do
+    Movie
+    |> where([m], m.id in ^seed_ids)
+    |> where([m], m.import_status == "full")
+    |> preload([:genres, :keywords, :score_cache])
+    |> Repo.replica().all()
+    |> Enum.sort_by(fn movie -> Enum.find_index(seed_ids, &(&1 == movie.id)) || 999 end)
+  end
+
+  defp candidate_movies(seeds, fingerprint) do
+    seed_ids = Enum.map(seeds, & &1.id)
+
+    canonical =
+      Movie
+      |> where([m], m.import_status == "full")
+      |> where([m], is_nil(m.release_date) or m.release_date <= ^Date.utc_today())
+      |> where(
+        [m],
+        fragment("? \\? ?", m.canonical_sources, "cult_movies_400") or
+          fragment("? \\? ?", m.canonical_sources, "1001_movies")
+      )
+      |> where([m], m.id not in ^seed_ids)
+      |> order_by([m],
+        desc: fragment("? \\? ?", m.canonical_sources, "cult_movies_400"),
+        desc: fragment("? \\? ?", m.canonical_sources, "1001_movies"),
+        desc_nulls_last: m.release_date
+      )
+      |> limit(@candidate_limit)
+      |> preload([:genres, :keywords, :score_cache])
+      |> Repo.replica().all()
+
+    graph =
+      graph_candidate_query(seed_ids, fingerprint)
+      |> preload([:genres, :keywords, :score_cache])
+      |> Repo.replica().all()
+
+    (canonical ++ graph)
+    |> Enum.uniq_by(& &1.id)
+  end
+
+  defp graph_candidate_query(seed_ids, fingerprint) do
+    genre_ids = MapSet.to_list(fingerprint.genre_ids)
+    keyword_ids = MapSet.to_list(fingerprint.keyword_ids)
+    person_ids = MapSet.to_list(fingerprint.person_ids)
+
+    Movie
+    |> where([m], m.import_status == "full")
+    |> where([m], is_nil(m.release_date) or m.release_date <= ^Date.utc_today())
+    |> where([m], m.id not in ^seed_ids)
+    |> join(:left, [m], g in "movie_genres", on: g.movie_id == m.id)
+    |> join(:left, [m, g], k in "movie_keywords", on: k.movie_id == m.id)
+    |> join(:left, [m, g, k], c in Credit, on: c.movie_id == m.id)
+    |> where(
+      [m, g, k, c],
+      g.genre_id in ^genre_ids or k.keyword_id in ^keyword_ids or c.person_id in ^person_ids
+    )
+    |> group_by([m], m.id)
+    |> order_by([m, g, k, c],
+      desc:
+        fragment(
+          "COUNT(DISTINCT ?) + COUNT(DISTINCT ?) + COUNT(DISTINCT ?)",
+          g.genre_id,
+          k.keyword_id,
+          c.person_id
+        ),
+      desc_nulls_last: m.release_date
+    )
+    |> limit(@candidate_limit)
+  end
+
+  defp fingerprint(seeds) do
+    seed_ids = Enum.map(seeds, & &1.id)
+
+    credits =
+      Credit
+      |> where([c], c.movie_id in ^seed_ids)
+      |> where([c], c.credit_type == "cast" or c.job in ["Director", "Writer", "Screenplay"])
+      |> preload([:person])
+      |> Repo.replica().all()
+
+    %{
+      genre_ids: seeds |> Enum.flat_map(& &1.genres) |> ids(),
+      keyword_ids: seeds |> Enum.flat_map(& &1.keywords) |> ids(),
+      person_ids: credits |> Enum.map(& &1.person_id) |> MapSet.new(),
+      people_names: people_names(credits),
+      canonical_sources: seeds |> Enum.flat_map(&Movie.canonical_source_keys/1) |> MapSet.new(),
+      seed_years: seeds |> Enum.map(&release_year/1) |> Enum.reject(&is_nil/1),
+      seed_count: length(seeds)
+    }
+  end
+
+  defp score_candidate(movie, fingerprint, person_overlap_by_movie) do
+    genre_overlap = overlap_count(movie.genres, fingerprint.genre_ids)
+    keyword_overlap = overlap_count(movie.keywords, fingerprint.keyword_ids)
+    person_overlap = Map.get(person_overlap_by_movie, movie.id, 0)
+    cult? = Movie.is_canonical?(movie, "cult_movies_400")
+    canon? = Movie.is_canonical?(movie, "1001_movies")
+    score_cache = loaded_score_cache(movie)
+
+    evidence =
+      []
+      |> maybe_add(cult?, "Cult afterlife", 22)
+      |> maybe_add(canon?, "Cultural memory", 18)
+      |> maybe_add(person_overlap > 0, "Human graph", min(person_overlap * 8, 24))
+      |> maybe_add(genre_overlap > 0, "Tone bridge", min(genre_overlap * 6, 18))
+      |> maybe_add(keyword_overlap > 0, "Taste tension", min(keyword_overlap * 4, 16))
+      |> maybe_add(
+        score_cache && (score_cache.unpredictability_score || 0) > 0,
+        "Taste tension",
+        6
+      )
+      |> maybe_add(score_cache && (score_cache.overall_score || 0) > 0, "Cinegraph confidence", 4)
+
+    score = Enum.reduce(evidence, 0, fn {_label, points}, acc -> acc + points end)
+
+    %{
+      movie: movie,
+      score: score,
+      evidence: merge_evidence(evidence),
+      overlaps: %{
+        genres: genre_overlap,
+        keywords: keyword_overlap,
+        people: person_overlap,
+        score_cache: score_cache
+      }
+    }
+  end
+
+  defp shape_result(scored) do
+    movie = scored.movie
+
+    %{
+      id: movie.id,
+      title: movie.title,
+      year: release_year(movie),
+      slug: to_string(movie.slug),
+      poster_url: Movie.poster_url(movie, "w342"),
+      href: movie_href(movie),
+      score: scored.score,
+      evidence: scored.evidence,
+      route_labels: Enum.map(scored.evidence, & &1.label),
+      reason: reason(scored)
+    }
+  end
+
+  defp reason(%{movie: movie, evidence: evidence, overlaps: overlaps}) do
+    routes =
+      evidence
+      |> Enum.map(& &1.label)
+      |> Enum.take(3)
+      |> readable_join()
+
+    detail =
+      cond do
+        overlaps.people > 0 ->
+          "It shares creative DNA with your picks, then bends toward #{routes}."
+
+        overlaps.genres > 0 or overlaps.keywords > 0 ->
+          "It rhymes with the mood of your picks without collapsing into more of the same."
+
+        true ->
+          "It comes from Cinegraph's cult and cultural-memory shelves."
+      end
+
+    "#{movie.title} is the clerk's move: #{detail}"
+  end
+
+  defp candidate_person_overlap_map(candidates, seed_person_ids) do
+    movie_ids = Enum.map(candidates, & &1.id)
+    person_ids = MapSet.to_list(seed_person_ids)
+
+    if person_ids == [] or movie_ids == [] do
+      %{}
+    else
+      Credit
+      |> where([c], c.movie_id in ^movie_ids)
+      |> where([c], c.person_id in ^person_ids)
+      |> group_by([c], c.movie_id)
+      |> select([c], {c.movie_id, count(c.person_id, :distinct)})
+      |> Repo.replica().all()
+      |> Map.new()
+    end
+  end
+
+  defp route_labels(results) do
+    results
+    |> Enum.flat_map(& &1.route_labels)
+    |> Enum.uniq()
+    |> Enum.take(5)
+  end
+
+  defp evidence_summary(results) do
+    results
+    |> Enum.flat_map(& &1.evidence)
+    |> Enum.group_by(& &1.label)
+    |> Enum.map(fn {label, rows} ->
+      %{label: label, points: Enum.sum(Enum.map(rows, & &1.points))}
+    end)
+    |> Enum.sort_by(& &1.points, :desc)
+    |> Enum.take(5)
+    |> Enum.map(& &1.label)
+  end
+
+  defp ids(rows), do: rows |> Enum.map(& &1.id) |> MapSet.new()
+
+  defp people_names(credits) do
+    credits
+    |> Enum.map(fn
+      %{person: %Person{name: name}} -> name
+      _ -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp overlap_count(rows, ids) do
+    rows
+    |> Enum.map(& &1.id)
+    |> MapSet.new()
+    |> MapSet.intersection(ids)
+    |> MapSet.size()
+  end
+
+  defp maybe_add(evidence, true, label, points), do: [{label, points} | evidence]
+  defp maybe_add(evidence, _condition, _label, _points), do: evidence
+
+  defp merge_evidence(evidence) do
+    evidence
+    |> Enum.group_by(fn {label, _points} -> label end, fn {_label, points} -> points end)
+    |> Enum.map(fn {label, points} -> %{label: label, points: Enum.sum(points)} end)
+    |> Enum.sort_by(& &1.points, :desc)
+  end
+
+  defp loaded_score_cache(%{score_cache: %MovieScoreCache{} = cache}), do: cache
+  defp loaded_score_cache(_), do: nil
+
+  defp release_year(%Movie{release_date: %Date{year: year}}), do: year
+  defp release_year(_movie), do: nil
+  defp release_year_sort(movie), do: release_year(movie) || 0
+
+  defp movie_href(%Movie{slug: slug}) when not is_nil(slug), do: "/movies/#{slug}"
+  defp movie_href(%Movie{imdb_id: imdb_id}) when is_binary(imdb_id), do: "/movies/imdb/#{imdb_id}"
+  defp movie_href(_movie), do: "#"
+
+  defp readable_join([]), do: "Cinegraph evidence"
+  defp readable_join([one]), do: one
+  defp readable_join([one, two]), do: "#{one} and #{two}"
+
+  defp readable_join(labels) do
+    {last, rest} = List.pop_at(labels, -1)
+    "#{Enum.join(rest, ", ")}, and #{last}"
+  end
+end

--- a/lib/cinegraph/workers/canonical_import_completion_worker.ex
+++ b/lib/cinegraph/workers/canonical_import_completion_worker.ex
@@ -15,12 +15,15 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
       states: [:available, :scheduled, :retryable]
     ]
 
-  alias Cinegraph.Movies.MovieLists
+  alias Cinegraph.Movies.{MovieList, MovieLists}
   alias Cinegraph.Repo
   import Ecto.Query
   require Logger
 
-  @doc false
+  @doc """
+  Checks whether all page jobs for a canonical list import have finished and
+  finalizes the import once the list reaches a terminal state.
+  """
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
     %{
@@ -119,22 +122,16 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
 
       list ->
         status = completion_status(actual_count, expected_count)
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
 
         updated_metadata =
           (list.metadata || %{})
           |> Map.put("expected_movie_count", expected_count)
           |> Map.put("actual_movie_count", actual_count)
-          |> Map.put("last_import_finished_at", DateTime.utc_now() |> DateTime.to_iso8601())
+          |> Map.put("last_import_finished_at", DateTime.to_iso8601(now))
           |> maybe_put_error(status, actual_count, expected_count)
 
-        attrs = %{
-          last_import_at: DateTime.utc_now(),
-          last_import_status: status,
-          metadata: updated_metadata,
-          total_imports: (list.total_imports || 0) + 1
-        }
-
-        case MovieLists.update_movie_list(list, attrs) do
+        case finalize_pending_import(list, status, now, updated_metadata) do
           {:ok, updated_list} ->
             Logger.info(
               "Import #{status} for #{list_key}: #{actual_count} movies (expected: #{expected_count || "unknown"})"
@@ -151,16 +148,47 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
                  import_status: status,
                  total_movies: actual_count,
                  expected_movies: expected_count,
-                 timestamp: DateTime.utc_now()
+                 timestamp: now
                }}
             )
 
             {:ok, updated_list}
 
-          {:error, changeset} ->
-            Logger.error("Failed to update import stats: #{inspect(changeset.errors)}")
-            {:error, changeset}
+          {:skipped, current_list} ->
+            Logger.info(
+              "Import already finalized for #{list_key} with status #{inspect(current_list.last_import_status)}"
+            )
+
+            {:ok, current_list}
         end
+    end
+  end
+
+  defp finalize_pending_import(%MovieList{} = list, status, now, metadata) do
+    updated_at = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    query =
+      from movie_list in MovieList,
+        where:
+          movie_list.id == ^list.id and
+            (is_nil(movie_list.last_import_status) or movie_list.last_import_status == "pending"),
+        update: [
+          set: [
+            last_import_at: ^now,
+            last_import_status: ^status,
+            metadata: ^metadata,
+            total_imports: fragment("COALESCE(?, 0) + 1", movie_list.total_imports),
+            updated_at: ^updated_at
+          ]
+        ],
+        select: movie_list
+
+    case Repo.update_all(query, []) do
+      {1, [updated_list]} ->
+        {:ok, updated_list}
+
+      {0, []} ->
+        {:skipped, Repo.get!(MovieList, list.id)}
     end
   end
 

--- a/lib/cinegraph/workers/canonical_list_refresh_sweeper.ex
+++ b/lib/cinegraph/workers/canonical_list_refresh_sweeper.ex
@@ -10,25 +10,28 @@ defmodule Cinegraph.Workers.CanonicalListRefreshSweeper do
 
   require Logger
 
-  @doc false
+  @doc """
+  Queues refreshes for blank IMDb lists first, then stale lists that were not
+  already selected by the blank-list pass.
+  """
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    [
-      [blank_only: true],
-      [stale_days: 90]
-    ]
-    |> Enum.map(&run_refresh/1)
+    blank_stats = run_refresh(blank_only: true)
+    stale_stats = run_refresh([stale_days: 90], exclude_source_keys: blank_stats.lists)
+
+    [blank_stats, stale_stats]
     |> combine_stats()
     |> then(&{:ok, &1})
   end
 
-  defp run_refresh(selector_opts) do
+  defp run_refresh(selector_opts, extra_opts \\ []) do
     opts =
-      selector_opts ++
-        [
-          limit: 5,
-          trigger: "scheduled_canonical_refresh"
-        ]
+      selector_opts
+      |> Keyword.merge(
+        limit: 5,
+        trigger: "scheduled_canonical_refresh"
+      )
+      |> Keyword.merge(extra_opts)
 
     {:ok, stats} = RefreshCanonicalLists.run(opts)
 

--- a/lib/cinegraph_web/live/global_search/components.ex
+++ b/lib/cinegraph_web/live/global_search/components.ex
@@ -13,7 +13,8 @@ defmodule CinegraphWeb.GlobalSearch.Components do
       </li>
       <li :for={r <- @recents} class="px-2">
         <a
-          href={safe_recent_href(r["href"])}
+          href={recent_href(r)}
+          role="option"
           class="flex items-center gap-2 px-2 py-2 rounded-md text-[13px] text-mist-950 dark:text-white hover:bg-mist-50 dark:hover:bg-white/5 no-underline"
         >
           <span class="text-mist-500 dark:text-mist-400" aria-hidden="true">🕘</span>
@@ -23,6 +24,27 @@ defmodule CinegraphWeb.GlobalSearch.Components do
     </ul>
     """
   end
+
+  defp recent_href(%{"href" => href} = recent) do
+    case safe_recent_href(href) do
+      "#" -> recent_search_href(recent)
+      href -> href
+    end
+  end
+
+  defp recent_href(recent), do: recent_search_href(recent)
+
+  defp recent_search_href(%{"label" => label}) when is_binary(label) do
+    query = String.trim(label)
+
+    if query == "" do
+      "#"
+    else
+      "/movies?search=#{URI.encode_www_form(query)}"
+    end
+  end
+
+  defp recent_search_href(_), do: "#"
 
   defp safe_recent_href(href) when is_binary(href) do
     uri = URI.parse(href)

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -14,6 +14,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
   import CinegraphWeb.MovieLive.ShowV2.Presentation
   import CinegraphWeb.SEOHelpers
 
+  alias Cinegraph.VideoClerk
   alias CinegraphWeb.Components.ListAppearanceCard
   alias CinegraphWeb.MovieLive.ShowV2.Data
   alias CinegraphWeb.MovieLive.ShowV2.ProductionDetails
@@ -47,6 +48,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
         {:noreply,
          socket
          |> assign(data)
+         |> assign(:video_clerk_recommendation, VideoClerk.recommend([data.movie.id], limit: 3))
          |> assign_availability(data.movie, socket.assigns[:availability_browser_region])
          |> assign_movie_seo(data.movie)}
 
@@ -98,6 +100,11 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
       %{id: "awards", label: "Awards", present?: assigns[:festival_noms] != []},
       %{id: "lists", label: "Lists", present?: assigns[:canon_lists] != []},
       %{id: "collaborations", label: "Collabs", present?: has_collabs},
+      %{
+        id: "video-clerk",
+        label: "Clerk",
+        present?: not is_nil(assigns[:video_clerk_recommendation][:primary])
+      },
       %{
         id: "director",
         label: "Director",
@@ -579,6 +586,59 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
             >
               Explore the full collaboration network →
             </a>
+          </section>
+
+          <%!-- VIDEO CLERK --%>
+          <section :if={@video_clerk_recommendation[:primary]} id="video-clerk">
+            <div class="mb-6 flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <div class="text-[11px] font-semibold uppercase tracking-[.08em] text-mist-500">
+                  Video Clerk
+                </div>
+                <h2 class="mt-1 font-display italic text-[28px] sm:text-[32px] tracking-[-.01em] text-mist-950">
+                  Ask for the next strange right thing
+                </h2>
+              </div>
+              <.link
+                navigate={~p"/video-clerk?#{%{seed: movie_slug_or_id(@movie)}}"}
+                class="inline-flex rounded-md bg-mist-950 px-3 py-2 text-[12px] font-semibold text-mist-50 hover:bg-mist-800"
+              >
+                Ask the Video Clerk
+              </.link>
+            </div>
+            <div class="grid grid-cols-1 gap-3 lg:grid-cols-3">
+              <a
+                :for={
+                  rec <-
+                    [@video_clerk_recommendation.primary | @video_clerk_recommendation.alternates]
+                    |> Enum.reject(&is_nil/1)
+                    |> Enum.take(3)
+                }
+                href={rec.href}
+                class="rounded-lg border border-mist-950/10 bg-mist-50 p-4 no-underline hover:bg-white"
+              >
+                <div class="text-[11px] font-semibold uppercase tracking-[.08em] text-mist-500">
+                  {Enum.join(Enum.take(rec.route_labels, 2), " / ")}
+                </div>
+                <div class="mt-2 flex gap-3">
+                  <img
+                    :if={rec.poster_url}
+                    src={rec.poster_url}
+                    alt=""
+                    class="h-24 w-16 rounded-[4px] object-cover"
+                  />
+                  <div class="min-w-0">
+                    <div class="text-[14px] font-semibold leading-snug text-mist-950">
+                      {rec.title}
+                    </div>
+                    <div class="mt-1 text-[12px] text-mist-500">{rec.year}</div>
+                    <p class="mt-2 line-clamp-3 text-[12px] leading-relaxed text-mist-700">
+                      {rec.reason}
+                    </p>
+                  </div>
+                </div>
+              </a>
+            </div>
           </section>
 
           <%!-- MORE FROM DIRECTOR --%>

--- a/lib/cinegraph_web/live/video_clerk_live.ex
+++ b/lib/cinegraph_web/live/video_clerk_live.ex
@@ -1,0 +1,303 @@
+defmodule CinegraphWeb.VideoClerkLive do
+  @moduledoc """
+  Public mock page for the Video Clerk recommendation concept.
+  """
+  use CinegraphWeb, :live_view
+
+  import Ecto.Query
+
+  alias Cinegraph.Repo
+  alias Cinegraph.Search
+  alias Cinegraph.VideoClerk
+  alias Cinegraph.Movies
+  alias Cinegraph.Movies.Movie
+
+  attr :title, :string, required: true
+  attr :eyebrow, :string, required: true
+  attr :movies, :list, required: true
+  attr :empty, :string, required: true
+
+  def shelf(assigns) do
+    ~H"""
+    <section>
+      <div class="mb-4 flex items-end justify-between gap-4">
+        <div>
+          <CinegraphWeb.NeutralV2Components.n_eyebrow>
+            {@eyebrow}
+          </CinegraphWeb.NeutralV2Components.n_eyebrow>
+          <h2 class="mt-2 font-display italic text-[34px] leading-tight text-mist-950">
+            {@title}
+          </h2>
+        </div>
+      </div>
+
+      <div
+        :if={@movies != []}
+        class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-12"
+      >
+        <CinegraphWeb.NeutralV2Components.n_film_card
+          :for={movie <- @movies}
+          film={movie}
+          rank={movie.rank}
+          show_score={false}
+          compact={true}
+        />
+      </div>
+
+      <div
+        :if={@movies == []}
+        class="rounded-lg border border-mist-950/10 bg-mist-50 px-4 py-8 text-center text-[13px] text-mist-600"
+      >
+        {@empty}
+      </div>
+    </section>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    cult_movies = load_shelf("cult_movies_400")
+    canon_movies = load_shelf("1001_movies")
+
+    {:ok,
+     socket
+     |> assign(:page_title, "The Video Clerk")
+     |> assign(:active_nav, "Video Clerk")
+     |> assign(:selected_movies, [])
+     |> assign(:search_query, "")
+     |> assign(:search_results, [])
+     |> assign(:recommendation, empty_recommendation())
+     |> assign(:routes, routes())
+     |> assign(:cult_movies, cult_movies)
+     |> assign(:canon_movies, canon_movies)
+     |> assign(:demo_films, demo_films())}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    selected_movies = selected_movies_from_params(params)
+
+    {:noreply,
+     socket
+     |> assign(:selected_movies, selected_movies)
+     |> assign_recommendation()}
+  end
+
+  @impl true
+  def handle_event("search_movies", %{"q" => query}, socket) do
+    query = String.trim(to_string(query || ""))
+
+    results =
+      if String.length(query) >= 2 do
+        query
+        |> Search.global(limit: 8)
+        |> Map.get(:films, [])
+        |> Enum.reject(&selected_slug?(socket.assigns.selected_movies, &1.slug))
+      else
+        []
+      end
+
+    {:noreply,
+     socket
+     |> assign(:search_query, query)
+     |> assign(:search_results, results)}
+  end
+
+  def handle_event("select_movie", %{"slug" => slug}, socket) do
+    selected =
+      socket.assigns.selected_movies
+      |> add_selected_movie(slug)
+      |> Enum.take(3)
+
+    {:noreply,
+     socket
+     |> assign(:search_query, "")
+     |> assign(:search_results, [])
+     |> push_patch(to: video_clerk_path(selected))}
+  end
+
+  def handle_event("remove_movie", %{"slug" => slug}, socket) do
+    selected = Enum.reject(socket.assigns.selected_movies, &(to_string(&1.slug) == slug))
+    {:noreply, push_patch(socket, to: video_clerk_path(selected))}
+  end
+
+  def handle_event("reset_clerk", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:search_query, "")
+     |> assign(:search_results, [])
+     |> push_patch(to: ~p"/video-clerk")}
+  end
+
+  def handle_event("load_demo", _params, socket) do
+    selected =
+      demo_films()
+      |> Enum.map(& &1.slug)
+      |> Enum.reduce([], &add_selected_movie(&2, &1))
+      |> Enum.take(3)
+
+    {:noreply, push_patch(socket, to: video_clerk_path(selected))}
+  end
+
+  defp load_shelf(source_key) do
+    source_key
+    |> Movies.list_canonical_shelf_movies(12)
+    |> Enum.with_index(1)
+    |> Enum.map(fn {movie, rank} -> movie_card(movie, source_key, rank) end)
+  end
+
+  defp movie_card(%Movie{} = movie, source_key, rank) do
+    metadata = Movie.canonical_metadata(movie, source_key) || %{}
+
+    %{
+      title: movie.title,
+      year: Movie.release_year(movie),
+      poster_url: Movie.poster_url(movie, "w342"),
+      href: movie_href(movie),
+      rank: normalize_rank(metadata["list_position"], rank),
+      reason: metadata["source_name"] || source_key,
+      dir: list_label(source_key),
+      score: nil
+    }
+  end
+
+  defp movie_href(%Movie{slug: slug}) when not is_nil(slug), do: ~p"/movies/#{slug}"
+
+  defp movie_href(%Movie{imdb_id: imdb_id}) when is_binary(imdb_id),
+    do: ~p"/movies/imdb/#{imdb_id}"
+
+  defp movie_href(_movie), do: "#"
+
+  defp list_label("cult_movies_400"), do: "Cult source"
+  defp list_label("1001_movies"), do: "Cultural canon"
+  defp list_label(source_key), do: source_key
+
+  defp normalize_rank(position, _fallback) when is_integer(position), do: position
+
+  defp normalize_rank(position, fallback) when is_binary(position) do
+    case Integer.parse(position) do
+      {rank, ""} -> rank
+      _ -> fallback
+    end
+  end
+
+  defp normalize_rank(_position, fallback), do: fallback
+
+  defp selected_movies_from_params(%{"movies" => movies}) when is_binary(movies) do
+    movies
+    |> String.split(",", trim: true)
+    |> Enum.take(3)
+    |> movies_by_slugs()
+  end
+
+  defp selected_movies_from_params(%{"seed" => seed}) when is_binary(seed) do
+    seed
+    |> List.wrap()
+    |> movies_by_slugs()
+  end
+
+  defp selected_movies_from_params(_params), do: []
+
+  defp movies_by_slugs([]), do: []
+
+  defp movies_by_slugs(slugs) do
+    Movie
+    |> where([m], m.slug in ^slugs)
+    |> where([m], m.import_status == "full")
+    |> Repo.replica().all()
+    |> Enum.sort_by(fn movie -> Enum.find_index(slugs, &(&1 == to_string(movie.slug))) || 999 end)
+  end
+
+  defp add_selected_movie(selected, slug) do
+    slug = to_string(slug)
+
+    cond do
+      selected_slug?(selected, slug) ->
+        selected
+
+      length(selected) >= 3 ->
+        selected
+
+      movie = movie_by_slug(slug) ->
+        selected ++ [movie]
+
+      true ->
+        selected
+    end
+  end
+
+  defp movie_by_slug(slug) do
+    Movie
+    |> where([m], m.slug == ^slug)
+    |> where([m], m.import_status == "full")
+    |> limit(1)
+    |> Repo.replica().one()
+  end
+
+  defp selected_slug?(selected, slug) do
+    Enum.any?(selected, &(to_string(&1.slug) == to_string(slug)))
+  end
+
+  defp pick_slots(selected) do
+    count = max(3 - length(selected), 0)
+    if count == 0, do: [], else: Enum.to_list(1..count)
+  end
+
+  defp assign_recommendation(socket) do
+    result =
+      socket.assigns.selected_movies
+      |> Enum.map(& &1.id)
+      |> VideoClerk.recommend(limit: 4)
+
+    assign(socket, :recommendation, result)
+  end
+
+  defp empty_recommendation do
+    %{primary: nil, alternates: [], seed_movies: [], route_labels: [], evidence_summary: []}
+  end
+
+  defp video_clerk_path([]), do: ~p"/video-clerk"
+
+  defp video_clerk_path(selected) do
+    slugs = selected |> Enum.map(&to_string(&1.slug)) |> Enum.join(",")
+    ~p"/video-clerk?#{%{movies: slugs}}"
+  end
+
+  defp demo_films do
+    [
+      %{title: "Donnie Darko", year: "2001", slug: "donnie-darko-2001"},
+      %{title: "Napoleon Dynamite", year: "2004", slug: "napoleon-dynamite-2004"},
+      %{title: "Ghost World", year: "2001", slug: "ghost-world-2001"}
+    ]
+  end
+
+  defp routes do
+    [
+      %{
+        title: "Cult Classic",
+        body:
+          "Start with movies that built a second life through obsession, quotation, midnight screenings, and misfit affection."
+      },
+      %{
+        title: "1001 / Cultural Relevance",
+        body:
+          "Use the canon as a pressure test: not because canon is law, but because cultural memory leaves evidence."
+      },
+      %{
+        title: "Human Graph",
+        body:
+          "Follow directors, writers, actors, crews, countries, movements, and production histories instead of anonymous co-watch behavior."
+      },
+      %{
+        title: "Disagreement",
+        body:
+          "Look for taste tension: movies critics defend, audiences rescue, or history corrects later."
+      },
+      %{
+        title: "Tonight",
+        body:
+          "Respect the mood. Sometimes the right answer is stranger, shorter, funnier, sadder, or just easier to start."
+      }
+    ]
+  end
+end

--- a/lib/cinegraph_web/live/video_clerk_live.html.heex
+++ b/lib/cinegraph_web/live/video_clerk_live.html.heex
@@ -1,0 +1,281 @@
+<div class="mx-auto w-full max-w-2xl px-6 pt-6 pb-16 md:max-w-3xl lg:max-w-7xl lg:px-10">
+  <nav class="mb-8 text-[12px] text-mist-600">
+    <.link navigate={~p"/movies"} class="hover:text-mist-950">Movies</.link>
+    <span class="mx-2 text-mist-400">/</span>
+    <span class="font-medium text-mist-950">Video Clerk</span>
+  </nav>
+
+  <section class="mb-12 grid gap-8 lg:grid-cols-[1fr_420px] lg:items-end">
+    <div>
+      <CinegraphWeb.NeutralV2Components.n_eyebrow>
+        Anti-collaborative filtering
+      </CinegraphWeb.NeutralV2Components.n_eyebrow>
+      <h1 class="mt-2 font-display italic text-[44px] leading-[1.02] text-balance text-mist-950 sm:text-[58px] lg:text-[78px]">
+        The Video Clerk.
+      </h1>
+      <p class="mt-4 max-w-3xl text-[18px] leading-relaxed text-mist-800">
+        Three films in. One human-feeling recommendation out.
+      </p>
+      <p class="mt-4 max-w-3xl text-[15px] leading-relaxed text-mist-700">
+        Built from cult afterlives, cultural relevance, creative relationships, and Cinegraph's own evidence. Not anonymous co-watch sludge.
+      </p>
+      <div class="mt-6 flex flex-wrap gap-2">
+        <.link
+          navigate={~p"/lists/cult-movies-400"}
+          class="inline-flex items-center rounded-md bg-mist-950 px-4 py-2 text-[13px] font-semibold text-mist-50 hover:bg-mist-800"
+        >
+          Browse cult source
+        </.link>
+        <.link
+          navigate={~p"/lists/1001-movies"}
+          class="inline-flex items-center rounded-md border border-mist-950/15 bg-mist-50 px-4 py-2 text-[13px] font-semibold text-mist-950 hover:bg-mist-100"
+        >
+          Browse 1001 source
+        </.link>
+      </div>
+    </div>
+
+    <div class="rounded-lg border border-mist-950/10 bg-mist-50 p-4 shadow-[0_12px_30px_rgba(20,18,15,.07)]">
+      <div class="mb-3 flex items-center justify-between">
+        <span class="text-[12px] font-semibold uppercase tracking-[.08em] text-mist-500">
+          Ask the clerk
+        </span>
+        <span class="rounded-md bg-mist-950 px-2 py-1 text-[11px] font-semibold text-mist-50 tabular-nums">
+          {length(@selected_movies)}/3
+        </span>
+      </div>
+
+      <form phx-change="search_movies" phx-submit="search_movies" autocomplete="off">
+        <input
+          type="text"
+          name="q"
+          value={@search_query}
+          placeholder="Search for a film"
+          phx-debounce="200"
+          class="h-10 w-full rounded-md border border-mist-950/15 bg-white px-3 text-[13px] text-mist-950 placeholder:text-mist-500"
+        />
+      </form>
+
+      <div
+        :if={@search_results != []}
+        class="mt-2 overflow-hidden rounded-md border border-mist-950/10 bg-white"
+      >
+        <button
+          :for={film <- @search_results}
+          type="button"
+          phx-click="select_movie"
+          phx-value-slug={film.slug}
+          class="flex w-full items-center gap-3 border-b border-mist-950/[0.06] px-3 py-2 text-left last:border-b-0 hover:bg-mist-50"
+        >
+          <img
+            :if={film.poster_path}
+            src={Movie.image_url(film.poster_path, "w92")}
+            alt=""
+            class="h-12 w-8 rounded-[3px] object-cover"
+          />
+          <div
+            :if={!film.poster_path}
+            class="grid h-12 w-8 place-items-center rounded-[3px] bg-mist-100 text-[12px] text-mist-500"
+          >
+            Film
+          </div>
+          <span class="min-w-0 flex-1">
+            <span class="block truncate text-[13px] font-semibold text-mist-950">
+              {film.title}
+            </span>
+            <span class="block text-[12px] text-mist-500">{film.year}</span>
+          </span>
+        </button>
+      </div>
+
+      <div
+        :if={@search_query != "" && @search_results == []}
+        class="mt-2 rounded-md border border-mist-950/10 bg-white px-3 py-3 text-[12px] text-mist-600"
+      >
+        No film matches yet. Try another title.
+      </div>
+
+      <div class="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          phx-click="load_demo"
+          class="rounded-md border border-mist-950/10 bg-white px-2 py-1 text-[11px] font-semibold text-mist-800 hover:bg-mist-100"
+        >
+          Load demo trio
+        </button>
+        <button
+          :if={@selected_movies != []}
+          type="button"
+          phx-click="reset_clerk"
+          class="rounded-md border border-mist-950/10 bg-white px-2 py-1 text-[11px] font-semibold text-mist-600 hover:bg-mist-100"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="mt-4 grid gap-2">
+        <div
+          :for={movie <- @selected_movies}
+          class="rounded-md border border-mist-950/10 bg-white px-3 py-3"
+        >
+          <div class="flex items-baseline justify-between gap-3">
+            <span class="text-[13px] font-semibold text-mist-950">{movie.title}</span>
+            <span class="text-[12px] tabular-nums text-mist-500">
+              {Movie.release_year(movie)}
+            </span>
+          </div>
+          <div class="mt-2 flex items-center justify-between gap-3">
+            <p class="text-[12px] leading-snug text-mist-600">Selected taste signal</p>
+            <button
+              type="button"
+              phx-click="remove_movie"
+              phx-value-slug={movie.slug}
+              class="text-[11px] font-semibold text-mist-500 hover:text-mist-950"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+
+        <div
+          :for={slot <- pick_slots(@selected_movies)}
+          class="rounded-md border border-dashed border-mist-950/15 bg-white/60 px-3 py-3"
+        >
+          <div class="text-[13px] font-semibold text-mist-500">
+            Pick {slot + length(@selected_movies)}
+          </div>
+          <p class="mt-1 text-[12px] leading-snug text-mist-500">
+            The clerk works with one film, but three gives it better taste weather.
+          </p>
+        </div>
+      </div>
+
+      <div :if={@recommendation.primary} class="mt-4 rounded-md bg-mist-950 p-4 text-mist-50">
+        <div class="text-[11px] font-semibold uppercase tracking-[.08em] text-mist-300">
+          The clerk says
+        </div>
+        <div class="mt-2 flex items-baseline justify-between gap-3">
+          <a
+            href={@recommendation.primary.href}
+            class="font-display italic text-[28px] leading-none text-mist-50 no-underline hover:text-white"
+          >
+            {@recommendation.primary.title}
+          </a>
+          <span class="text-[13px] tabular-nums text-mist-300">
+            {@recommendation.primary.year}
+          </span>
+        </div>
+        <p class="mt-3 text-[13px] leading-relaxed text-mist-200">
+          {@recommendation.primary.reason}
+        </p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <span
+            :for={route <- @recommendation.route_labels}
+            class="rounded-md border border-mist-50/15 px-2 py-1 text-[11px] font-medium text-mist-100"
+          >
+            {route}
+          </span>
+        </div>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <span
+            :for={alternate <- @recommendation.alternates}
+            class="rounded-md border border-mist-50/15 px-2 py-1 text-[11px] font-medium text-mist-100"
+          >
+            {alternate.title}
+          </span>
+        </div>
+      </div>
+
+      <div :if={!@recommendation.primary} class="mt-4 rounded-md bg-mist-950 p-4 text-mist-50">
+        <div class="text-[11px] font-semibold uppercase tracking-[.08em] text-mist-300">
+          The clerk is waiting
+        </div>
+        <p class="mt-3 text-[13px] leading-relaxed text-mist-200">
+          Pick a film, or load the demo trio, and Cinegraph will make a real recommendation from cult lists, canonical memory, and film-graph evidence.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-12 border-y border-mist-950/10 py-9">
+    <div class="grid gap-6 lg:grid-cols-[260px_1fr]">
+      <div>
+        <CinegraphWeb.NeutralV2Components.n_eyebrow>
+          Against the bubble
+        </CinegraphWeb.NeutralV2Components.n_eyebrow>
+        <h2 class="mt-2 font-display italic text-[34px] leading-tight text-mist-950">
+          Taste should not be a padded room.
+        </h2>
+      </div>
+      <div class="max-w-3xl space-y-4 text-[15px] leading-relaxed text-mist-700">
+        <p>
+          Collaborative filtering is good at keeping people inside a familiar loop. Cinegraph should do something more alive: notice the shape of a person's taste, then open a side door.
+        </p>
+        <p>
+          The Video Clerk is our shorthand for that ambition. It is not a faceless average of people like you. It is a recommendation with a point of view, built from films, filmmakers, canons, cult reputations, and the weird evidence that makes movie taste interesting.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <CinegraphWeb.NeutralV2Components.n_eyebrow>
+      Routes the clerk can take
+    </CinegraphWeb.NeutralV2Components.n_eyebrow>
+    <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+      <article
+        :for={route <- @routes}
+        class="rounded-lg border border-mist-950/10 bg-mist-50 p-4"
+      >
+        <h3 class="text-[14px] font-semibold text-mist-950">{route.title}</h3>
+        <p class="mt-2 text-[12.5px] leading-relaxed text-mist-700">{route.body}</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="mb-12 space-y-10">
+    <.shelf
+      title="400 Greatest Cult Movies"
+      eyebrow="Cult Classic Route"
+      movies={@cult_movies}
+      empty="Import cult_movies_400 to turn this shelf on."
+    />
+    <.shelf
+      title="1001 Movies You Must See Before You Die"
+      eyebrow="Cultural Relevance Route"
+      movies={@canon_movies}
+      empty="Import 1001_movies to turn this shelf on."
+    />
+  </section>
+
+  <section class="grid gap-6 rounded-lg border border-mist-950/10 bg-mist-50 p-5 lg:grid-cols-[1fr_360px] lg:items-center">
+    <div>
+      <CinegraphWeb.NeutralV2Components.n_eyebrow>
+        iOS preview
+      </CinegraphWeb.NeutralV2Components.n_eyebrow>
+      <h2 class="mt-2 font-display italic text-[34px] leading-tight text-mist-950">
+        From any movie page, ask for the next strange right thing.
+      </h2>
+      <p class="mt-3 max-w-2xl text-[14px] leading-relaxed text-mist-700">
+        Phase 1 is the page. The product move is a reusable recommendation surface: start from one film, or give the clerk three, then let Cinegraph explain why the next pick belongs.
+      </p>
+    </div>
+    <div class="rounded-lg bg-mist-950 p-4 text-mist-50">
+      <div class="rounded-md border border-mist-50/10 p-3">
+        <div class="text-[11px] font-semibold uppercase tracking-[.08em] text-mist-300">
+          After Napoleon Dynamite
+        </div>
+        <div class="mt-4 rounded-md bg-mist-50 p-3 text-mist-950">
+          <div class="text-[12px] text-mist-600">Try next</div>
+          <div class="mt-1 font-display italic text-[28px] leading-none">Harold and Maude</div>
+          <p class="mt-2 text-[12px] leading-relaxed text-mist-700">
+            Outsider comedy with a deeper historical pulse.
+          </p>
+        </div>
+        <button class="mt-3 w-full rounded-md bg-mist-50 px-3 py-2 text-[13px] font-semibold text-mist-950">
+          Ask the Video Clerk
+        </button>
+      </div>
+    </div>
+  </section>
+</div>

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -188,6 +188,7 @@ defmodule CinegraphWeb.Router do
     live_session :v2_collections,
       root_layout: {CinegraphWeb.Layouts, :v2_root},
       layout: false do
+      live "/video-clerk", VideoClerkLive, :show
       live "/lists", ListLive.Index, :index
       live "/lists/:slug", ListLive.Show, :show
       live "/awards", AwardsLive.Index, :index

--- a/lib/mix/tasks/cinegraph/audit/imdb_list_pagination.ex
+++ b/lib/mix/tasks/cinegraph/audit/imdb_list_pagination.ex
@@ -1,0 +1,120 @@
+defmodule Mix.Tasks.Cinegraph.Audit.ImdbListPagination do
+  @moduledoc """
+  Audit IMDb list pagination windows without mutating importer data.
+
+  ## Usage
+
+      mix cinegraph.audit.imdb_list_pagination --list cult_movies_400
+      mix cinegraph.audit.imdb_list_pagination --list-id ls053182933 --starts 1,76,151 --json
+  """
+  use Mix.Task
+
+  alias Cinegraph.Health.ImdbListPaginationAudit
+
+  @shortdoc "Audit rendered IMDb list pagination windows"
+
+  @doc false
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _, invalid} = parse_args(args)
+    raise_invalid_options!(invalid)
+
+    audit_opts = audit_opts(opts)
+    result = ImdbListPaginationAudit.audit(audit_opts)
+
+    if Keyword.get(opts, :json, false) do
+      result |> Jason.encode!(pretty: true) |> IO.puts()
+    else
+      print_table(result)
+    end
+  end
+
+  @doc false
+  def parse_args(args) do
+    OptionParser.parse(args,
+      strict: [
+        list: :string,
+        list_id: :string,
+        "list-id": :string,
+        starts: :string,
+        page_wait: :integer,
+        "page-wait": :integer,
+        ajax_wait: :boolean,
+        "ajax-wait": :boolean,
+        scroll: :boolean,
+        scroll_interval: :integer,
+        "scroll-interval": :integer,
+        json: :boolean
+      ]
+    )
+  end
+
+  @doc false
+  def audit_opts(opts) do
+    opts
+    |> normalize_alias(:"list-id", :list_id)
+    |> normalize_alias(:"page-wait", :page_wait)
+    |> normalize_alias(:"ajax-wait", :ajax_wait)
+    |> normalize_alias(:"scroll-interval", :scroll_interval)
+    |> Keyword.take([:list, :list_id, :starts, :page_wait, :ajax_wait, :scroll, :scroll_interval])
+  end
+
+  defp print_table(%{
+         generated_at: at,
+         list_key: list_key,
+         list_id: list_id,
+         summary: summary,
+         windows: windows
+       }) do
+    Mix.shell().info("IMDb list pagination audit - generated #{at}")
+    Mix.shell().info("list=#{list_key || "-"} list_id=#{list_id}")
+
+    Mix.shell().info(
+      "unique=#{summary.total_unique_ids} safe=#{summary.safe_to_import} gaps=#{summary.has_gaps} duplicates=#{summary.has_duplicates} page_size=#{summary.recommended_page_size || "-"} strategy=#{summary.recommended_url_strategy}"
+    )
+
+    Mix.shell().info("")
+
+    Mix.shell().info(
+      String.pad_leading("start", 7) <>
+        String.pad_leading("count", 7) <>
+        String.pad_leading("first", 8) <>
+        String.pad_leading("last", 8) <>
+        String.pad_leading("gap", 6) <>
+        "  " <>
+        String.pad_trailing("status", 8) <>
+        String.pad_trailing("layout", 14) <>
+        "sample"
+    )
+
+    Mix.shell().info(String.duplicate("-", 100))
+
+    Enum.each(windows, fn window ->
+      sample = Enum.join(window.sample_titles, " | ")
+
+      Mix.shell().info(
+        String.pad_leading(to_string(window.start), 7) <>
+          String.pad_leading(to_string(window.movie_count), 7) <>
+          String.pad_leading(to_string(window.first_rank || "-"), 8) <>
+          String.pad_leading(to_string(window.last_rank || "-"), 8) <>
+          String.pad_leading(to_string(window.rank_gap_from_previous || "-"), 6) <>
+          "  " <>
+          String.pad_trailing(window.fetch_status, 8) <>
+          String.pad_trailing(window.parser_layout, 14) <>
+          sample
+      )
+    end)
+  end
+
+  defp normalize_alias(opts, from, to) do
+    case Keyword.pop(opts, from) do
+      {nil, opts} -> opts
+      {value, opts} -> Keyword.put(opts, to, value)
+    end
+  end
+
+  defp raise_invalid_options!([]), do: :ok
+  defp raise_invalid_options!(invalid), do: Mix.raise("invalid option(s): #{inspect(invalid)}")
+end

--- a/lib/mix/tasks/cinegraph/prod/audit/imdb_list_pagination.ex
+++ b/lib/mix/tasks/cinegraph/prod/audit/imdb_list_pagination.ex
@@ -1,0 +1,52 @@
+defmodule Mix.Tasks.Cinegraph.Prod.Audit.ImdbListPagination do
+  @moduledoc """
+  Run the IMDb list pagination audit against production via `kamal app exec`.
+
+  ## Usage
+
+      mix cinegraph.prod.audit.imdb_list_pagination --list cult_movies_400 --json
+      mix cinegraph.prod.audit.imdb_list_pagination --list-id ls053182933 --starts 1,76,151 --json
+  """
+  use Mix.Task
+
+  alias Cinegraph.ProdRpc
+
+  @shortdoc "Audit production IMDb list pagination windows"
+
+  @doc false
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, invalid} = Mix.Tasks.Cinegraph.Audit.ImdbListPagination.parse_args(args)
+    raise_invalid_options!(invalid)
+
+    case ProdRpc.eval_json(build_expression(opts)) do
+      {:ok, audit} -> ProdRpc.print(audit, opts)
+      {:error, reason} -> ProdRpc.print_error(reason)
+    end
+  end
+
+  @doc false
+  def build_expression(opts) do
+    opts = Mix.Tasks.Cinegraph.Audit.ImdbListPagination.audit_opts(opts)
+
+    ~s|IO.puts(Jason.encode!(Cinegraph.Health.ImdbListPaginationAudit.audit(#{build_opts_kw(opts)})))|
+  end
+
+  defp build_opts_kw(opts) do
+    opts
+    |> Enum.map(fn
+      {:list, value} when is_binary(value) -> "list: #{inspect(value)}"
+      {:list_id, value} when is_binary(value) -> "list_id: #{inspect(value)}"
+      {:starts, value} when is_binary(value) -> "starts: #{inspect(value)}"
+      {:page_wait, value} when is_integer(value) -> "page_wait: #{value}"
+      {:ajax_wait, value} when is_boolean(value) -> "ajax_wait: #{value}"
+      {:scroll, value} when is_boolean(value) -> "scroll: #{value}"
+      {:scroll_interval, value} when is_integer(value) -> "scroll_interval: #{value}"
+    end)
+    |> Enum.join(", ")
+    |> then(&"[#{&1}]")
+  end
+
+  defp raise_invalid_options!([]), do: :ok
+  defp raise_invalid_options!(invalid), do: Mix.raise("invalid option(s): #{inspect(invalid)}")
+end

--- a/test/cinegraph/health/imdb_list_pagination_audit_test.exs
+++ b/test/cinegraph/health/imdb_list_pagination_audit_test.exs
@@ -1,0 +1,263 @@
+defmodule Cinegraph.Health.ImdbListPaginationAuditTest do
+  use Cinegraph.DataCase, async: true
+
+  alias Cinegraph.Health.ImdbListPaginationAudit
+  alias Cinegraph.Movies.MovieList
+  alias Cinegraph.Repo
+
+  describe "URL generation" do
+    test "builds candidate list window URLs" do
+      assert ImdbListPaginationAudit.default_starts() == [1, 76, 151, 226, 301, 376]
+
+      assert ImdbListPaginationAudit.build_window_url("ls053182933", 76) ==
+               "https://www.imdb.com/list/ls053182933/?sort=list_order,asc&start=76&mode=detail"
+    end
+  end
+
+  describe "parser" do
+    test "uses displayed ranks when present" do
+      parsed =
+        ImdbListPaginationAudit.parse_window_html(
+          ipc_html([
+            {76, "tt0073629", "The Rocky Horror Picture Show"},
+            {77, "tt0091042", "Ferris Bueller's Day Off"}
+          ]),
+          76
+        )
+
+      assert parsed.parser_layout == "ipc"
+      assert Enum.map(parsed.movies, & &1.rank) == [76, 77]
+      assert Enum.all?(parsed.movies, &(&1.rank_source == "displayed"))
+    end
+
+    test "falls back to start plus item index when displayed ranks are absent" do
+      parsed =
+        ImdbListPaginationAudit.parse_window_html(
+          fallback_html([
+            {"tt0073629", "The Rocky Horror Picture Show"},
+            {"tt0091042", "Ferris Bueller's Day Off"}
+          ]),
+          76
+        )
+
+      assert Enum.map(parsed.movies, & &1.rank) == [76, 77]
+      assert Enum.all?(parsed.movies, &(&1.rank_source == "fallback"))
+    end
+  end
+
+  describe "audit" do
+    test "reports contiguous non-duplicative windows as safe to import" do
+      result =
+        audit_for_windows(%{
+          1 =>
+            ipc_html([
+              {1, "tt0000001", "One"},
+              {2, "tt0000002", "Two"}
+            ]),
+          3 =>
+            ipc_html([
+              {3, "tt0000003", "Three"},
+              {4, "tt0000004", "Four"}
+            ])
+        })
+
+      assert result.summary.total_unique_ids == 4
+      assert result.summary.has_gaps == false
+      assert result.summary.has_duplicates == false
+      assert result.summary.recommended_page_size == 2
+      assert result.summary.safe_to_import == true
+      refute Map.has_key?(hd(result.windows), :_ids)
+    end
+
+    test "detects rank gaps between windows" do
+      result =
+        audit_for_windows(%{
+          1 =>
+            ipc_html([
+              {1, "tt0000001", "One"},
+              {2, "tt0000002", "Two"}
+            ]),
+          3 =>
+            ipc_html([
+              {500, "tt0000003", "Three"},
+              {501, "tt0000004", "Four"}
+            ])
+        })
+
+      assert result.summary.has_gaps == true
+      assert result.summary.safe_to_import == false
+      assert Enum.at(result.windows, 1).rank_gap_from_previous == 497
+    end
+
+    test "detects duplicate IDs across windows" do
+      result =
+        audit_for_windows(%{
+          1 =>
+            ipc_html([
+              {1, "tt0000001", "One"},
+              {2, "tt0000002", "Two"}
+            ]),
+          3 =>
+            ipc_html([
+              {3, "tt0000002", "Two Again"},
+              {4, "tt0000004", "Four"}
+            ])
+        })
+
+      assert result.summary.has_duplicates == true
+      assert result.summary.safe_to_import == false
+      assert Enum.at(result.windows, 1).duplicate_ids == ["tt0000002"]
+    end
+
+    test "detects duplicate IDs within a single rendered window" do
+      result =
+        audit_for_windows(%{
+          1 =>
+            ipc_html([
+              {1, "tt0000001", "One"},
+              {2, "tt0000001", "One Again"}
+            ])
+        })
+
+      assert result.summary.total_unique_ids == 1
+      assert result.summary.has_duplicates == true
+      assert result.summary.safe_to_import == false
+      assert hd(result.windows).duplicate_ids == ["tt0000001"]
+    end
+
+    test "marks zero-movie windows unsafe" do
+      result =
+        audit_for_windows(%{
+          1 =>
+            ipc_html([
+              {1, "tt0000001", "One"},
+              {2, "tt0000002", "Two"}
+            ]),
+          3 => "<html><body>No list items</body></html>"
+        })
+
+      assert Enum.at(result.windows, 1).movie_count == 0
+      assert result.summary.safe_to_import == false
+    end
+
+    test "resolves --list through movie_lists config" do
+      insert_movie_list!("cult_movies_400", "ls053182933")
+
+      result =
+        ImdbListPaginationAudit.audit(
+          list: "cult_movies_400",
+          starts: [1],
+          fetcher:
+            fetcher_for(%{
+              1 => ipc_html([{1, "tt0000001", "One"}])
+            })
+        )
+
+      assert result.list_key == "cult_movies_400"
+      assert result.list_id == "ls053182933"
+    end
+
+    test "passes Crawlbase JS options through to fetcher and output" do
+      parent = self()
+
+      fetcher = fn _url, :imdb, opts ->
+        send(parent, {:fetch_opts, opts})
+        {:ok, ipc_html([{1, "tt0000001", "One"}]), %{adapter: "test"}}
+      end
+
+      result =
+        ImdbListPaginationAudit.audit(
+          list_id: "ls053182933",
+          starts: [1],
+          page_wait: 7_500,
+          ajax_wait: false,
+          scroll: true,
+          scroll_interval: 800,
+          fetcher: fetcher
+        )
+
+      assert_received {:fetch_opts,
+                       [
+                         mode: :javascript,
+                         page_wait: 7_500,
+                         ajax_wait: false,
+                         scroll: true,
+                         scroll_interval: 800
+                       ]}
+
+      assert hd(result.windows).crawlbase_options == %{
+               page_wait: 7_500,
+               ajax_wait: false,
+               scroll: true,
+               scroll_interval: 800
+             }
+    end
+  end
+
+  defp audit_for_windows(windows_by_start) do
+    starts = windows_by_start |> Map.keys() |> Enum.sort()
+
+    ImdbListPaginationAudit.audit(
+      list_id: "ls053182933",
+      starts: starts,
+      fetcher: fetcher_for(windows_by_start)
+    )
+  end
+
+  defp fetcher_for(windows_by_start) do
+    fn url, :imdb, _opts ->
+      start =
+        url
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+        |> Map.fetch!("start")
+        |> String.to_integer()
+
+      {:ok, Map.fetch!(windows_by_start, start)}
+    end
+  end
+
+  defp ipc_html(items) do
+    body =
+      Enum.map_join(items, "\n", fn {rank, imdb_id, title} ->
+        """
+        <li class="ipc-metadata-list-summary-item">
+          <h3 class="ipc-title__text">#{rank}. #{title}</h3>
+          <a href="/title/#{imdb_id}/">#{title}</a>
+        </li>
+        """
+      end)
+
+    "<html><body><ul>#{body}</ul></body></html>"
+  end
+
+  defp fallback_html(items) do
+    body =
+      Enum.map_join(items, "\n", fn {imdb_id, title} ->
+        """
+        <div class="ipc-metadata-list-summary-item">
+          <a href="/title/#{imdb_id}/">#{title}</a>
+        </div>
+        """
+      end)
+
+    "<html><body>#{body}</body></html>"
+  end
+
+  defp insert_movie_list!(source_key, list_id) do
+    attrs = %{
+      source_key: source_key,
+      name: source_key,
+      source_type: "imdb",
+      source_url: "https://www.imdb.com/list/#{list_id}/",
+      category: "curated",
+      active: true,
+      slug: source_key
+    }
+
+    %MovieList{}
+    |> MovieList.changeset(attrs)
+    |> Repo.insert!()
+  end
+end

--- a/test/cinegraph/movies/canonical_shelf_test.exs
+++ b/test/cinegraph/movies/canonical_shelf_test.exs
@@ -1,0 +1,38 @@
+defmodule Cinegraph.Movies.CanonicalShelfTest do
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Movies
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Repo
+
+  test "list_canonical_shelf_movies/2 orders by canonical list position" do
+    later = insert_movie!("Later", "cult_movies_400", 9)
+    earlier = insert_movie!("Earlier", "cult_movies_400", 1)
+    _other = insert_movie!("Other", "1001_movies", 1)
+
+    assert [earlier.id, later.id] ==
+             "cult_movies_400"
+             |> Movies.list_canonical_shelf_movies(10)
+             |> Enum.map(& &1.id)
+  end
+
+  defp insert_movie!(title, source_key, position) do
+    attrs = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: title,
+      original_title: title,
+      release_date: ~D[1984-01-01],
+      import_status: "full",
+      canonical_sources: %{
+        source_key => %{
+          "included" => true,
+          "list_position" => position
+        }
+      }
+    }
+
+    %Movie{}
+    |> Movie.changeset(attrs)
+    |> Repo.insert!()
+  end
+end

--- a/test/cinegraph/video_clerk_test.exs
+++ b/test/cinegraph/video_clerk_test.exs
@@ -1,0 +1,162 @@
+defmodule Cinegraph.VideoClerkTest do
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Movies.{Credit, Genre, Keyword, Movie, MovieScoreCache, Person}
+  alias Cinegraph.Repo
+  alias Cinegraph.VideoClerk
+  alias Cinegraph.Workers.MovieScoreCacheWorker
+
+  test "recommend/2 returns a primary recommendation with explanations and alternates" do
+    drama = insert_genre!("Drama")
+    offbeat = insert_keyword!("offbeat")
+    clerk = insert_person!("Clerk Director")
+
+    seed =
+      insert_movie!("Seed Oddball", canonical_sources: %{})
+      |> add_genres!([drama])
+      |> add_keywords!([offbeat])
+      |> add_credit!(clerk, %{credit_type: "crew", department: "Directing", job: "Director"})
+
+    primary =
+      insert_movie!("Cult Canon Pick",
+        canonical_sources: %{
+          "cult_movies_400" => %{"included" => true},
+          "1001_movies" => %{"included" => true}
+        }
+      )
+      |> add_genres!([drama])
+      |> add_keywords!([offbeat])
+      |> add_credit!(clerk, %{credit_type: "crew", department: "Directing", job: "Director"})
+      |> add_score_cache!()
+
+    alternate =
+      insert_movie!("Cult Alternate",
+        canonical_sources: %{"cult_movies_400" => %{"included" => true}}
+      )
+      |> add_genres!([drama])
+
+    result = VideoClerk.recommend([seed.id], limit: 3)
+
+    assert result.primary.id == primary.id
+    assert Enum.map(result.alternates, & &1.id) == [alternate.id]
+    assert "Cult afterlife" in result.primary.route_labels
+    assert "Human graph" in result.primary.route_labels
+    assert result.primary.reason =~ "Cult Canon Pick is the clerk's move"
+  end
+
+  test "recommend/2 excludes seed movies and handles empty inputs gracefully" do
+    movie =
+      insert_movie!("Lonely Seed",
+        canonical_sources: %{"cult_movies_400" => %{"included" => true}}
+      )
+
+    assert %{primary: nil, alternates: []} = VideoClerk.recommend([])
+    assert %{primary: nil, alternates: []} = VideoClerk.recommend([movie.id])
+  end
+
+  test "recommend/2 works with up to three seed movies" do
+    comedy = insert_genre!("Comedy")
+
+    seed_a = insert_movie!("Seed A") |> add_genres!([comedy])
+    seed_b = insert_movie!("Seed B") |> add_genres!([comedy])
+    seed_c = insert_movie!("Seed C") |> add_genres!([comedy])
+
+    pick =
+      insert_movie!("Three Seed Pick",
+        canonical_sources: %{"cult_movies_400" => %{"included" => true}}
+      )
+      |> add_genres!([comedy])
+
+    result = VideoClerk.recommend([seed_a.id, seed_b.id, seed_c.id], limit: 1)
+
+    assert result.primary.id == pick.id
+    assert length(result.seed_movies) == 3
+  end
+
+  defp insert_movie!(title, attrs \\ []) do
+    defaults = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: title,
+      original_title: title,
+      release_date: ~D[1984-01-01],
+      import_status: "full",
+      canonical_sources: %{}
+    }
+
+    %Movie{}
+    |> Movie.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!()
+  end
+
+  defp insert_genre!(name) do
+    %Genre{}
+    |> Genre.changeset(%{tmdb_id: System.unique_integer([:positive]), name: name})
+    |> Repo.insert!()
+  end
+
+  defp insert_keyword!(name) do
+    %Keyword{}
+    |> Keyword.changeset(%{tmdb_id: System.unique_integer([:positive]), name: name})
+    |> Repo.insert!()
+  end
+
+  defp insert_person!(name) do
+    %Person{}
+    |> Person.changeset(%{tmdb_id: System.unique_integer([:positive]), name: name})
+    |> Repo.insert!()
+  end
+
+  defp add_genres!(movie, genres) do
+    Repo.insert_all(
+      "movie_genres",
+      Enum.map(genres, &%{movie_id: movie.id, genre_id: &1.id})
+    )
+
+    movie
+  end
+
+  defp add_keywords!(movie, keywords) do
+    Repo.insert_all(
+      "movie_keywords",
+      Enum.map(keywords, &%{movie_id: movie.id, keyword_id: &1.id})
+    )
+
+    movie
+  end
+
+  defp add_credit!(movie, person, attrs) do
+    defaults = %{
+      movie_id: movie.id,
+      person_id: person.id,
+      credit_type: "cast",
+      credit_id: "credit-#{System.unique_integer([:positive])}"
+    }
+
+    %Credit{}
+    |> Credit.changeset(Map.merge(defaults, attrs))
+    |> Repo.insert!()
+
+    movie
+  end
+
+  defp add_score_cache!(movie) do
+    %MovieScoreCache{}
+    |> MovieScoreCache.changeset(%{
+      movie_id: movie.id,
+      mob_score: 4.0,
+      critics_score: 6.0,
+      festival_recognition_score: 2.0,
+      time_machine_score: 8.0,
+      auteurs_score: 7.0,
+      box_office_score: 1.0,
+      overall_score: 7.0,
+      score_confidence: 0.8,
+      unpredictability_score: 6.0,
+      calculated_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      calculation_version: MovieScoreCacheWorker.current_version()
+    })
+    |> Repo.insert!()
+
+    movie
+  end
+end

--- a/test/cinegraph/workers/canonical_import_completion_worker_test.exs
+++ b/test/cinegraph/workers/canonical_import_completion_worker_test.exs
@@ -55,6 +55,27 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorkerTest do
     assert updated.metadata["actual_movie_count"] == 1
   end
 
+  test "finalizing an already terminal import does not increment twice" do
+    list = insert_list!(source_key: "duplicate_finalize", last_import_status: "pending")
+    insert_movie!(canonical_sources: %{list.source_key => %{}})
+
+    job = %Oban.Job{
+      args: %{
+        "list_key" => "duplicate_finalize",
+        "expected_count" => 1,
+        "total_pages" => 0
+      }
+    }
+
+    assert {:ok, first} = CanonicalImportCompletionWorker.perform(job)
+    assert first.last_import_status == "success"
+    assert first.total_imports == 1
+
+    assert {:ok, second} = CanonicalImportCompletionWorker.perform(job)
+    assert second.last_import_status == "success"
+    assert second.total_imports == 1
+  end
+
   defp insert_list!(attrs) do
     source_key = Keyword.fetch!(attrs, :source_key)
 

--- a/test/cinegraph/workers/canonical_list_refresh_sweeper_test.exs
+++ b/test/cinegraph/workers/canonical_list_refresh_sweeper_test.exs
@@ -32,6 +32,30 @@ defmodule Cinegraph.Workers.CanonicalListRefreshSweeperTest do
     assert canonical_job_count() == 2
   end
 
+  test "does not count blank stale lists twice or spend stale pass budget on them" do
+    overlap =
+      insert_list!(
+        source_key: "overlap",
+        last_import_at: days_ago(120),
+        last_import_status: "success"
+      )
+
+    stale =
+      insert_list!(
+        source_key: "stale",
+        last_import_at: days_ago(120),
+        last_import_status: "success"
+      )
+
+    insert_movie!(canonical_sources: %{stale.source_key => %{}})
+
+    assert {:ok, %{found: 2, enqueued: 2, already_queued: 0, lists: lists}} =
+             perform_job(CanonicalListRefreshSweeper, %{})
+
+    assert lists == [overlap.source_key, stale.source_key]
+    assert canonical_job_count() == 2
+  end
+
   defp canonical_job_count do
     Repo.aggregate(
       from(j in Oban.Job, where: j.worker == "Cinegraph.Workers.CanonicalImportOrchestrator"),

--- a/test/cinegraph_web/live/global_search_live_test.exs
+++ b/test/cinegraph_web/live/global_search_live_test.exs
@@ -162,8 +162,24 @@ defmodule CinegraphWeb.GlobalSearchLiveTest do
       html = render(view)
 
       assert html =~ "Unsafe Recent"
-      assert html =~ ~s|href="#"|
+      assert html =~ ~s|href="/movies?search=Unsafe+Recent"|
       refute html =~ "javascript:alert"
+    end
+
+    test "label-only recents link to movie search", %{conn: conn} do
+      {:ok, view, _} = live_isolated(conn, CinegraphWeb.GlobalSearchLive)
+
+      _ =
+        render_hook(view, "update_recents", %{
+          "recents" => [%{"label" => "Stephen King Simmons"}]
+        })
+
+      _ = render_hook(view, "focus", %{})
+      html = render(view)
+
+      assert html =~ "Stephen King Simmons"
+      assert html =~ ~s|href="/movies?search=Stephen+King+Simmons"|
+      assert html =~ ~s|role="option"|
     end
   end
 

--- a/test/cinegraph_web/live/movie_live/show_v2_video_clerk_test.exs
+++ b/test/cinegraph_web/live/movie_live/show_v2_video_clerk_test.exs
@@ -1,0 +1,38 @@
+defmodule CinegraphWeb.MovieLive.ShowV2VideoClerkTest do
+  use CinegraphWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Repo
+
+  test "movie show page renders the Video Clerk module and seed link", %{conn: conn} do
+    seed = insert_movie!("Clerk Source Movie", %{})
+
+    _pick =
+      insert_movie!("Clerk Candidate Movie", %{
+        canonical_sources: %{"cult_movies_400" => %{"included" => true}}
+      })
+
+    {:ok, _view, html} = live(conn, ~p"/movies/#{seed.slug}")
+
+    assert html =~ "Ask the Video Clerk"
+    assert html =~ ~s(/video-clerk?seed=#{seed.slug})
+    assert html =~ "Clerk Candidate Movie"
+  end
+
+  defp insert_movie!(title, attrs) do
+    defaults = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: title,
+      original_title: title,
+      release_date: ~D[1984-01-01],
+      import_status: "full",
+      canonical_sources: %{}
+    }
+
+    %Movie{}
+    |> Movie.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!()
+  end
+end

--- a/test/cinegraph_web/live/video_clerk_live_test.exs
+++ b/test/cinegraph_web/live/video_clerk_live_test.exs
@@ -1,0 +1,81 @@
+defmodule CinegraphWeb.VideoClerkLiveTest do
+  use CinegraphWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Repo
+
+  test "renders the Video Clerk page with manifesto copy", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/video-clerk")
+
+    assert html =~ "The Video Clerk"
+    assert html =~ "Three films in. One human-feeling recommendation out."
+    assert html =~ "Against the bubble"
+    assert html =~ "400 Greatest Cult Movies"
+    assert html =~ "1001 Movies You Must See Before You Die"
+    assert html =~ "Search for a film"
+    assert html =~ "Load demo trio"
+  end
+
+  test "renders linked movie shelves from canonical list data", %{conn: conn} do
+    cult = insert_movie!("Repo Man", "cult_movies_400", 2)
+    canon = insert_movie!("Bicycle Thieves", "1001_movies", 1)
+
+    {:ok, _view, html} = live(conn, ~p"/video-clerk")
+
+    assert html =~ cult.title
+    assert html =~ canon.title
+    assert html =~ ~s(href="/movies/#{cult.slug}")
+    assert html =~ ~s(href="/movies/#{canon.slug}")
+  end
+
+  test "preselects seed movies from URL params and renders a live recommendation", %{conn: conn} do
+    seed = insert_movie!("Donnie Darko", "1001_movies", 1)
+    pick = insert_movie!("Harold and Maude", "cult_movies_400", 2)
+
+    {:ok, _view, html} = live(conn, ~p"/video-clerk?seed=#{seed.slug}")
+
+    assert html =~ seed.title
+    assert html =~ pick.title
+    assert html =~ "is the clerk&#39;s move"
+  end
+
+  test "searches, selects, and resets movies", %{conn: conn} do
+    seed = insert_movie!("Searchable Clerk Seed", "1001_movies", 1)
+    pick = insert_movie!("Searchable Clerk Pick", "cult_movies_400", 2)
+
+    {:ok, view, _html} = live(conn, ~p"/video-clerk")
+
+    html = render_change(view, "search_movies", %{"q" => "Searchable Clerk Seed"})
+    assert html =~ seed.title
+
+    html = render_click(view, "select_movie", %{"slug" => to_string(seed.slug)})
+    assert html =~ pick.title
+
+    html = render_click(view, "reset_clerk")
+    assert html =~ "The clerk is waiting"
+  end
+
+  defp insert_movie!(title, source_key, position) do
+    attrs = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: title,
+      original_title: title,
+      release_date: ~D[1984-01-01],
+      import_status: "full",
+      poster_path: "/poster.jpg",
+      canonical_sources: %{
+        source_key => %{
+          "included" => true,
+          "list_position" => position,
+          "source_name" => source_key
+        }
+      }
+    }
+
+    %Movie{}
+    |> Movie.changeset(attrs)
+    |> Repo.insert!()
+  end
+end

--- a/test/mix/tasks/cinegraph_imdb_list_pagination_audit_test.exs
+++ b/test/mix/tasks/cinegraph_imdb_list_pagination_audit_test.exs
@@ -1,0 +1,88 @@
+defmodule Mix.Tasks.CinegraphImdbListPaginationAuditTest do
+  use Cinegraph.DataCase, async: false
+
+  setup do
+    Mix.Task.reenable("cinegraph.audit.imdb_list_pagination")
+    Mix.Task.reenable("cinegraph.prod.audit.imdb_list_pagination")
+    Mix.Task.reenable("app.start")
+    :ok
+  end
+
+  test "local audit task normalizes option aliases" do
+    opts =
+      Mix.Tasks.Cinegraph.Audit.ImdbListPagination.audit_opts(
+        list: "cult_movies_400",
+        "list-id": "ls053182933",
+        starts: "1,76,151",
+        "page-wait": 7_500,
+        "ajax-wait": false,
+        scroll: true,
+        "scroll-interval": 800,
+        json: true
+      )
+
+    assert Keyword.get(opts, :list) == "cult_movies_400"
+    assert Keyword.get(opts, :list_id) == "ls053182933"
+    assert Keyword.get(opts, :starts) == "1,76,151"
+    assert Keyword.get(opts, :page_wait) == 7_500
+    assert Keyword.get(opts, :ajax_wait) == false
+    assert Keyword.get(opts, :scroll) == true
+    assert Keyword.get(opts, :scroll_interval) == 800
+    refute Keyword.has_key?(opts, :json)
+  end
+
+  test "parse_args accepts documented local flags" do
+    {opts, [], []} =
+      Mix.Tasks.Cinegraph.Audit.ImdbListPagination.parse_args([
+        "--list-id",
+        "ls053182933",
+        "--starts",
+        "1,76",
+        "--page-wait",
+        "7500",
+        "--no-ajax-wait",
+        "--scroll",
+        "--scroll-interval",
+        "800",
+        "--json"
+      ])
+
+    assert Keyword.get(opts, :list_id) == "ls053182933"
+    assert Keyword.get(opts, :starts) == "1,76"
+    assert Keyword.get(opts, :page_wait) == 7_500
+    assert Keyword.get(opts, :ajax_wait) == false
+    assert Keyword.get(opts, :scroll) == true
+    assert Keyword.get(opts, :scroll_interval) == 800
+    assert Keyword.get(opts, :json) == true
+  end
+
+  test "prod audit builds safe ProdRpc expression" do
+    expr =
+      Mix.Tasks.Cinegraph.Prod.Audit.ImdbListPagination.build_expression(
+        list: "cult_movies_400",
+        starts: "1,76,151",
+        "page-wait": 7_500,
+        "ajax-wait": false,
+        scroll: true,
+        "scroll-interval": 800,
+        json: true
+      )
+
+    assert expr =~ "Cinegraph.Health.ImdbListPaginationAudit.audit"
+    assert expr =~ ~s|list: "cult_movies_400"|
+    assert expr =~ ~s|starts: "1,76,151"|
+    assert expr =~ "page_wait: 7500"
+    assert expr =~ "ajax_wait: false"
+    assert expr =~ "scroll: true"
+    assert expr =~ "scroll_interval: 800"
+  end
+
+  test "audit module fails clearly without a list selector" do
+    assert_raise ArgumentError, "provide either --list or --list-id", fn ->
+      Cinegraph.Health.ImdbListPaginationAudit.audit(
+        starts: [1],
+        fetcher: fn _, _, _ -> {:ok, ""} end
+      )
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced "Video Clerk"—an intelligent movie recommendation engine that suggests films based on your selections, with evidence-based explanations of why each recommendation matches.
- Added "Ask the Video Clerk" recommendation panel to movie detail pages.
- Launched dedicated `/video-clerk` page for exploring recommendations with interactive movie selection.
- Added canonical movie shelf display for curated lists.

**Improvements**
- Updated IMDb list pagination from 250-title to 100-title windows for better accuracy.
- Added diagnostic audit tool for IMDb list pagination issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->