### PR TITLE
Override REPLICA_POOL_SIZE=25 in prod (#910 Phase 0)

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -27,6 +27,12 @@ env:
     PHX_HOST: cinegraph.org
     PHX_SERVER: "true"
     PORT: "4000"
+    # Phase 0 of #910 — the previous default of 5 caused request pile-up,
+    # LongPoll process memory growth, and kernel OOMs every 20-60s (255
+    # restarts over 2026-05-10 → 2026-05-15). #908 raised the default to 15
+    # and added queue_target/queue_interval; this env override holds the
+    # prod-tested value of 25 to mirror POOL_SIZE.
+    REPLICA_POOL_SIZE: "25"
   secret:
     - SECRET_KEY_BASE
     - DATABASE_USERNAME


### PR DESCRIPTION
## Summary

- Adds `REPLICA_POOL_SIZE: "25"` to `env.clear` in `config/deploy.yml`, layered on top of #908's new default of 15.
- This is the prod-tested value that stopped the **255-restart OOM crash loop** between 2026-05-10 and 2026-05-15 (Phase 0 of #910).
- Validated live before this commit: replaced the running container with this env override, watched `connection not available` errors drop to 0 over a 3-minute window and BEAM memory settle below 3.4 GiB (vs the 7.65 GiB Docker Desktop VM cap that was being hit every 20–60s).

## Why an override instead of bumping the default

#908 already raised the runtime.exs default from 5 → 15 and (more importantly) added `queue_target=5000ms` / `queue_interval=10000ms`. Those changes alone may be sufficient — but Phase 0 is on the critical path, the crash loop was active, and 25 is the value I verified end-to-end. Keeping it as an env override:

- Holds production at the empirically-tested value while letting dev/test stay at #908's default.
- Easy to dial down later if metrics show 15 is enough.
- No code change required to revert.

## Test plan

- [x] Built env override on host, replaced the OOM-looping container with one running `REPLICA_POOL_SIZE=25`. Cleaned up post-swap.
- [x] `/health` returns 200 in 4–7ms through `kamal-proxy`.
- [x] `connection not available` errors: 0 in 3-minute monitoring window (previously hundreds per minute).
- [x] BEAM total memory: 3.4 GiB (was hitting 7.65 GiB ceiling and OOMing).
- [ ] Confirm no fresh OOM events in 24h after this PR deploys — owner to verify via `docker events --filter container=cinegraph-web-* --since 24h | grep oom`.

## Notes

- Refs #910 (Phase 0 meta tracker).
- Follow-up: Phase 1 (#871) for the real DB pool / Postgres tuning work.
- Stacks cleanly on top of #908 (squash-merged just before this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system replica pool configuration value to support improved resource allocation and capacity management across the platform infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/911)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->