### PR TITLE
temp kill homepage

### DIFF
--- a/lib/cinegraph_web/controllers/page_controller.ex
+++ b/lib/cinegraph_web/controllers/page_controller.ex
@@ -11,4 +11,8 @@ defmodule CinegraphWeb.PageController do
     # Temporary landing page while app is in development
     render(conn, :coming_soon, layout: false)
   end
+
+  def redirect_to_movies(conn, _params) do
+    redirect(conn, to: "/movies")
+  end
 end

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -37,11 +37,10 @@ defmodule CinegraphWeb.Router do
   scope "/", CinegraphWeb do
     pipe_through :browser
 
-    live_session :v2_home,
-      root_layout: {CinegraphWeb.Layouts, :v2_root},
-      layout: false do
-      live "/", HomeLive, :index
-    end
+    # HomeLive temporarily disabled — its Homepage.snapshot/1 fan-out was
+    # exhausting the Repo.Replica pool under bot-driven mount-retry storms.
+    # Redirect "/" to "/movies" until the homepage can be optimized.
+    get "/", PageController, :redirect_to_movies
 
     if Mix.env() != :prod do
       get "/design-preview", DesignPreviewController, :show


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The root URL now redirects to the movies page while the homepage is being optimized.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/904)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->