### PR TITLE
tiny

### DIFF
--- a/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
+++ b/lib/cinegraph/scrapers/imdb_canonical_scraper.ex
@@ -610,7 +610,7 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
         {:ok, movies}
       else
         Logger.warning("No movies found with primary parsing, trying alternative methods...")
-        alternative_parse(document, list_config)
+        alternative_parse(document, list_config, page)
       end
     rescue
       exception ->
@@ -651,7 +651,9 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
     end
   end
 
-  defp alternative_parse(document, list_config) do
+  defp alternative_parse(document, list_config, page) do
+    base_position = (page - 1) * 100
+
     Logger.info("Trying alternative parsing methods for #{list_config.name}")
 
     # Try alternative selectors for different IMDb list layouts
@@ -675,8 +677,8 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraper do
       |> Enum.flat_map(fn selector ->
         Floki.find(document, selector)
         |> Enum.with_index(1)
-        |> Enum.map(fn {link, position} ->
-          extract_movie_from_title_link(link, position)
+        |> Enum.map(fn {link, index} ->
+          extract_movie_from_title_link(link, base_position + index)
         end)
         |> Enum.reject(&is_nil/1)
       end)

--- a/lib/cinegraph/workers/canonical_import_completion_worker.ex
+++ b/lib/cinegraph/workers/canonical_import_completion_worker.ex
@@ -174,6 +174,9 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
             )
 
             {:ok, current_list}
+
+          {:error, :not_found} ->
+            {:error, :not_found}
         end
     end
   end
@@ -209,7 +212,7 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
   defp update_import_failed(list_key, reason) do
     case MovieLists.get_active_by_source_key(list_key) do
       nil ->
-        :ok
+        {:error, :not_found}
 
       list ->
         now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -225,7 +228,7 @@ defmodule Cinegraph.Workers.CanonicalImportCompletionWorker do
 
   defp skipped_import(%MovieList{} = list) do
     case Repo.get(MovieList, list.id) do
-      nil -> {:skipped, list}
+      nil -> {:error, :not_found}
       current_list -> {:skipped, current_list}
     end
   end

--- a/lib/cinegraph_web/live/video_clerk_live.ex
+++ b/lib/cinegraph_web/live/video_clerk_live.ex
@@ -136,7 +136,11 @@ defmodule CinegraphWeb.VideoClerkLive do
       |> Enum.map(& &1.slug)
       |> Enum.take(3)
 
-    {:noreply, push_patch(socket, to: video_clerk_path(slugs))}
+    {:noreply,
+     socket
+     |> assign(:search_query, "")
+     |> assign(:search_results, [])
+     |> push_patch(to: video_clerk_path(slugs))}
   end
 
   defp load_shelf(source_key) do

--- a/test/cinegraph/scrapers/imdb_canonical_scraper_test.exs
+++ b/test/cinegraph/scrapers/imdb_canonical_scraper_test.exs
@@ -23,4 +23,21 @@ defmodule Cinegraph.Scrapers.ImdbCanonicalScraperTest do
 
     assert Enum.map(movies, & &1.position) == [101, 102]
   end
+
+  test "parse_single_page/3 preserves absolute positions on alternative parser path" do
+    html = """
+    <html>
+      <body>
+        <section>
+          <a href="/title/tt0000003/">Alternative Page Two Movie</a>
+          <a href="/title/tt0000004/">Another Alternative Page Two Movie</a>
+        </section>
+      </body>
+    </html>
+    """
+
+    assert {:ok, movies} = ImdbCanonicalScraper.parse_single_page(html, 2, false)
+
+    assert Enum.map(movies, & &1.position) == [101, 102]
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect movie position calculations when importing multi-page IMDb lists; pagination offsets now applied consistently across primary and fallback parsing methods.
  * Resolved search state persisting when loading demo films; search queries and results now properly cleared.
  * Improved error handling for missing movie lists during import operations.

* **Tests**
  * Added coverage for pagination behavior in alternative parsing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->