### PR TITLE
Add stock image search providers and festival admin UI

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,6 +43,29 @@ config :cinegraph, Cinegraph.Services.TMDb.Client, api_key: tmdb_api_key
 # Configure OMDb (optional)
 config :cinegraph, Cinegraph.Services.OMDb.Client, api_key: omdb_api_key
 
+# Stock image search APIs (#880 Phase 2 — optional "Suggest images" picker
+# for festival admin). Each is read at runtime; provider modules return
+# `:disabled` when their key is unset, which the picker uses to hide that
+# source without crashing.
+unsplash_access_key =
+  if config_env() == :dev,
+    do: env!("UNSPLASH_ACCESS_KEY", :string, ""),
+    else: System.get_env("UNSPLASH_ACCESS_KEY") || ""
+
+pexels_api_key =
+  if config_env() == :dev,
+    do: env!("PEXELS_API_KEY", :string, ""),
+    else: System.get_env("PEXELS_API_KEY") || ""
+
+pixabay_api_key =
+  if config_env() == :dev,
+    do: env!("PIXABAY_API_KEY", :string, ""),
+    else: System.get_env("PIXABAY_API_KEY") || ""
+
+config :cinegraph, Cinegraph.Images.Providers.Unsplash, access_key: unsplash_access_key
+config :cinegraph, Cinegraph.Images.Providers.Pexels, api_key: pexels_api_key
+config :cinegraph, Cinegraph.Images.Providers.Pixabay, api_key: pixabay_api_key
+
 # Daily OMDb batch size for RatingsRefreshWorker.
 # Defaults to 100,000 — the full Basic plan daily limit.
 # Override via OMDB_DAILY_BATCH_SIZE env var only if you need to throttle.

--- a/lib/cinegraph/festivals.ex
+++ b/lib/cinegraph/festivals.ex
@@ -171,6 +171,47 @@ defmodule Cinegraph.Festivals do
   end
 
   @doc """
+  Updates a festival organization.
+
+  Invalidates the home page's `:ceremonies` and `:festival_pulse` Cachex
+  entries when imagery fields (`logo_url` / `hero_image_url`) change so the
+  /admin/festivals editor reflects on `/` without waiting for the daily TTL.
+  """
+  @spec update_organization(FestivalOrganization.t(), map()) ::
+          {:ok, FestivalOrganization.t()} | {:error, Ecto.Changeset.t()}
+  def update_organization(%FestivalOrganization{} = org, attrs) do
+    imagery_changed? =
+      to_string(Map.get(attrs, :logo_url) || Map.get(attrs, "logo_url") || "") !=
+        to_string(org.logo_url || "") or
+        to_string(Map.get(attrs, :hero_image_url) || Map.get(attrs, "hero_image_url") || "") !=
+          to_string(org.hero_image_url || "")
+
+    case org |> FestivalOrganization.changeset(attrs) |> Repo.update() do
+      {:ok, updated} ->
+        if imagery_changed?, do: invalidate_homepage_festival_caches()
+        {:ok, updated}
+
+      err ->
+        err
+    end
+  end
+
+  defp invalidate_homepage_festival_caches do
+    # Cachex keys live as `{Cinegraph.Homepage, name, date}`. We only need
+    # to clear today's entries — future days haven't been computed yet, and
+    # past days don't matter. Best-effort: silent on failure.
+    today = Date.utc_today()
+
+    try do
+      Cachex.del(:movies_cache, {Cinegraph.Homepage, :ceremonies, today})
+      Cachex.del(:movies_cache, {Cinegraph.Homepage, :festival_pulse, today})
+      Cachex.del(:movies_cache, {Cinegraph.Homepage, :spotlight, today})
+    rescue
+      _ -> :ok
+    end
+  end
+
+  @doc """
   Gets a category by name for a specific organization.
   """
   def get_category_by_name(organization_id, name) do

--- a/lib/cinegraph/images/providers/pexels.ex
+++ b/lib/cinegraph/images/providers/pexels.ex
@@ -1,0 +1,70 @@
+defmodule Cinegraph.Images.Providers.Pexels do
+  @moduledoc """
+  Pexels search provider for the festival admin "Suggest images" picker
+  (#880 Phase 2).
+
+  Hits `https://api.pexels.com/v1/search`. Auth via `Authorization` header.
+  Returns the canonical `result()` shape; `:disabled` when `PEXELS_API_KEY`
+  is unset.
+  """
+
+  @endpoint "https://api.pexels.com/v1/search"
+
+  @type result :: Cinegraph.Images.Providers.Unsplash.result()
+
+  @spec search(String.t(), pos_integer()) ::
+          {:ok, [result()]} | {:error, term()} | :disabled
+  def search(query, per_page \\ 6) when is_binary(query) and is_integer(per_page) do
+    case api_key() do
+      nil ->
+        :disabled
+
+      "" ->
+        :disabled
+
+      api_key ->
+        params = URI.encode_query(%{"query" => query, "per_page" => per_page})
+        url = "#{@endpoint}?#{params}"
+        headers = [{"Authorization", api_key}]
+
+        case HTTPoison.get(url, headers, recv_timeout: 5_000, timeout: 5_000) do
+          {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+            with {:ok, json} <- Jason.decode(body),
+                 photos when is_list(photos) <- Map.get(json, "photos", []) do
+              {:ok, Enum.map(photos, &normalize/1)}
+            else
+              _ -> {:error, :decode_failed}
+            end
+
+          {:ok, %HTTPoison.Response{status_code: 429}} ->
+            {:error, :rate_limited}
+
+          {:ok, %HTTPoison.Response{status_code: code}} ->
+            {:error, {:http, code}}
+
+          {:error, %HTTPoison.Error{reason: reason}} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp api_key do
+    Application.get_env(:cinegraph, __MODULE__, [])
+    |> Keyword.get(:api_key)
+  end
+
+  defp normalize(%{} = photo) do
+    src = Map.get(photo, "src", %{})
+
+    %{
+      id: photo |> Map.get("id") |> to_string(),
+      thumb_url: Map.get(src, "tiny") || Map.get(src, "small") || Map.get(src, "medium"),
+      full_url: Map.get(src, "large") || Map.get(src, "large2x") || Map.get(src, "original"),
+      attribution: %{
+        name: Map.get(photo, "photographer") || "Pexels",
+        profile_url: Map.get(photo, "photographer_url")
+      },
+      source: :pexels
+    }
+  end
+end

--- a/lib/cinegraph/images/providers/pixabay.ex
+++ b/lib/cinegraph/images/providers/pixabay.ex
@@ -1,0 +1,78 @@
+defmodule Cinegraph.Images.Providers.Pixabay do
+  @moduledoc """
+  Pixabay search provider for the festival admin "Suggest images" picker
+  (#880 Phase 2).
+
+  Hits `https://pixabay.com/api/`. Auth via `key=` query param. Returns the
+  canonical `result()` shape; `:disabled` when `PIXABAY_API_KEY` is unset.
+  """
+
+  @endpoint "https://pixabay.com/api/"
+
+  @type result :: Cinegraph.Images.Providers.Unsplash.result()
+
+  @spec search(String.t(), pos_integer()) ::
+          {:ok, [result()]} | {:error, term()} | :disabled
+  def search(query, per_page \\ 6) when is_binary(query) and is_integer(per_page) do
+    case api_key() do
+      nil ->
+        :disabled
+
+      "" ->
+        :disabled
+
+      api_key ->
+        # Pixabay's `per_page` minimum is 3.
+        per_page = max(per_page, 3)
+
+        params =
+          URI.encode_query(%{
+            "key" => api_key,
+            "q" => query,
+            "per_page" => per_page,
+            "image_type" => "photo",
+            "safesearch" => "true",
+            "orientation" => "horizontal"
+          })
+
+        url = "#{@endpoint}?#{params}"
+
+        case HTTPoison.get(url, [], recv_timeout: 5_000, timeout: 5_000) do
+          {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+            with {:ok, json} <- Jason.decode(body),
+                 hits when is_list(hits) <- Map.get(json, "hits", []) do
+              {:ok, Enum.map(hits, &normalize/1)}
+            else
+              _ -> {:error, :decode_failed}
+            end
+
+          {:ok, %HTTPoison.Response{status_code: 429}} ->
+            {:error, :rate_limited}
+
+          {:ok, %HTTPoison.Response{status_code: code}} ->
+            {:error, {:http, code}}
+
+          {:error, %HTTPoison.Error{reason: reason}} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp api_key do
+    Application.get_env(:cinegraph, __MODULE__, [])
+    |> Keyword.get(:api_key)
+  end
+
+  defp normalize(%{} = hit) do
+    %{
+      id: hit |> Map.get("id") |> to_string(),
+      thumb_url: Map.get(hit, "previewURL") || Map.get(hit, "webformatURL"),
+      full_url: Map.get(hit, "largeImageURL") || Map.get(hit, "webformatURL"),
+      attribution: %{
+        name: Map.get(hit, "user") || "Pixabay",
+        profile_url: Map.get(hit, "pageURL")
+      },
+      source: :pixabay
+    }
+  end
+end

--- a/lib/cinegraph/images/providers/unsplash.ex
+++ b/lib/cinegraph/images/providers/unsplash.ex
@@ -1,0 +1,85 @@
+defmodule Cinegraph.Images.Providers.Unsplash do
+  @moduledoc """
+  Unsplash search provider for the festival admin "Suggest images" picker
+  (#880 Phase 2).
+
+  Hits `https://api.unsplash.com/search/photos`. Auth via `client_id` query
+  param. Returns the canonical `result()` shape used by all stock providers.
+
+  Returns `:disabled` when `UNSPLASH_ACCESS_KEY` is unset — the picker uses
+  this to hide the Unsplash section without crashing.
+  """
+
+  @endpoint "https://api.unsplash.com/search/photos"
+
+  @type result :: %{
+          id: String.t(),
+          thumb_url: String.t(),
+          full_url: String.t(),
+          attribution: %{name: String.t(), profile_url: String.t() | nil},
+          source: :unsplash
+        }
+
+  @spec search(String.t(), pos_integer()) ::
+          {:ok, [result()]} | {:error, term()} | :disabled
+  def search(query, per_page \\ 6) when is_binary(query) and is_integer(per_page) do
+    case access_key() do
+      nil ->
+        :disabled
+
+      "" ->
+        :disabled
+
+      access_key ->
+        params =
+          URI.encode_query(%{
+            "query" => query,
+            "per_page" => per_page,
+            "orientation" => "landscape",
+            "client_id" => access_key
+          })
+
+        url = "#{@endpoint}?#{params}"
+
+        case HTTPoison.get(url, [], recv_timeout: 5_000, timeout: 5_000) do
+          {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+            with {:ok, json} <- Jason.decode(body),
+                 results when is_list(results) <- Map.get(json, "results", []) do
+              {:ok, Enum.map(results, &normalize/1)}
+            else
+              _ -> {:error, :decode_failed}
+            end
+
+          {:ok, %HTTPoison.Response{status_code: 429}} ->
+            {:error, :rate_limited}
+
+          {:ok, %HTTPoison.Response{status_code: code}} ->
+            {:error, {:http, code}}
+
+          {:error, %HTTPoison.Error{reason: reason}} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp access_key do
+    Application.get_env(:cinegraph, __MODULE__, [])
+    |> Keyword.get(:access_key)
+  end
+
+  defp normalize(%{} = photo) do
+    urls = Map.get(photo, "urls", %{})
+    user = Map.get(photo, "user", %{})
+
+    %{
+      id: Map.get(photo, "id"),
+      thumb_url: Map.get(urls, "thumb") || Map.get(urls, "small"),
+      full_url: Map.get(urls, "regular") || Map.get(urls, "full") || Map.get(urls, "raw"),
+      attribution: %{
+        name: Map.get(user, "name") || Map.get(user, "username") || "Unsplash",
+        profile_url: get_in(user, ["links", "html"])
+      },
+      source: :unsplash
+    }
+  end
+end

--- a/lib/cinegraph/images/stock_image_search.ex
+++ b/lib/cinegraph/images/stock_image_search.ex
@@ -1,0 +1,77 @@
+defmodule Cinegraph.Images.StockImageSearch do
+  @moduledoc """
+  Parallel orchestrator for the festival admin "Suggest images" picker
+  (#880 Phase 2).
+
+  Hits Unsplash, Pexels, and Pixabay concurrently via `Task.async` /
+  `Task.yield`. Returns a map keyed by provider with each value being:
+
+  - `{:ok, [result()]}` — list of normalized results
+  - `:disabled` — provider's env var is unset
+  - `{:error, reason}` — HTTP failure, decode failure, or timeout
+
+  The caller (LiveView modal) decides what to render per provider — usually
+  shows results, hides disabled providers, and shows a retry hint on error.
+
+  ## Caching
+
+  Results are cached for 10 minutes by `(provider, query, per_provider)` in
+  the existing `:movies_cache` Cachex. Rapid-fire retypes from the modal's
+  debounced input don't pound the upstream APIs.
+  """
+
+  alias Cinegraph.Images.Providers
+
+  @providers [:unsplash, :pexels, :pixabay]
+  @timeout_ms 5_000
+  @cache_ttl :timer.minutes(10)
+  @cache_name :movies_cache
+
+  @type provider :: :unsplash | :pexels | :pixabay
+  @type provider_result ::
+          {:ok, [Cinegraph.Images.Providers.Unsplash.result()]}
+          | :disabled
+          | {:error, term()}
+
+  @spec search(String.t(), pos_integer()) :: %{provider() => provider_result()}
+  def search(query, per_provider \\ 6) when is_binary(query) and is_integer(per_provider) do
+    @providers
+    |> Enum.map(fn provider ->
+      task = Task.async(fn -> cached_search(provider, query, per_provider) end)
+      {provider, task}
+    end)
+    |> Enum.map(fn {provider, task} ->
+      result =
+        case Task.yield(task, @timeout_ms) || Task.shutdown(task, :brutal_kill) do
+          {:ok, value} -> value
+          nil -> {:error, :timeout}
+          {:exit, reason} -> {:error, {:exit, reason}}
+        end
+
+      {provider, result}
+    end)
+    |> Map.new()
+  end
+
+  @doc "Returns the list of providers in display order."
+  @spec providers() :: [provider()]
+  def providers, do: @providers
+
+  defp cached_search(provider, query, per_provider) do
+    key = {__MODULE__, provider, query, per_provider}
+
+    case Cachex.fetch(@cache_name, key, fn ->
+           {:commit, run_provider(provider, query, per_provider), ttl: @cache_ttl}
+         end) do
+      {:ok, value} -> value
+      {:commit, value} -> value
+      _ -> run_provider(provider, query, per_provider)
+    end
+  rescue
+    _ -> run_provider(provider, query, per_provider)
+  end
+
+  defp run_provider(:unsplash, query, n), do: Providers.Unsplash.search(query, n)
+  defp run_provider(:pexels, query, n), do: Providers.Pexels.search(query, n)
+  defp run_provider(:pixabay, query, n), do: Providers.Pixabay.search(query, n)
+end

--- a/lib/cinegraph_web/components/admin/dashboard_components.ex
+++ b/lib/cinegraph_web/components/admin/dashboard_components.ex
@@ -324,4 +324,285 @@ defmodule CinegraphWeb.Admin.Components.DashboardComponents do
   defp format_time(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
   defp format_time(%NaiveDateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
   defp format_time(_), do: "Unknown"
+
+  # ============================================================================
+  # Homeostasis-style components (ported from AdminHealthLive.Components)
+  #
+  # These were originally local to /admin/health (#723) but they're reusable
+  # KPI/status primitives for any admin page that needs a status pill, hero
+  # banner, KPI tile with sparkline, line-chart sparkline, or queue-state
+  # table. Phase 1 of #880 promotes them to the shared admin namespace.
+  # ============================================================================
+
+  @doc """
+  Status pill — small badge showing GREEN / AMBER / RED / UNKNOWN.
+
+  ## Examples
+
+      <.verdict_pill status={:green} />
+      <.verdict_pill status={:amber} label="warning" />
+  """
+  attr :status, :atom, default: :unknown, values: [:green, :amber, :red, :unknown]
+  attr :label, :string, default: nil
+  attr :class, :string, default: ""
+
+  def verdict_pill(assigns) do
+    ~H"""
+    <span class={[
+      "inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide",
+      pill_classes(@status),
+      @class
+    ]}>
+      <span class={["w-2 h-2 rounded-full mr-2", dot_classes(@status)]}></span>
+      {@label || pill_label(@status)}
+    </span>
+    """
+  end
+
+  @doc """
+  Hero verdict band — large status indicator at the top of a page.
+
+  ## Slots
+
+    * `:controls` — right-side controls (refresh button, timestamp)
+  """
+  attr :status, :atom, required: true, values: [:green, :amber, :red, :unknown]
+  attr :worst_check, :map, default: nil
+  attr :generated_at, DateTime, default: nil
+  slot :controls
+
+  def hero_band(assigns) do
+    ~H"""
+    <div class={["rounded-lg p-6 mb-6 border", hero_band_classes(@status)]}>
+      <div class="flex items-center justify-between flex-wrap gap-3">
+        <div class="flex items-center gap-4">
+          <.verdict_pill status={@status} class="text-base px-4 py-2" />
+          <div>
+            <h1 class="text-xl font-semibold">{hero_headline(@status)}</h1>
+            <p :if={@worst_check} class="text-sm opacity-80 mt-1">
+              Worst: <span class="font-medium">{format_check_name(@worst_check)}</span>
+              <span :if={@worst_check[:affected_pct]} class="ml-1">
+                ({@worst_check.affected_pct}%)
+              </span>
+            </p>
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <span :if={@generated_at} class="text-xs opacity-70">
+            {format_pill_dt(@generated_at)}
+          </span>
+          {render_slot(@controls)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Activity stat tile — label, count, and a 7-day SVG sparkline.
+
+  ## Examples
+
+      <.stat_tile label="Movies+" count={142} sparkline={[10, 15, 22, 30, 24, 18, 12]} />
+  """
+  attr :label, :string, required: true
+  attr :count, :integer, required: true
+  attr :sparkline, :list, default: []
+  attr :tone, :atom, default: :blue, values: [:blue, :green, :amber, :purple, :zinc]
+
+  def stat_tile(assigns) do
+    ~H"""
+    <div class={["rounded-lg p-4 border", tile_classes(@tone)]}>
+      <div class="text-xs uppercase tracking-wide font-medium opacity-80">{@label}</div>
+      <div class="text-3xl font-bold mt-1">{format_int(@count)}</div>
+      <div class="mt-2 h-6">
+        <.sparkline points={@sparkline} stroke={tile_stroke(@tone)} />
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Inline SVG line-chart sparkline. Takes a list of integers; auto-normalizes.
+
+  Renders a 70x20 viewBox path. Empty / 1-element lists render an empty SVG
+  (no error).
+  """
+  attr :points, :list, default: []
+  attr :stroke, :string, default: "currentColor"
+  attr :width, :integer, default: 70
+  attr :height, :integer, default: 20
+
+  def sparkline(assigns) do
+    polyline =
+      case build_sparkline_points(assigns.points, assigns.width, assigns.height) do
+        nil -> nil
+        coords -> Enum.map_join(coords, " ", fn {x, y} -> "#{x},#{y}" end)
+      end
+
+    assigns = assign(assigns, :polyline, polyline)
+
+    ~H"""
+    <svg
+      viewBox={"0 0 #{@width} #{@height}"}
+      class="w-full h-full"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <polyline
+        :if={@polyline}
+        points={@polyline}
+        fill="none"
+        stroke={@stroke}
+        stroke-width="1.5"
+        stroke-linejoin="round"
+        stroke-linecap="round"
+      />
+    </svg>
+    """
+  end
+
+  @doc """
+  Queue state table — renders a `Cinegraph.Health.Queues.snapshot/0` shape.
+  """
+  attr :snapshot, :any, required: true
+
+  def queue_strip(assigns) do
+    ~H"""
+    <div class="rounded-lg border border-zinc-200 bg-white p-4">
+      <%= case @snapshot do %>
+        <% {:error, msg} -> %>
+          <p class="text-sm text-zinc-700">Queue snapshot unavailable: {msg}</p>
+        <% %{queues: queues, total_failures_last_hour: total_fail} -> %>
+          <div class="flex items-center justify-between mb-2">
+            <h3 class="text-sm uppercase tracking-wide font-semibold text-zinc-500">
+              <a
+                href="/admin/oban"
+                class="hover:text-zinc-900 hover:underline inline-flex items-center gap-1"
+              >
+                Queues <span aria-hidden="true">→</span>
+              </a>
+            </h3>
+            <span :if={total_fail > 0} class="text-xs font-mono text-red-700">
+              {total_fail} failures last hour
+            </span>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full text-sm">
+              <thead class="text-xs uppercase text-zinc-500">
+                <tr>
+                  <th class="text-left py-1 pr-3 font-medium">queue</th>
+                  <th class="text-right py-1 px-2 font-medium">avail</th>
+                  <th class="text-right py-1 px-2 font-medium">exec</th>
+                  <th class="text-right py-1 px-2 font-medium">retry</th>
+                  <th class="text-right py-1 px-2 font-medium">disc</th>
+                  <th class="text-right py-1 px-2 font-medium">fail/hr</th>
+                  <th class="text-right py-1 px-2 font-medium">longest(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr :for={q <- queues} class="border-t border-zinc-100">
+                  <td class="py-1 pr-3 font-mono text-zinc-800">{q.name}</td>
+                  <td class="py-1 px-2 text-right font-mono">{q.available}</td>
+                  <td class="py-1 px-2 text-right font-mono">{q.executing}</td>
+                  <td class="py-1 px-2 text-right font-mono">{q.retryable}</td>
+                  <td class="py-1 px-2 text-right font-mono">{q.discarded}</td>
+                  <td class={[
+                    "py-1 px-2 text-right font-mono",
+                    q.failures_last_hour > 0 && "text-red-700 font-semibold"
+                  ]}>
+                    {q.failures_last_hour}
+                  </td>
+                  <td class="py-1 px-2 text-right font-mono">{q.longest_running_seconds}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        <% _ -> %>
+          <p class="text-sm text-zinc-500">No queue data.</p>
+      <% end %>
+    </div>
+    """
+  end
+
+  # ===== Public helpers (used by AdminHealthLive's local components too) =====
+
+  @doc "Formats an integer with thousands separators."
+  def format_int(n) when is_integer(n) do
+    n
+    |> Integer.to_string()
+    |> String.graphemes()
+    |> Enum.reverse()
+    |> Enum.chunk_every(3)
+    |> Enum.intersperse(",")
+    |> List.flatten()
+    |> Enum.reverse()
+    |> Enum.join()
+  end
+
+  def format_int(other), do: to_string(other)
+
+  # ===== Private helpers =====
+
+  defp pill_classes(:green), do: "bg-green-100 text-green-800"
+  defp pill_classes(:amber), do: "bg-amber-100 text-amber-800"
+  defp pill_classes(:red), do: "bg-red-100 text-red-800"
+  defp pill_classes(_), do: "bg-zinc-100 text-zinc-700"
+
+  defp dot_classes(:green), do: "bg-green-500"
+  defp dot_classes(:amber), do: "bg-amber-500"
+  defp dot_classes(:red), do: "bg-red-500"
+  defp dot_classes(_), do: "bg-zinc-400"
+
+  defp pill_label(:green), do: "Healthy"
+  defp pill_label(:amber), do: "Warning"
+  defp pill_label(:red), do: "Critical"
+  defp pill_label(_), do: "Unknown"
+
+  defp hero_band_classes(:green), do: "bg-green-50 border-green-200 text-green-900"
+  defp hero_band_classes(:amber), do: "bg-amber-50 border-amber-200 text-amber-900"
+  defp hero_band_classes(:red), do: "bg-red-50 border-red-200 text-red-900"
+  defp hero_band_classes(_), do: "bg-zinc-50 border-zinc-200 text-zinc-900"
+
+  defp hero_headline(:green), do: "All systems in sync"
+  defp hero_headline(:amber), do: "Some drift detected"
+  defp hero_headline(:red), do: "Critical drift — investigate"
+  defp hero_headline(_), do: "Status unknown"
+
+  defp tile_classes(:blue), do: "bg-blue-50 text-blue-900 border-blue-200"
+  defp tile_classes(:green), do: "bg-green-50 text-green-900 border-green-200"
+  defp tile_classes(:amber), do: "bg-amber-50 text-amber-900 border-amber-200"
+  defp tile_classes(:purple), do: "bg-purple-50 text-purple-900 border-purple-200"
+  defp tile_classes(:zinc), do: "bg-zinc-50 text-zinc-900 border-zinc-200"
+
+  defp tile_stroke(:blue), do: "rgb(37 99 235)"
+  defp tile_stroke(:green), do: "rgb(22 163 74)"
+  defp tile_stroke(:amber), do: "rgb(217 119 6)"
+  defp tile_stroke(:purple), do: "rgb(147 51 234)"
+  defp tile_stroke(:zinc), do: "rgb(82 82 91)"
+
+  defp format_check_name(%{domain: d, check: c}),
+    do: "#{d}/#{c}" |> String.replace("_", " ")
+
+  defp format_check_name(_), do: ""
+
+  defp format_pill_dt(nil), do: ""
+  defp format_pill_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%H:%M:%S UTC")
+
+  defp build_sparkline_points(points, _w, _h) when length(points) < 2, do: nil
+
+  defp build_sparkline_points(points, width, height) do
+    {min, max} = Enum.min_max(points)
+    range = if max == min, do: 1, else: max - min
+    n = length(points)
+    step = if n > 1, do: width / (n - 1), else: 0
+
+    points
+    |> Enum.with_index()
+    |> Enum.map(fn {v, i} ->
+      x = i * step
+      y = height - (v - min) / range * height
+      {Float.round(x, 1), Float.round(y, 1)}
+    end)
+  end
 end

--- a/lib/cinegraph_web/components/admin/health_components.ex
+++ b/lib/cinegraph_web/components/admin/health_components.ex
@@ -129,60 +129,11 @@ defmodule CinegraphWeb.Admin.Components.HealthComponents do
     """
   end
 
-  # ============================================================================
-  # Sparkline
-  # ============================================================================
-
-  @doc """
-  Renders a 7-day mini bar chart.
-
-  ## Examples
-
-      <.sparkline data={[10, 15, 12, 18, 22, 20, 25]} />
-      <.sparkline data={@weekly_counts} highlight_last={false} color={:green} />
-  """
-  attr :data, :list, default: []
-  attr :highlight_last, :boolean, default: true
-  attr :color, :atom, default: :blue
-  attr :height, :integer, default: 16
-
-  def sparkline(assigns) do
-    heights = sparkline_heights(assigns.data)
-
-    bar_color =
-      case assigns.color do
-        :blue -> "bg-blue-500"
-        :green -> "bg-green-500"
-        :gray -> "bg-gray-400"
-        _ -> "bg-blue-500"
-      end
-
-    inactive_color = "bg-gray-300"
-
-    assigns =
-      assigns
-      |> assign(:heights, heights)
-      |> assign(:bar_color, bar_color)
-      |> assign(:inactive_color, inactive_color)
-
-    ~H"""
-    <div
-      class="flex items-end gap-0.5"
-      style={"height: #{@height}px"}
-      title={"Last #{length(@data)} days: #{Enum.join(@data, ", ")}"}
-    >
-      <%= for {height, idx} <- Enum.with_index(@heights) do %>
-        <% is_last = idx == length(@heights) - 1 %>
-        <% color = if @highlight_last && is_last, do: @bar_color, else: @inactive_color %>
-        <div
-          class={"w-1 rounded-t #{color}"}
-          style={"height: #{max(height * (@height / 100), 1)}px"}
-        >
-        </div>
-      <% end %>
-    </div>
-    """
-  end
+  # NOTE: The bar-chart `sparkline/1` originally ported from eventasaurus
+  # was removed in #880 Phase 1 to avoid name collision with the line-chart
+  # `sparkline/1` promoted from AdminHealthLive into DashboardComponents.
+  # Use `CinegraphWeb.Admin.Components.DashboardComponents.sparkline/1` —
+  # `<.sparkline points={...} stroke="..." />`.
 
   # ============================================================================
   # Trend Indicator

--- a/lib/cinegraph_web/components/layouts/admin.html.heex
+++ b/lib/cinegraph_web/components/layouts/admin.html.heex
@@ -67,6 +67,12 @@
             assigns={assigns}
           />
           <.sidebar_item
+            path="/admin/festivals"
+            label="Festivals"
+            icon={:film}
+            assigns={assigns}
+          />
+          <.sidebar_item
             path="/admin/festival-events"
             label="Festival events"
             icon={:beaker}
@@ -75,7 +81,7 @@
           <.sidebar_item
             path="/admin/festival"
             label="Festival audit"
-            icon={:film}
+            icon={:duplicate}
             assigns={assigns}
           />
           <.sidebar_item
@@ -244,6 +250,7 @@
             <.mobile_sidebar_item path="/admin/imports" label="Imports" />
             <.mobile_sidebar_item path="/admin/year-imports" label="Year imports" />
             <.mobile_sidebar_item path="/admin/award-imports" label="Award imports" />
+            <.mobile_sidebar_item path="/admin/festivals" label="Festivals" />
             <.mobile_sidebar_item path="/admin/festival-events" label="Festival events" />
             <.mobile_sidebar_item path="/admin/festival" label="Festival audit" />
             <.mobile_sidebar_item path="/admin/lists-manager" label="Lists" />

--- a/lib/cinegraph_web/live/admin/festivals_live/index.ex
+++ b/lib/cinegraph_web/live/admin/festivals_live/index.ex
@@ -1,0 +1,628 @@
+defmodule CinegraphWeb.Admin.FestivalsLive.Index do
+  @moduledoc """
+  Festival admin index — replaces the bare `/admin/festival-events` modal
+  with a real editor for `festival_organizations`.
+
+  Phase 2 of #880. Lets a human:
+
+  - See every festival org at a glance, with logo / hero image-coverage badges
+  - Click into a drawer to edit identity + imagery
+  - Paste a URL for `logo_url` / `hero_image_url`, OR open the "Suggest images"
+    modal to search Unsplash / Pexels / Pixabay and click-to-save a CDN URL
+  - Link out to `/admin/festival/:slug` for ceremony audit and to
+    `/admin/festival-events` for import-config edits (until those fold in
+    in a follow-up phase)
+  """
+  use CinegraphWeb, :admin_live_view
+
+  alias Cinegraph.Festivals
+  alias Cinegraph.Festivals.FestivalOrganization
+  alias Cinegraph.Images.StockImageSearch
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Festivals")
+     |> assign(:editing_org, nil)
+     |> assign(:form, nil)
+     |> assign(:suggest_for, nil)
+     |> assign(:suggest_query, "")
+     |> assign(:suggest_results, %{})
+     |> assign_orgs()}
+  end
+
+  defp assign_orgs(socket) do
+    orgs = Festivals.list_organizations()
+
+    stats = %{
+      total: length(orgs),
+      with_logo: Enum.count(orgs, &has_url?(&1.logo_url)),
+      with_hero: Enum.count(orgs, &has_url?(&1.hero_image_url))
+    }
+
+    socket
+    |> assign(:orgs, orgs)
+    |> assign(:stats, stats)
+  end
+
+  defp has_url?(nil), do: false
+  defp has_url?(""), do: false
+  defp has_url?(_), do: true
+
+  @impl true
+  def handle_event("edit_org", %{"id" => id}, socket) do
+    case Enum.find(socket.assigns.orgs, &(to_string(&1.id) == id)) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Festival not found.")}
+
+      org ->
+        {:noreply, open_drawer(socket, org)}
+    end
+  end
+
+  def handle_event("close_drawer", _params, socket) do
+    {:noreply, close_drawer(socket)}
+  end
+
+  def handle_event("validate", %{"organization" => attrs}, socket) do
+    case socket.assigns.editing_org do
+      nil ->
+        {:noreply, socket}
+
+      org ->
+        changeset =
+          org
+          |> FestivalOrganization.changeset(attrs)
+          |> Map.put(:action, :validate)
+
+        {:noreply, assign(socket, :form, to_form(changeset, as: "organization"))}
+    end
+  end
+
+  def handle_event("save", %{"organization" => attrs}, socket) do
+    org = socket.assigns.editing_org
+
+    case Festivals.update_organization(org, attrs) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> assign_orgs()
+         |> close_drawer()
+         |> put_flash(:info, "Saved #{updated.name}.")}
+
+      {:error, changeset} ->
+        {:noreply,
+         socket
+         |> assign(:form, to_form(changeset, as: "organization"))
+         |> put_flash(:error, "Could not save festival — see field errors.")}
+    end
+  end
+
+  def handle_event("open_suggest", %{"field" => field}, socket)
+      when field in ["logo_url", "hero_image_url"] do
+    field_atom = String.to_existing_atom(field)
+    query = socket.assigns.editing_org.name
+    results = StockImageSearch.search(query, 6)
+
+    {:noreply,
+     socket
+     |> assign(:suggest_for, field_atom)
+     |> assign(:suggest_query, query)
+     |> assign(:suggest_results, results)}
+  end
+
+  def handle_event("close_suggest", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:suggest_for, nil)
+     |> assign(:suggest_query, "")
+     |> assign(:suggest_results, %{})}
+  end
+
+  def handle_event("suggest_search", %{"q" => q}, socket) do
+    query = String.trim(q)
+
+    results =
+      if query == "" do
+        %{}
+      else
+        StockImageSearch.search(query, 6)
+      end
+
+    {:noreply,
+     socket
+     |> assign(:suggest_query, query)
+     |> assign(:suggest_results, results)}
+  end
+
+  def handle_event("use_image", %{"url" => url}, socket) do
+    field = socket.assigns.suggest_for
+
+    case {field, socket.assigns.editing_org} do
+      {nil, _} ->
+        {:noreply, socket}
+
+      {_, nil} ->
+        {:noreply, socket}
+
+      {field, org} ->
+        # Patch the in-memory form changeset so the drawer's text input updates
+        existing_params =
+          case socket.assigns.form do
+            %Phoenix.HTML.Form{params: p} when is_map(p) -> p
+            _ -> %{}
+          end
+
+        new_params = Map.put(existing_params, to_string(field), url)
+
+        changeset =
+          org
+          |> FestivalOrganization.changeset(new_params)
+          |> Map.put(:action, :validate)
+
+        {:noreply,
+         socket
+         |> assign(:form, to_form(changeset, as: "organization"))
+         |> assign(:suggest_for, nil)
+         |> assign(:suggest_results, %{})}
+    end
+  end
+
+  defp open_drawer(socket, org) do
+    changeset = FestivalOrganization.changeset(org, %{})
+
+    socket
+    |> assign(:editing_org, org)
+    |> assign(:form, to_form(changeset, as: "organization"))
+  end
+
+  defp close_drawer(socket) do
+    socket
+    |> assign(:editing_org, nil)
+    |> assign(:form, nil)
+    |> assign(:suggest_for, nil)
+    |> assign(:suggest_query, "")
+    |> assign(:suggest_results, %{})
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.page_header
+      title="Festivals"
+      subtitle={
+        "#{@stats.total} organizations · #{@stats.with_logo} with logo · #{@stats.with_hero} with hero image"
+      }
+    >
+      <:actions>
+        <.link
+          navigate="/admin/festival"
+          class="text-sm font-medium text-blue-700 hover:text-blue-900"
+        >
+          Ceremony audit →
+        </.link>
+      </:actions>
+    </.page_header>
+
+    <.section_card>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Logo</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                Festival
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Country</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Tier</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Hero</th>
+              <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-200">
+            <%= for org <- @orgs do %>
+              <tr class="hover:bg-gray-50">
+                <td class="px-4 py-2">
+                  <%= if has_url?(org.logo_url) do %>
+                    <img
+                      src={org.logo_url}
+                      alt={"#{org.name} logo"}
+                      class="h-10 w-10 object-contain bg-gray-50 rounded"
+                    />
+                  <% else %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                      no logo
+                    </span>
+                  <% end %>
+                </td>
+                <td class="px-4 py-2 text-sm">
+                  <div class="font-medium text-gray-900">{org.name}</div>
+                  <div class="text-xs text-gray-500 font-mono">{org.slug}</div>
+                </td>
+                <td class="px-4 py-2 text-sm text-gray-700">{org.country || "—"}</td>
+                <td class="px-4 py-2 text-sm text-gray-700">{tier_label(org.prestige_tier)}</td>
+                <td class="px-4 py-2 text-sm">
+                  <%= if has_url?(org.hero_image_url) do %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                      ✓
+                    </span>
+                  <% else %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                      no hero
+                    </span>
+                  <% end %>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <button
+                    type="button"
+                    phx-click="edit_org"
+                    phx-value-id={org.id}
+                    class="inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700"
+                  >
+                    Edit
+                  </button>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </.section_card>
+
+    <%= if @editing_org do %>
+      <.drawer
+        org={@editing_org}
+        form={@form}
+        suggest_for={@suggest_for}
+        suggest_query={@suggest_query}
+        suggest_results={@suggest_results}
+      />
+    <% end %>
+    """
+  end
+
+  attr :org, :map, required: true
+  attr :form, :any, required: true
+  attr :suggest_for, :any, required: true
+  attr :suggest_query, :string, required: true
+  attr :suggest_results, :map, required: true
+
+  defp drawer(assigns) do
+    ~H"""
+    <div class="fixed inset-0 z-40 flex" role="dialog" aria-modal="true">
+      <div class="fixed inset-0 bg-zinc-900/40" phx-click="close_drawer" aria-label="Close drawer">
+      </div>
+      <aside class="ml-auto h-full w-full max-w-2xl bg-white shadow-xl flex flex-col z-50 relative">
+        <header class="px-6 py-4 border-b border-zinc-200 flex items-center justify-between">
+          <div>
+            <p class="text-xs uppercase tracking-wide text-zinc-500 font-semibold">Festival</p>
+            <h2 class="text-lg font-semibold text-zinc-900">{@org.name}</h2>
+            <p class="text-xs text-zinc-500 font-mono">{@org.slug}</p>
+          </div>
+          <button
+            type="button"
+            phx-click="close_drawer"
+            class="text-zinc-500 hover:text-zinc-900 text-2xl leading-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div class="flex-1 overflow-y-auto px-6 py-4">
+          <.form
+            for={@form}
+            id={"org-form-#{@org.id}"}
+            phx-change="validate"
+            phx-submit="save"
+            class="space-y-6"
+          >
+            <%!-- Identity --%>
+            <section>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-zinc-500 mb-3">
+                Identity
+              </h3>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 mb-1">Name</label>
+                  <input
+                    type="text"
+                    name={@form[:name].name}
+                    value={Phoenix.HTML.Form.input_value(@form, :name)}
+                    class="w-full rounded-md border-gray-300 text-sm"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 mb-1">Country</label>
+                  <input
+                    type="text"
+                    name={@form[:country].name}
+                    value={Phoenix.HTML.Form.input_value(@form, :country)}
+                    class="w-full rounded-md border-gray-300 text-sm"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 mb-1">Abbreviation</label>
+                  <input
+                    type="text"
+                    name={@form[:abbreviation].name}
+                    value={Phoenix.HTML.Form.input_value(@form, :abbreviation)}
+                    class="w-full rounded-md border-gray-300 text-sm"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 mb-1">Founded year</label>
+                  <input
+                    type="number"
+                    name={@form[:founded_year].name}
+                    value={Phoenix.HTML.Form.input_value(@form, :founded_year)}
+                    class="w-full rounded-md border-gray-300 text-sm"
+                  />
+                </div>
+                <div class="sm:col-span-2">
+                  <label class="block text-xs font-medium text-gray-700 mb-1">Website</label>
+                  <input
+                    type="url"
+                    name={@form[:website].name}
+                    value={Phoenix.HTML.Form.input_value(@form, :website)}
+                    class="w-full rounded-md border-gray-300 text-sm font-mono"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs font-medium text-gray-700 mb-1">Prestige tier</label>
+                  <input
+                    type="number"
+                    name={@form[:prestige_tier].name}
+                    value={Phoenix.HTML.Form.input_value(@form, :prestige_tier)}
+                    min="0"
+                    max="5"
+                    class="w-full rounded-md border-gray-300 text-sm"
+                  />
+                </div>
+              </div>
+            </section>
+
+            <%!-- Imagery --%>
+            <section>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-zinc-500 mb-3">
+                Imagery
+              </h3>
+
+              <div class="space-y-4">
+                <.image_field
+                  form={@form}
+                  field={:logo_url}
+                  label="Logo URL"
+                  preview_class="h-16 w-16 object-contain bg-gray-50 rounded border"
+                />
+                <.image_field
+                  form={@form}
+                  field={:hero_image_url}
+                  label="Hero image URL"
+                  preview_class="h-32 w-full object-cover rounded border"
+                />
+              </div>
+            </section>
+
+            <%!-- Stats / external links --%>
+            <section>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-zinc-500 mb-3">
+                Health & related
+              </h3>
+              <div class="text-sm text-gray-700 space-y-2">
+                <p>Detailed import config + ceremony audit live in their own pages:</p>
+                <div class="flex flex-wrap gap-2">
+                  <.link
+                    navigate={"/admin/festival/#{@org.slug}"}
+                    class="inline-flex items-center rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
+                  >
+                    Ceremony audit →
+                  </.link>
+                  <.link
+                    navigate="/admin/festival-events"
+                    class="inline-flex items-center rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
+                  >
+                    Import config →
+                  </.link>
+                </div>
+              </div>
+            </section>
+
+            <div class="pt-4 border-t border-gray-200 flex justify-end gap-2">
+              <button
+                type="button"
+                phx-click="close_drawer"
+                class="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                class="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+              >
+                Save
+              </button>
+            </div>
+          </.form>
+        </div>
+      </aside>
+
+      <%= if @suggest_for do %>
+        <.suggest_modal
+          field={@suggest_for}
+          query={@suggest_query}
+          results={@suggest_results}
+        />
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :form, :any, required: true
+  attr :field, :atom, required: true
+  attr :label, :string, required: true
+  attr :preview_class, :string, default: "h-16 w-16 object-contain bg-gray-50 rounded border"
+
+  defp image_field(assigns) do
+    value = Phoenix.HTML.Form.input_value(assigns.form, assigns.field) || ""
+
+    assigns = assign(assigns, :value, value)
+
+    ~H"""
+    <div>
+      <label class="block text-xs font-medium text-gray-700 mb-1">{@label}</label>
+      <div class="flex gap-3 items-start">
+        <%= if has_url?(@value) do %>
+          <img src={@value} alt="" class={@preview_class} />
+        <% else %>
+          <div class={[@preview_class, "grid place-items-center text-xs text-gray-400 bg-gray-50"]}>
+            no image
+          </div>
+        <% end %>
+        <div class="flex-1 space-y-2">
+          <input
+            type="url"
+            name={@form[@field].name}
+            value={@value}
+            placeholder="https://..."
+            class="w-full rounded-md border-gray-300 text-sm font-mono"
+          />
+          <div class="flex flex-wrap gap-2">
+            <button
+              type="button"
+              phx-click="open_suggest"
+              phx-value-field={Atom.to_string(@field)}
+              class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-xs text-gray-700 hover:bg-gray-50"
+            >
+              ✨ Suggest images
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :field, :atom, required: true
+  attr :query, :string, required: true
+  attr :results, :map, required: true
+
+  defp suggest_modal(assigns) do
+    ~H"""
+    <div
+      class="fixed inset-0 z-50 flex items-start justify-center pt-12"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        class="fixed inset-0 bg-zinc-900/50"
+        phx-click="close_suggest"
+        aria-label="Close suggest modal"
+      >
+      </div>
+      <div class="relative bg-white rounded-lg shadow-2xl w-full max-w-4xl max-h-[80vh] flex flex-col z-10 mx-4">
+        <header class="px-5 py-3 border-b border-zinc-200 flex items-center justify-between">
+          <div>
+            <h3 class="text-base font-semibold text-zinc-900">Suggest images</h3>
+            <p class="text-xs text-zinc-500">
+              Click a result to use it for {field_label(@field)}.
+            </p>
+          </div>
+          <button
+            type="button"
+            phx-click="close_suggest"
+            class="text-zinc-500 hover:text-zinc-900 text-2xl leading-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <form phx-change="suggest_search" class="px-5 py-3 border-b border-zinc-100">
+          <input
+            type="text"
+            name="q"
+            value={@query}
+            placeholder="Search Unsplash, Pexels, Pixabay..."
+            phx-debounce="400"
+            class="w-full rounded-md border-gray-300 text-sm"
+            autofocus
+          />
+        </form>
+
+        <div class="flex-1 overflow-y-auto px-5 py-3 space-y-6">
+          <%= for provider <- [:unsplash, :pexels, :pixabay] do %>
+            <% result = Map.get(@results, provider) %>
+            <section>
+              <h4 class="text-xs font-semibold uppercase tracking-wide text-zinc-500 mb-2">
+                {provider_label(provider)}
+              </h4>
+              <%= case result do %>
+                <% nil -> %>
+                  <p class="text-xs text-gray-500">Search to see results.</p>
+                <% :disabled -> %>
+                  <p class="text-xs text-amber-700">
+                    {provider_label(provider)} is disabled — set
+                    <code class="font-mono">{env_var(provider)}</code>
+                    in .env to enable.
+                  </p>
+                <% {:error, reason} -> %>
+                  <p class="text-xs text-red-700">
+                    Error: {format_error(reason)}.
+                  </p>
+                <% {:ok, []} -> %>
+                  <p class="text-xs text-gray-500">No results.</p>
+                <% {:ok, items} -> %>
+                  <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                    <%= for item <- items do %>
+                      <button
+                        type="button"
+                        phx-click="use_image"
+                        phx-value-url={item.full_url}
+                        class="group block rounded-md border border-gray-200 hover:ring-2 hover:ring-blue-500 hover:border-blue-500 overflow-hidden text-left transition"
+                      >
+                        <img
+                          src={item.thumb_url}
+                          alt=""
+                          class="w-full h-24 object-cover bg-gray-100"
+                        />
+                        <div class="px-2 py-1 text-[10px] text-gray-500 truncate">
+                          by {item.attribution.name}
+                        </div>
+                      </button>
+                    <% end %>
+                  </div>
+              <% end %>
+            </section>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp tier_label(nil), do: "—"
+  defp tier_label(0), do: "tier 0"
+  defp tier_label(n) when is_integer(n), do: "tier #{n}"
+  defp tier_label(_), do: "—"
+
+  defp field_label(:logo_url), do: "logo"
+  defp field_label(:hero_image_url), do: "hero image"
+  defp field_label(_), do: "image"
+
+  defp provider_label(:unsplash), do: "Unsplash"
+  defp provider_label(:pexels), do: "Pexels"
+  defp provider_label(:pixabay), do: "Pixabay"
+  defp provider_label(other), do: to_string(other)
+
+  defp env_var(:unsplash), do: "UNSPLASH_ACCESS_KEY"
+  defp env_var(:pexels), do: "PEXELS_API_KEY"
+  defp env_var(:pixabay), do: "PIXABAY_API_KEY"
+  defp env_var(_), do: ""
+
+  defp format_error(:rate_limited), do: "rate limited"
+  defp format_error(:timeout), do: "timeout"
+  defp format_error({:http, code}), do: "HTTP #{code}"
+  defp format_error(other), do: inspect(other) |> String.slice(0, 80)
+end

--- a/lib/cinegraph_web/live/admin/jobs_live.ex
+++ b/lib/cinegraph_web/live/admin/jobs_live.ex
@@ -180,13 +180,13 @@ defmodule CinegraphWeb.Admin.JobsLive do
                 </td>
                 <td class="px-4 py-2 text-xs font-mono text-gray-700">{row.entry.queue}</td>
                 <td class="px-4 py-2 text-sm text-right text-gray-900">
-                  {format_int(row.totals.completed)}
+                  {format_count(row.totals.completed)}
                 </td>
                 <td class={"px-4 py-2 text-sm text-right #{count_color(row.totals.discarded)}"}>
-                  {format_int(row.totals.discarded)}
+                  {format_count(row.totals.discarded)}
                 </td>
                 <td class={"px-4 py-2 text-sm text-right #{count_color(row.totals.retryable)}"}>
-                  {format_int(row.totals.retryable)}
+                  {format_count(row.totals.retryable)}
                 </td>
                 <td class="px-4 py-2 text-sm text-right text-gray-700 font-mono">
                   {format_duration(row.avg_duration_seconds)}
@@ -217,7 +217,7 @@ defmodule CinegraphWeb.Admin.JobsLive do
   end
 
   defp kpi_value(:error), do: "—"
-  defp kpi_value(n) when is_integer(n), do: format_int(n)
+  defp kpi_value(n) when is_integer(n), do: format_count(n)
   defp kpi_value(_), do: "—"
 
   defp success_rate(:error, _), do: "—"
@@ -266,9 +266,9 @@ defmodule CinegraphWeb.Admin.JobsLive do
   defp count_color(n) when is_integer(n) and n > 0, do: "text-red-700 font-medium"
   defp count_color(_), do: "text-gray-700"
 
-  defp format_int(nil), do: "0"
+  defp format_count(nil), do: "0"
 
-  defp format_int(n) when is_integer(n) do
+  defp format_count(n) when is_integer(n) do
     n
     |> Integer.to_string()
     |> String.graphemes()
@@ -279,7 +279,7 @@ defmodule CinegraphWeb.Admin.JobsLive do
     |> String.reverse()
   end
 
-  defp format_int(_), do: "—"
+  defp format_count(_), do: "—"
 
   defp format_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
   defp format_dt(_), do: "—"

--- a/lib/cinegraph_web/live/admin/queues_live.ex
+++ b/lib/cinegraph_web/live/admin/queues_live.ex
@@ -233,14 +233,14 @@ defmodule CinegraphWeb.Admin.QueuesLive do
                 {format_pct(coverage.coverage_percent)}
               </dd>
               <dd class="text-xs text-gray-500">
-                {format_int(coverage.people_with_pqs)} / {format_int(coverage.eligible_people)}
+                {format_count(coverage.people_with_pqs)} / {format_count(coverage.eligible_people)}
               </dd>
             </div>
             <div>
               <dt class="text-xs text-gray-500">Freshness</dt>
               <dd class="font-mono text-gray-900">{format_pct(freshness.fresh_percent)}</dd>
               <dd class="text-xs text-gray-500">
-                avg age {format_int(freshness.average_age_days)}d
+                avg age {format_count(freshness.average_age_days)}d
               </dd>
             </div>
           </dl>
@@ -337,10 +337,10 @@ defmodule CinegraphWeb.Admin.QueuesLive do
   defp format_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%H:%M:%S")
   defp format_dt(_), do: "—"
 
-  defp format_int(nil), do: "0"
-  defp format_int(n) when is_integer(n), do: Integer.to_string(n)
-  defp format_int(n) when is_float(n), do: Integer.to_string(round(n))
-  defp format_int(_), do: "—"
+  defp format_count(nil), do: "0"
+  defp format_count(n) when is_integer(n), do: Integer.to_string(n)
+  defp format_count(n) when is_float(n), do: Integer.to_string(round(n))
+  defp format_count(_), do: "—"
 
   defp format_pct(nil), do: "—"
   defp format_pct(p) when is_number(p), do: "#{:erlang.float_to_binary(p * 1.0, decimals: 1)}%"

--- a/lib/cinegraph_web/live/admin_dashboard_live.ex
+++ b/lib/cinegraph_web/live/admin_dashboard_live.ex
@@ -375,9 +375,14 @@ defmodule CinegraphWeb.AdminDashboardLive do
             description: "Festival/awards import orchestration."
           },
           %{
+            title: "Festivals",
+            path: "/admin/festivals",
+            description: "Edit festival organizations: identity, imagery, links to audit."
+          },
+          %{
             title: "Festival events",
             path: "/admin/festival-events",
-            description: "Festival event import-config CRUD."
+            description: "Legacy import-config modal (folds into Festivals editor in Phase 3)."
           },
           %{
             title: "Festival audit",

--- a/lib/cinegraph_web/live/admin_health_live/components.ex
+++ b/lib/cinegraph_web/live/admin_health_live/components.ex
@@ -1,144 +1,26 @@
 defmodule CinegraphWeb.AdminHealthLive.Components do
   @moduledoc """
-  Function components for the `/admin/health` dashboard (#723).
+  Function components specific to the `/admin/health` dashboard (#723).
+
+  Five generic admin primitives — `verdict_pill`, `hero_band`, `stat_tile`,
+  `sparkline`, `queue_strip` — moved to
+  `CinegraphWeb.Admin.Components.DashboardComponents` in #880 Phase 1.
+  This module imports them and adds the homeostasis-specific ones:
+  `drift_card`, `drift_drawer`, and the 30-day completeness `trend_chart`.
 
   All data flows through `Cinegraph.Health.*` — components take already-shaped
   maps and render. No DB calls here.
   """
   use Phoenix.Component
 
-  @doc """
-  Status pill — small badge showing GREEN / AMBER / RED / UNKNOWN.
-
-  ## Examples
-
-      <.verdict_pill status={:green} />
-      <.verdict_pill status={:amber} label="warning" />
-  """
-  attr :status, :atom, default: :unknown, values: [:green, :amber, :red, :unknown]
-  attr :label, :string, default: nil
-  attr :class, :string, default: ""
-
-  def verdict_pill(assigns) do
-    ~H"""
-    <span class={[
-      "inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide",
-      pill_classes(@status),
-      @class
-    ]}>
-      <span class={["w-2 h-2 rounded-full mr-2", dot_classes(@status)]}></span>
-      {@label || pill_label(@status)}
-    </span>
-    """
-  end
-
-  @doc """
-  Hero verdict band — large status indicator at the top of the page.
-
-  ## Slots
-
-    * Inner block renders the right-side controls (refresh button, timestamp)
-  """
-  attr :status, :atom, required: true, values: [:green, :amber, :red, :unknown]
-  attr :worst_check, :map, default: nil
-  attr :generated_at, DateTime, default: nil
-  slot :controls
-
-  def hero_band(assigns) do
-    ~H"""
-    <div class={["rounded-lg p-6 mb-6 border", hero_band_classes(@status)]}>
-      <div class="flex items-center justify-between flex-wrap gap-3">
-        <div class="flex items-center gap-4">
-          <.verdict_pill status={@status} class="text-base px-4 py-2" />
-          <div>
-            <h1 class="text-xl font-semibold">{hero_headline(@status)}</h1>
-            <p :if={@worst_check} class="text-sm opacity-80 mt-1">
-              Worst: <span class="font-medium">{format_check_name(@worst_check)}</span>
-              <span :if={@worst_check[:affected_pct]} class="ml-1">
-                ({@worst_check.affected_pct}%)
-              </span>
-            </p>
-          </div>
-        </div>
-        <div class="flex items-center gap-3">
-          <span :if={@generated_at} class="text-xs opacity-70">
-            {format_dt(@generated_at)}
-          </span>
-          {render_slot(@controls)}
-        </div>
-      </div>
-    </div>
-    """
-  end
-
-  @doc """
-  Activity stat tile — label, count, and a 7-day SVG sparkline.
-
-  ## Examples
-
-      <.stat_tile label="Movies+" count={142} sparkline={[10, 15, 22, 30, 24, 18, 12]} />
-  """
-  attr :label, :string, required: true
-  attr :count, :integer, required: true
-  attr :sparkline, :list, default: []
-  attr :tone, :atom, default: :blue, values: [:blue, :green, :amber, :purple, :zinc]
-
-  def stat_tile(assigns) do
-    ~H"""
-    <div class={["rounded-lg p-4 border", tile_classes(@tone)]}>
-      <div class="text-xs uppercase tracking-wide font-medium opacity-80">{@label}</div>
-      <div class="text-3xl font-bold mt-1">{format_int(@count)}</div>
-      <div class="mt-2 h-6">
-        <.sparkline points={@sparkline} stroke={tile_stroke(@tone)} />
-      </div>
-    </div>
-    """
-  end
-
-  @doc """
-  Inline SVG sparkline. Takes a list of integers; auto-normalizes.
-
-  Renders a 70x20 viewBox path. Empty / 1-element lists render an empty SVG
-  (no error).
-  """
-  attr :points, :list, default: []
-  attr :stroke, :string, default: "currentColor"
-  attr :width, :integer, default: 70
-  attr :height, :integer, default: 20
-
-  def sparkline(assigns) do
-    polyline =
-      case build_sparkline_points(assigns.points, assigns.width, assigns.height) do
-        nil -> nil
-        coords -> Enum.map_join(coords, " ", fn {x, y} -> "#{x},#{y}" end)
-      end
-
-    assigns = assign(assigns, :polyline, polyline)
-
-    ~H"""
-    <svg
-      viewBox={"0 0 #{@width} #{@height}"}
-      class="w-full h-full"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <polyline
-        :if={@polyline}
-        points={@polyline}
-        fill="none"
-        stroke={@stroke}
-        stroke-width="1.5"
-        stroke-linejoin="round"
-        stroke-linecap="round"
-      />
-    </svg>
-    """
-  end
+  import CinegraphWeb.Admin.Components.DashboardComponents,
+    only: [verdict_pill: 1, format_int: 1]
 
   @doc """
   Drift card — title, headline metric, top-N signals, "View details" link.
 
-  Used for each domain on the main page (People, Movies, Festivals, Ratings).
+  Used for each domain on the main page (People, Movies, Festivals, Ratings,
+  Availability, Collaborations).
   """
   attr :domain, :atom, required: true
   attr :title, :string, required: true
@@ -274,70 +156,6 @@ defmodule CinegraphWeb.AdminHealthLive.Components do
   def refresh_action_label(_), do: ""
 
   @doc """
-  Per-queue Oban state strip. Takes the snapshot map from
-  `Cinegraph.Health.Queues.snapshot/0`.
-  """
-  attr :snapshot, :any, required: true
-
-  def queue_strip(assigns) do
-    ~H"""
-    <div class="rounded-lg border border-zinc-200 bg-white p-4">
-      <%= case @snapshot do %>
-        <% {:error, msg} -> %>
-          <p class="text-sm text-zinc-700">Queue snapshot unavailable: {msg}</p>
-        <% %{queues: queues, total_failures_last_hour: total_fail} -> %>
-          <div class="flex items-center justify-between mb-2">
-            <h3 class="text-sm uppercase tracking-wide font-semibold text-zinc-500">
-              <a
-                href="/admin/oban"
-                class="hover:text-zinc-900 hover:underline inline-flex items-center gap-1"
-              >
-                Queues <span aria-hidden="true">→</span>
-              </a>
-            </h3>
-            <span :if={total_fail > 0} class="text-xs font-mono text-red-700">
-              {total_fail} failures last hour
-            </span>
-          </div>
-          <div class="overflow-x-auto">
-            <table class="min-w-full text-sm">
-              <thead class="text-xs uppercase text-zinc-500">
-                <tr>
-                  <th class="text-left py-1 pr-3 font-medium">queue</th>
-                  <th class="text-right py-1 px-2 font-medium">avail</th>
-                  <th class="text-right py-1 px-2 font-medium">exec</th>
-                  <th class="text-right py-1 px-2 font-medium">retry</th>
-                  <th class="text-right py-1 px-2 font-medium">disc</th>
-                  <th class="text-right py-1 px-2 font-medium">fail/hr</th>
-                  <th class="text-right py-1 px-2 font-medium">longest(s)</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr :for={q <- queues} class="border-t border-zinc-100">
-                  <td class="py-1 pr-3 font-mono text-zinc-800">{q.name}</td>
-                  <td class="py-1 px-2 text-right font-mono">{q.available}</td>
-                  <td class="py-1 px-2 text-right font-mono">{q.executing}</td>
-                  <td class="py-1 px-2 text-right font-mono">{q.retryable}</td>
-                  <td class="py-1 px-2 text-right font-mono">{q.discarded}</td>
-                  <td class={[
-                    "py-1 px-2 text-right font-mono",
-                    q.failures_last_hour > 0 && "text-red-700 font-semibold"
-                  ]}>
-                    {q.failures_last_hour}
-                  </td>
-                  <td class="py-1 px-2 text-right font-mono">{q.longest_running_seconds}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        <% _ -> %>
-          <p class="text-sm text-zinc-500">No queue data.</p>
-      <% end %>
-    </div>
-    """
-  end
-
-  @doc """
   30-day completeness trend chart. Renders an SVG line from a list of
   `%{captured_on, payload}` rows. Falls back to a friendly message when
   history is too sparse to plot.
@@ -395,7 +213,11 @@ defmodule CinegraphWeb.AdminHealthLive.Components do
           </p>
         <% true -> %>
           <% {min_pct, max_pct} = pct_range(@series) %>
-          <svg viewBox={"0 0 #{@width} #{@height}"} class="w-full h-32" preserveAspectRatio="none">
+          <svg
+            viewBox={"0 0 #{@width} #{@height}"}
+            class="w-full h-32"
+            preserveAspectRatio="none"
+          >
             <polyline points={@polyline} fill="none" stroke="rgb(37 99 235)" stroke-width="2" />
           </svg>
           <div class="flex justify-between text-xs text-zinc-500 mt-1 font-mono">
@@ -415,6 +237,21 @@ defmodule CinegraphWeb.AdminHealthLive.Components do
   def status_classes(:amber), do: "bg-amber-50 text-amber-800 border-amber-200"
   def status_classes(:red), do: "bg-red-50 text-red-800 border-red-200"
   def status_classes(_), do: "bg-zinc-50 text-zinc-700 border-zinc-200"
+
+  # ===== private =====
+
+  defp card_border(:green), do: "border-green-200"
+  defp card_border(:amber), do: "border-amber-300"
+  defp card_border(:red), do: "border-red-300"
+  defp card_border(_), do: "border-zinc-200"
+
+  defp dot_classes(:green), do: "bg-green-500"
+  defp dot_classes(:amber), do: "bg-amber-500"
+  defp dot_classes(:red), do: "bg-red-500"
+  defp dot_classes(_), do: "bg-zinc-400"
+
+  defp ngettext_check(1), do: "check"
+  defp ngettext_check(_), do: "checks"
 
   defp format_example(%{} = ex) do
     id = Map.get(ex, :id) || Map.get(ex, "id")
@@ -465,93 +302,4 @@ defmodule CinegraphWeb.AdminHealthLive.Components do
   defp format_date(%Date{} = d), do: Date.to_iso8601(d)
   defp format_date(d) when is_binary(d), do: d
   defp format_date(_), do: ""
-
-  # ===== private =====
-
-  defp pill_classes(:green), do: "bg-green-100 text-green-800"
-  defp pill_classes(:amber), do: "bg-amber-100 text-amber-800"
-  defp pill_classes(:red), do: "bg-red-100 text-red-800"
-  defp pill_classes(_), do: "bg-zinc-100 text-zinc-700"
-
-  defp dot_classes(:green), do: "bg-green-500"
-  defp dot_classes(:amber), do: "bg-amber-500"
-  defp dot_classes(:red), do: "bg-red-500"
-  defp dot_classes(_), do: "bg-zinc-400"
-
-  defp pill_label(:green), do: "Healthy"
-  defp pill_label(:amber), do: "Warning"
-  defp pill_label(:red), do: "Critical"
-  defp pill_label(_), do: "Unknown"
-
-  defp hero_band_classes(:green), do: "bg-green-50 border-green-200 text-green-900"
-  defp hero_band_classes(:amber), do: "bg-amber-50 border-amber-200 text-amber-900"
-  defp hero_band_classes(:red), do: "bg-red-50 border-red-200 text-red-900"
-  defp hero_band_classes(_), do: "bg-zinc-50 border-zinc-200 text-zinc-900"
-
-  defp hero_headline(:green), do: "All systems in sync"
-  defp hero_headline(:amber), do: "Some drift detected"
-  defp hero_headline(:red), do: "Critical drift — investigate"
-  defp hero_headline(_), do: "Status unknown"
-
-  defp tile_classes(:blue), do: "bg-blue-50 text-blue-900 border-blue-200"
-  defp tile_classes(:green), do: "bg-green-50 text-green-900 border-green-200"
-  defp tile_classes(:amber), do: "bg-amber-50 text-amber-900 border-amber-200"
-  defp tile_classes(:purple), do: "bg-purple-50 text-purple-900 border-purple-200"
-  defp tile_classes(:zinc), do: "bg-zinc-50 text-zinc-900 border-zinc-200"
-
-  defp tile_stroke(:blue), do: "rgb(37 99 235)"
-  defp tile_stroke(:green), do: "rgb(22 163 74)"
-  defp tile_stroke(:amber), do: "rgb(217 119 6)"
-  defp tile_stroke(:purple), do: "rgb(147 51 234)"
-  defp tile_stroke(:zinc), do: "rgb(82 82 91)"
-
-  defp card_border(:green), do: "border-green-200"
-  defp card_border(:amber), do: "border-amber-300"
-  defp card_border(:red), do: "border-red-300"
-  defp card_border(_), do: "border-zinc-200"
-
-  defp ngettext_check(1), do: "check"
-  defp ngettext_check(_), do: "checks"
-
-  defp format_check_name(%{domain: d, check: c}),
-    do: "#{d}/#{c}" |> String.replace("_", " ")
-
-  defp format_check_name(_), do: ""
-
-  defp format_dt(nil), do: ""
-  defp format_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%H:%M:%S UTC")
-
-  defp format_int(n) when is_integer(n) do
-    n
-    |> Integer.to_string()
-    |> String.graphemes()
-    |> Enum.reverse()
-    |> Enum.chunk_every(3)
-    |> Enum.intersperse(",")
-    |> List.flatten()
-    |> Enum.reverse()
-    |> Enum.join()
-  end
-
-  defp format_int(other), do: to_string(other)
-
-  # Build SVG polyline coordinates for the given values.
-  # Returns nil for ≤1 points (nothing to draw).
-  defp build_sparkline_points(points, _w, _h) when length(points) < 2, do: nil
-
-  defp build_sparkline_points(points, width, height) do
-    {min, max} = Enum.min_max(points)
-    range = if max == min, do: 1, else: max - min
-    n = length(points)
-    step = if n > 1, do: width / (n - 1), else: 0
-
-    points
-    |> Enum.with_index()
-    |> Enum.map(fn {v, i} ->
-      x = i * step
-      # SVG y grows downward — invert
-      y = height - (v - min) / range * height
-      {Float.round(x, 1), Float.round(y, 1)}
-    end)
-  end
 end

--- a/lib/cinegraph_web/live/admin_health_live/show.ex
+++ b/lib/cinegraph_web/live/admin_health_live/show.ex
@@ -5,7 +5,7 @@ defmodule CinegraphWeb.AdminHealthLive.Show do
   Reads exclusively from `Cinegraph.Health.*` so CLI (`mix cinegraph.health`)
   and UI never disagree.
   """
-  use CinegraphWeb, :live_view
+  use CinegraphWeb, :admin_live_view
 
   import CinegraphWeb.AdminHealthLive.Components
 
@@ -316,20 +316,6 @@ defmodule CinegraphWeb.AdminHealthLive.Show do
   end
 
   defp headline_for(_, _), do: ""
-
-  defp format_int(n) when is_integer(n) do
-    n
-    |> Integer.to_string()
-    |> String.graphemes()
-    |> Enum.reverse()
-    |> Enum.chunk_every(3)
-    |> Enum.intersperse(",")
-    |> List.flatten()
-    |> Enum.reverse()
-    |> Enum.join()
-  end
-
-  defp format_int(other), do: to_string(other)
 
   defp collect_errors(values) do
     values

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -265,7 +265,11 @@ defmodule CinegraphWeb.Router do
       # Movie Predictions for 1001 Movies list
       live "/predictions", PredictionsLive.Index, :index
 
-      # Festival Events management
+      # Festivals admin (#880 Phase 2) — primary editor for festival_organizations
+      live "/festivals", Admin.FestivalsLive.Index, :index
+
+      # Festival Events management (legacy import-config modal — kept while
+      # /admin/festivals expands to fold this in; tracked in #880 Phase 3)
       live "/festival-events", FestivalEventLive.Index, :index
 
       # Lists Manager (Issue #487)

--- a/priv/repo/seeds/festival_organization_images.exs
+++ b/priv/repo/seeds/festival_organization_images.exs
@@ -1,0 +1,185 @@
+#!/usr/bin/env mix
+# One-shot seed (#880 Phase 2 PR-A) — populate `logo_url` and `hero_image_url`
+# on existing festival_organizations rows so the home page "Pick a festival"
+# shelf stops rendering blank cards.
+#
+# Idempotent: only writes a field if the current value is `nil` or `""`. Re-run
+# is a no-op for already-populated orgs.
+#
+# Source URLs are Wikimedia Commons / Wikipedia stable redirects. Any URL that
+# 404s or feels off can be replaced via the upcoming /admin/festivals editor
+# (#880 Phase 2 PR-C).
+#
+#   mix run priv/repo/seeds/festival_organization_images.exs
+
+require Logger
+
+alias Cinegraph.Festivals
+
+# Match on canonical name substrings — slugs in this DB are out of sync with
+# names for a few rows (e.g., the "cannes" slug actually points at "Berlin
+# International Film Festival"), so name matching is more reliable.
+seeds = [
+  %{
+    match: "Academy of Motion Picture",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Oscars_logo.svg/512px-Oscars_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Dolby_Theatre_at_Night.jpg/1280px-Dolby_Theatre_at_Night.jpg"
+  },
+  %{
+    match: "BAFTA",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/en/thumb/4/45/BAFTA_logo.svg/512px-BAFTA_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Royal_Albert_Hall_-_Central_View_-_London_-_2012.jpg/1280px-Royal_Albert_Hall_-_Central_View_-_London_-_2012.jpg"
+  },
+  %{
+    match: "Berlin International",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a8/Berlinale_Bears_Logo.svg/512px-Berlinale_Bears_Logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Berlinale_Palast_2013.jpg/1280px-Berlinale_Palast_2013.jpg"
+  },
+  %{
+    match: "Cannes",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/en/thumb/0/0a/Cannes_film_festival_logo.svg/512px-Cannes_film_festival_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Palais_des_Festivals_in_Cannes.jpg/1280px-Palais_des_Festivals_in_Cannes.jpg"
+  },
+  %{
+    match: "Critics Choice",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/en/thumb/9/95/Critics%27_Choice_Movie_Awards_logo.png/512px-Critics%27_Choice_Movie_Awards_logo.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Barker_Hangar.jpg/1280px-Barker_Hangar.jpg"
+  },
+  %{
+    match: "Golden Globe",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Golden_Globe_Award_Trophy.png/256px-Golden_Globe_Award_Trophy.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/The_Beverly_Hilton_Hotel.jpg/1280px-The_Beverly_Hilton_Hotel.jpg"
+  },
+  %{
+    match: "Locarno",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Locarno_Festival_Logo.svg/512px-Locarno_Festival_Logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/Locarno_Piazza_Grande.jpg/1280px-Locarno_Piazza_Grande.jpg"
+  },
+  %{
+    match: "New Horizons",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/T-Mobile_Nowe_Horyzonty_logo.svg/512px-T-Mobile_Nowe_Horyzonty_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Wroc%C5%82aw_Rynek_Panorama.jpg/1280px-Wroc%C5%82aw_Rynek_Panorama.jpg"
+  },
+  %{
+    match: "New York Film",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/New_York_Film_Festival_Logo.png/512px-New_York_Film_Festival_Logo.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Lincoln_Center_Twilight.jpg/1280px-Lincoln_Center_Twilight.jpg"
+  },
+  %{
+    match: "Screen Actors Guild",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Screen_Actors_Guild_Awards_logo.svg/512px-Screen_Actors_Guild_Awards_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/35/Shrine_Auditorium.jpg/1280px-Shrine_Auditorium.jpg"
+  },
+  %{
+    match: "Sundance Film",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Sundance_Film_Festival_logo.svg/512px-Sundance_Film_Festival_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Park_City_Main_Street_Sundance.jpg/1280px-Park_City_Main_Street_Sundance.jpg"
+  },
+  %{
+    match: "SXSW",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/South_by_Southwest_logo.svg/512px-South_by_Southwest_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Austin_skyline_2014.jpg/1280px-Austin_skyline_2014.jpg"
+  },
+  %{
+    match: "Telluride",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Telluride_Film_Festival_Logo.png/512px-Telluride_Film_Festival_Logo.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/Telluride%2C_Colorado.jpg/1280px-Telluride%2C_Colorado.jpg"
+  },
+  %{
+    match: "Toronto International",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Toronto_International_Film_Festival_logo.svg/512px-Toronto_International_Film_Festival_logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/TIFF_Bell_Lightbox_Building.jpg/1280px-TIFF_Bell_Lightbox_Building.jpg"
+  },
+  %{
+    match: "Venice",
+    logo_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/d/df/Venice_Film_Festival_Logo.svg/512px-Venice_Film_Festival_Logo.svg.png",
+    hero_image_url:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Lido_di_Venezia.jpg/1280px-Lido_di_Venezia.jpg"
+  }
+]
+
+orgs = Festivals.list_organizations()
+
+# Helper: only put a field into attrs when the org's current value is empty.
+maybe_put = fn attrs, key, new_value, current_value ->
+  if is_nil(current_value) or current_value == "" do
+    Map.put(attrs, key, new_value)
+  else
+    attrs
+  end
+end
+
+results =
+  Enum.map(seeds, fn %{match: needle} = seed ->
+    case Enum.find(orgs, &String.contains?(&1.name, needle)) do
+      nil ->
+        Logger.warning("Seed: no org matched '#{needle}'")
+        {:miss, needle}
+
+      org ->
+        attrs =
+          %{}
+          |> maybe_put.(:logo_url, seed.logo_url, org.logo_url)
+          |> maybe_put.(:hero_image_url, seed.hero_image_url, org.hero_image_url)
+
+        cond do
+          map_size(attrs) == 0 ->
+            Logger.info("Seed: '#{org.name}' already has imagery, skipping")
+            {:skip, org.name}
+
+          true ->
+            case Festivals.update_organization(org, attrs) do
+              {:ok, _} ->
+                Logger.info(
+                  "Seed: '#{org.name}' updated (#{Map.keys(attrs) |> Enum.join(", ")})"
+                )
+
+                {:ok, org.name}
+
+              {:error, changeset} ->
+                Logger.error("Seed: '#{org.name}' failed — #{inspect(changeset.errors)}")
+                {:error, org.name}
+            end
+        end
+    end
+  end)
+
+ok = Enum.count(results, &match?({:ok, _}, &1))
+skip = Enum.count(results, &match?({:skip, _}, &1))
+miss = Enum.count(results, &match?({:miss, _}, &1))
+err = Enum.count(results, &match?({:error, _}, &1))
+
+IO.puts(
+  "\nSeed complete: #{ok} updated, #{skip} skipped (already populated), #{miss} unmatched, #{err} errors\n"
+)
+
+if err > 0, do: System.halt(1)

--- a/test/cinegraph/images/stock_image_search_test.exs
+++ b/test/cinegraph/images/stock_image_search_test.exs
@@ -1,0 +1,67 @@
+defmodule Cinegraph.Images.StockImageSearchTest do
+  use ExUnit.Case, async: false
+
+  alias Cinegraph.Images.StockImageSearch
+
+  alias Cinegraph.Images.Providers.{Unsplash, Pexels, Pixabay}
+
+  setup do
+    # Snapshot config; restore after each test so we don't leak state.
+    saved = %{
+      unsplash: Application.get_env(:cinegraph, Unsplash),
+      pexels: Application.get_env(:cinegraph, Pexels),
+      pixabay: Application.get_env(:cinegraph, Pixabay)
+    }
+
+    on_exit(fn ->
+      Application.put_env(:cinegraph, Unsplash, saved.unsplash || [])
+      Application.put_env(:cinegraph, Pexels, saved.pexels || [])
+      Application.put_env(:cinegraph, Pixabay, saved.pixabay || [])
+    end)
+
+    :ok
+  end
+
+  describe "search/2 with no keys configured" do
+    setup do
+      Application.put_env(:cinegraph, Unsplash, access_key: "")
+      Application.put_env(:cinegraph, Pexels, api_key: "")
+      Application.put_env(:cinegraph, Pixabay, api_key: "")
+      :ok
+    end
+
+    test "returns :disabled for every provider" do
+      result = StockImageSearch.search("cannes")
+
+      assert %{unsplash: :disabled, pexels: :disabled, pixabay: :disabled} = result
+    end
+  end
+
+  describe "providers/0" do
+    test "lists the three providers in display order" do
+      assert StockImageSearch.providers() == [:unsplash, :pexels, :pixabay]
+    end
+  end
+
+  describe "provider :disabled handling" do
+    test "Unsplash returns :disabled when access_key is nil" do
+      Application.put_env(:cinegraph, Unsplash, access_key: nil)
+      assert Unsplash.search("cannes") == :disabled
+    end
+
+    test "Unsplash returns :disabled when access_key is empty string" do
+      Application.put_env(:cinegraph, Unsplash, access_key: "")
+      assert Unsplash.search("cannes") == :disabled
+    end
+
+    test "Pexels returns :disabled when api_key is empty" do
+      Application.put_env(:cinegraph, Pexels, api_key: "")
+      assert Pexels.search("cannes") == :disabled
+    end
+
+    test "Pixabay returns :disabled when api_key is empty" do
+      Application.put_env(:cinegraph, Pixabay, api_key: "")
+      assert Pixabay.search("cannes") == :disabled
+    end
+  end
+end

--- a/test/cinegraph_web/live/admin/festivals_live/index_test.exs
+++ b/test/cinegraph_web/live/admin/festivals_live/index_test.exs
@@ -1,0 +1,90 @@
+defmodule CinegraphWeb.Admin.FestivalsLive.IndexTest do
+  use CinegraphWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Cinegraph.Festivals
+  alias Cinegraph.Festivals.FestivalOrganization
+  alias Cinegraph.Repo
+
+  setup do
+    # Insert a clean test festival org so we don't depend on the full seeded
+    # set in dev DB. ConnCase wraps in a sandbox transaction by default.
+    {:ok, org} =
+      %FestivalOrganization{}
+      |> FestivalOrganization.changeset(%{
+        name: "Test Festival #{System.unique_integer([:positive])}",
+        country: "Testland",
+        prestige_tier: 3
+      })
+      |> Repo.insert()
+
+    %{org: org}
+  end
+
+  describe "GET /admin/festivals" do
+    test "renders the table with the test org", %{conn: conn, org: org} do
+      {:ok, _live, html} = live(conn, ~p"/admin/festivals")
+
+      assert html =~ "Festivals"
+      assert html =~ org.name
+      assert html =~ "no logo"
+      assert html =~ "no hero"
+    end
+
+    test "edit_org event opens the drawer", %{conn: conn, org: org} do
+      {:ok, live, _html} = live(conn, ~p"/admin/festivals")
+
+      result = render_click(live, "edit_org", %{"id" => to_string(org.id)})
+
+      assert result =~ "Identity"
+      assert result =~ "Imagery"
+      assert result =~ org.name
+    end
+
+    test "saving with a paste-URL persists logo_url", %{conn: conn, org: org} do
+      {:ok, live, _html} = live(conn, ~p"/admin/festivals")
+
+      _ = render_click(live, "edit_org", %{"id" => to_string(org.id)})
+
+      url = "https://example.test/logo.png"
+
+      _ =
+        render_submit(live, "save", %{
+          "organization" => %{
+            "name" => org.name,
+            "logo_url" => url,
+            "hero_image_url" => "",
+            "country" => org.country
+          }
+        })
+
+      reloaded =
+        Festivals.get_organization_by_slug(org.slug) || Repo.get!(FestivalOrganization, org.id)
+
+      assert reloaded.logo_url == url
+    end
+
+    test "close_drawer clears the editing state", %{conn: conn, org: org} do
+      {:ok, live, _html} = live(conn, ~p"/admin/festivals")
+
+      _ = render_click(live, "edit_org", %{"id" => to_string(org.id)})
+
+      after_close = render_click(live, "close_drawer", %{})
+
+      # Admin layout's mobile menu also uses role="dialog"; use the festival
+      # drawer's unique close-button aria-label.
+      refute after_close =~ ~s(aria-label="Close drawer")
+    end
+
+    test "open_suggest with a known field initializes suggest UI", %{conn: conn, org: org} do
+      {:ok, live, _html} = live(conn, ~p"/admin/festivals")
+
+      _ = render_click(live, "edit_org", %{"id" => to_string(org.id)})
+
+      after_suggest = render_click(live, "open_suggest", %{"field" => "logo_url"})
+
+      assert after_suggest =~ "Suggest images"
+    end
+  end
+end

--- a/test/cinegraph_web/live/admin_health_live/components_test.exs
+++ b/test/cinegraph_web/live/admin_health_live/components_test.exs
@@ -4,6 +4,9 @@ defmodule CinegraphWeb.AdminHealthLive.ComponentsTest do
 
   import Phoenix.LiveViewTest
   import CinegraphWeb.AdminHealthLive.Components
+  # Five generic primitives moved to DashboardComponents in #880 Phase 1.
+  import CinegraphWeb.Admin.Components.DashboardComponents,
+    only: [verdict_pill: 1, hero_band: 1, stat_tile: 1, sparkline: 1, queue_strip: 1]
 
   describe "verdict_pill/1" do
     test "renders status label and color for green/amber/red/unknown" do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin festivals management UI with drawer editor and image suggestion workflow.
  * Multi-source stock image search (Unsplash, Pexels, Pixabay) and orchestrated provider results for image selection.
  * Runtime-configured image provider keys and a one-shot seed script to populate festival imagery.

* **Bug Fixes**
  * Queue strip now displays actual failure counts.

* **Refactor**
  * Consolidated reusable admin dashboard components (verdict pill, hero band, stat tiles, sparklines, queue strip).

* **Tests**
  * Added tests for stock image search and festivals admin UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->