### PR TITLE
ShowV2: fix rating wiring + migrate content_rating/omdb_awards off JSONB (#913 PR A pt 1)

### DIFF
--- a/lib/cinegraph/external_sources.ex
+++ b/lib/cinegraph/external_sources.ex
@@ -181,18 +181,71 @@ defmodule Cinegraph.ExternalSources do
 
     metrics = Repo.replica().all(query)
 
-    # Convert metrics to a format compatible with the old ratings structure
+    # #913 Session 2: the returned key was historically `rating_type` while the
+    # underlying schema field is `metric_type` — and consumers like
+    # `ShowV2.Presentation.rating_value/3` match on `r[:metric_type]`, so the
+    # mismatch meant ratings were silently never found and the show page fell
+    # back to JSONB reads. Single key now matches the schema.
     Enum.map(metrics, fn metric ->
       %{
         id: metric.id,
         movie_id: metric.movie_id,
-        rating_type: metric.metric_type,
+        metric_type: metric.metric_type,
         value: metric.value,
         metadata: metric.metadata,
         fetched_at: metric.fetched_at,
         source: %{
           name: metric.source,
           # No longer have separate source table
+          id: nil
+        }
+      }
+    end)
+  end
+
+  @doc """
+  Returns external_metrics rows for a movie, filtered to the requested
+  metric_types. Same row shape as `get_movie_ratings/1` but with `text_value`
+  included (needed by display callers reading text-typed metrics like
+  `content_rating` and `awards_summary`).
+
+  Uses the read replica. Latest-first by `fetched_at`.
+
+  ## Examples
+
+      iex> get_movie_metrics(42, ["content_rating", "awards_summary"], ["omdb"])
+      [%{metric_type: "content_rating", text_value: "PG-13", source: %{name: "omdb", id: nil}, ...}]
+  """
+  def get_movie_metrics(movie_id, metric_types, source_names \\ nil) when is_list(metric_types) do
+    import Ecto.Query
+    alias Cinegraph.Movies.ExternalMetric
+
+    query =
+      from em in ExternalMetric,
+        where: em.movie_id == ^movie_id,
+        where: em.metric_type in ^metric_types,
+        order_by: [desc: em.fetched_at]
+
+    query =
+      if source_names do
+        from em in query, where: em.source in ^source_names
+      else
+        query
+      end
+
+    query
+    |> Repo.replica().all()
+    |> Enum.map(fn metric ->
+      %{
+        id: metric.id,
+        movie_id: metric.movie_id,
+        metric_type: metric.metric_type,
+        value: metric.value,
+        text_value: metric.text_value,
+        metadata: metric.metadata,
+        fetched_at: metric.fetched_at,
+        source: %{
+          name: metric.source,
           id: nil
         }
       }

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -219,7 +219,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
             <div class="text-[12px] font-semibold text-white/70 tracking-[.06em] uppercase mb-3">
               {year_of(@movie.release_date)}
               <span :if={@movie.runtime}>{" · #{format_runtime(@movie.runtime)}"}</span>
-              <span :if={content_rating(@movie)}>{" · #{content_rating(@movie)}"}</span>
+              <span :if={content_rating(@metrics)}>{" · #{content_rating(@metrics)}"}</span>
               <span
                 :if={disparity_label(@disparity_data[:disparity_category])}
                 class="ml-3 text-amber-300 font-display italic normal-case tracking-normal"
@@ -559,7 +559,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
                 )}
               </span>
             </h2>
-            <div :if={a = omdb_awards(@movie)} class="mb-6 text-[13.5px] text-mist-700 italic">
+            <div :if={a = omdb_awards(@metrics)} class="mb-6 text-[13.5px] text-mist-700 italic">
               {a}
             </div>
             <div class="space-y-4">

--- a/lib/cinegraph_web/live/movie_live/show_v2/data.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2/data.ex
@@ -124,6 +124,8 @@ defmodule CinegraphWeb.MovieLive.ShowV2.Data do
     directors = Enum.filter(crew, &(&1.job == "Director"))
 
     ratings = ExternalSources.get_movie_ratings(movie.id)
+    # #913 PR A: text-valued metrics that used to be read off omdb_data JSONB.
+    metrics = ExternalSources.get_movie_metrics(movie.id, ["content_rating", "awards_summary"], ["omdb"])
     festival_noms = Cultural.get_movie_all_festival_nominations(movie.id) || []
     canon_lists = Cultural.get_list_movies_for_movie(movie.id) || []
     keywords = Movies.get_movie_keywords(movie.id) || []
@@ -146,6 +148,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2.Data do
       crew: crew,
       directors: directors,
       ratings: ratings,
+      metrics: metrics,
       festival_noms: festival_noms,
       canon_lists: canon_lists,
       keywords: keywords,

--- a/lib/cinegraph_web/live/movie_live/show_v2/presentation.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2/presentation.ex
@@ -27,8 +27,15 @@ defmodule CinegraphWeb.MovieLive.ShowV2.Presentation do
     end
   end
 
-  def content_rating(%{omdb_data: %{"Rated" => r}}) when is_binary(r) and r != "" and r != "N/A",
-    do: r
+  # #913 PR A: reads from external_metrics preload (`@metrics` from data.ex),
+  # not the `omdb_data` JSONB blob on the movie struct.
+  @doc "Returns the OMDb content rating from preloaded external metrics."
+  def content_rating(metrics) when is_list(metrics) do
+    case find_metric(metrics, "omdb", "content_rating") do
+      %{text_value: v} when is_binary(v) and v != "" and v != "N/A" -> v
+      _ -> nil
+    end
+  end
 
   def content_rating(_), do: nil
 
@@ -76,6 +83,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2.Presentation do
 
   def format_money(n) when is_number(n), do: "$#{n}"
 
+  @doc "Finds a rating metric by source key and metric type."
   def rating_value(ratings, source_key, type \\ "rating_average") do
     Enum.find(ratings, fn r ->
       key =
@@ -249,10 +257,24 @@ defmodule CinegraphWeb.MovieLive.ShowV2.Presentation do
   defp director_name(%{person: person}), do: person_name(person)
   defp director_name(_), do: person_name(nil)
 
-  def omdb_awards(%{omdb_data: %{"Awards" => a}}) when is_binary(a) and a != "" and a != "N/A",
-    do: a
+  # #913 PR A: reads from external_metrics preload, not omdb_data JSONB.
+  @doc "Returns the OMDb awards summary from preloaded external metrics."
+  def omdb_awards(metrics) when is_list(metrics) do
+    case find_metric(metrics, "omdb", "awards_summary") do
+      %{text_value: v} when is_binary(v) and v != "" and v != "N/A" -> v
+      _ -> nil
+    end
+  end
 
   def omdb_awards(_), do: nil
+
+  # Shared lookup for the migrated reads above — matches the row shape returned
+  # by ExternalSources.get_movie_metrics/2 (and get_movie_ratings/1 post-#913).
+  defp find_metric(metrics, source_name, metric_type) do
+    Enum.find(metrics, fn r ->
+      r[:metric_type] == metric_type and get_in(r, [:source, :name]) == source_name
+    end)
+  end
 
   def top_org_names(noms) when is_list(noms) do
     noms

--- a/test/cinegraph/external_sources_test.exs
+++ b/test/cinegraph/external_sources_test.exs
@@ -1,0 +1,165 @@
+defmodule Cinegraph.ExternalSourcesTest do
+  use Cinegraph.DataCase, async: true
+
+  alias Cinegraph.ExternalSources
+  alias Cinegraph.Movies.{ExternalMetric, Movie}
+
+  describe "get_movie_ratings/1" do
+    test "returns rows with :metric_type key (regression guard for #913 wiring bug)" do
+      movie = insert_movie!()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "imdb",
+          metric_type: "rating_average",
+          value: 8.5,
+          metadata: %{"scale" => "1-10"},
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      [row] = ExternalSources.get_movie_ratings(movie.id)
+
+      # The bug was: get_movie_ratings/1 returned `rating_type:` while consumers
+      # match on `:metric_type`. Verify the key is `:metric_type` now.
+      assert Map.has_key?(row, :metric_type)
+      refute Map.has_key?(row, :rating_type)
+      assert row.metric_type == "rating_average"
+      assert row.value == 8.5
+      assert row.source.name == "imdb"
+    end
+
+    test "filters to the rating-related metric_types whitelist" do
+      movie = insert_movie!()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "imdb",
+          metric_type: "rating_average",
+          value: 8.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        # text-typed metric — must NOT come back from get_movie_ratings/1
+        %{
+          movie_id: movie.id,
+          source: "omdb",
+          metric_type: "content_rating",
+          text_value: "PG-13",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      rows = ExternalSources.get_movie_ratings(movie.id)
+      assert length(rows) == 1
+      assert hd(rows).metric_type == "rating_average"
+    end
+  end
+
+  describe "get_movie_metrics/2" do
+    test "filters to requested metric_types and includes text_value" do
+      movie = insert_movie!()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "omdb",
+          metric_type: "content_rating",
+          text_value: "PG-13",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "omdb",
+          metric_type: "awards_summary",
+          text_value: "Won 2 Oscars",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        # NOT requested — must be excluded
+        %{
+          movie_id: movie.id,
+          source: "imdb",
+          metric_type: "rating_average",
+          value: 8.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      rows = ExternalSources.get_movie_metrics(movie.id, ["content_rating", "awards_summary"])
+      assert length(rows) == 2
+
+      by_type = Map.new(rows, &{&1.metric_type, &1})
+      assert by_type["content_rating"].text_value == "PG-13"
+      assert by_type["content_rating"].source.name == "omdb"
+      assert by_type["awards_summary"].text_value == "Won 2 Oscars"
+    end
+
+    test "returns [] when no matching rows exist" do
+      movie = insert_movie!()
+      assert ExternalSources.get_movie_metrics(movie.id, ["content_rating"]) == []
+    end
+  end
+
+  describe "get_movie_metrics/3" do
+    test "filters to requested source names" do
+      movie = insert_movie!()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "omdb",
+          metric_type: "content_rating",
+          text_value: "PG-13",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "other_source",
+          metric_type: "content_rating",
+          text_value: "R",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      [row] = ExternalSources.get_movie_metrics(movie.id, ["content_rating"], ["omdb"])
+      assert row.text_value == "PG-13"
+      assert row.source.name == "omdb"
+    end
+  end
+
+  defp insert_movie!(attrs \\ %{}) do
+    base = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: "Test Movie #{System.unique_integer([:positive])}"
+    }
+
+    {:ok, movie} =
+      %Movie{}
+      |> Movie.changeset(Map.merge(base, attrs))
+      |> Repo.insert()
+
+    movie
+  end
+end

--- a/test/cinegraph_web/live/movie_live/show_v2/presentation_test.exs
+++ b/test/cinegraph_web/live/movie_live/show_v2/presentation_test.exs
@@ -1,0 +1,136 @@
+defmodule CinegraphWeb.MovieLive.ShowV2.PresentationTest do
+  # Pure-function tests — no DB needed. The functions under test operate on
+  # in-memory lists in the shape ExternalSources.get_movie_metrics/2 and
+  # get_movie_ratings/1 produce.
+  use ExUnit.Case, async: true
+
+  alias CinegraphWeb.MovieLive.ShowV2.Presentation
+
+  describe "rating_value/3" do
+    test "finds a row by source_key + metric_type (#913 wiring-bug regression guard)" do
+      # Shape mirrors ExternalSources.get_movie_ratings/1 — post-#913 the key is
+      # :metric_type, not :rating_type. If the rename ever regresses, this fails.
+      ratings = [
+        %{metric_type: "rating_average", value: 8.5, source: %{name: "imdb", id: nil}},
+        %{metric_type: "tomatometer", value: 95, source: %{name: "rotten_tomatoes", id: nil}}
+      ]
+
+      assert %{value: 8.5} = Presentation.rating_value(ratings, "imdb")
+      assert %{value: 95} = Presentation.rating_value(ratings, "rotten_tomatoes", "tomatometer")
+    end
+
+    test "returns nil when no row matches source + type" do
+      ratings = [
+        %{metric_type: "rating_average", value: 8.5, source: %{name: "imdb", id: nil}}
+      ]
+
+      assert Presentation.rating_value(ratings, "metacritic") == nil
+      assert Presentation.rating_value(ratings, "imdb", "tomatometer") == nil
+    end
+  end
+
+  describe "content_rating/1" do
+    test "returns text_value from the omdb/content_rating metric" do
+      metrics = [
+        %{metric_type: "content_rating", text_value: "PG-13", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.content_rating(metrics) == "PG-13"
+    end
+
+    test "is independent of other metric_types in the list" do
+      metrics = [
+        %{
+          metric_type: "awards_summary",
+          text_value: "Won 2 Oscars",
+          source: %{name: "omdb", id: nil}
+        },
+        %{metric_type: "content_rating", text_value: "R", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.content_rating(metrics) == "R"
+    end
+
+    test "returns nil when no content_rating row exists" do
+      metrics = [
+        %{
+          metric_type: "awards_summary",
+          text_value: "Won 2 Oscars",
+          source: %{name: "omdb", id: nil}
+        }
+      ]
+
+      assert Presentation.content_rating(metrics) == nil
+    end
+
+    test "returns nil for empty list" do
+      assert Presentation.content_rating([]) == nil
+    end
+
+    test "returns nil when text_value is empty string" do
+      metrics = [
+        %{metric_type: "content_rating", text_value: "", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.content_rating(metrics) == nil
+    end
+
+    test "returns nil when text_value is the OMDb N/A sentinel" do
+      metrics = [
+        %{metric_type: "content_rating", text_value: "N/A", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.content_rating(metrics) == nil
+    end
+
+    test "returns nil when input is not a list (no JSONB fallback)" do
+      # Catches regression where a caller passes @movie instead of @metrics.
+      assert Presentation.content_rating(%{omdb_data: %{"Rated" => "PG-13"}}) == nil
+      assert Presentation.content_rating(nil) == nil
+    end
+  end
+
+  describe "omdb_awards/1" do
+    test "returns text_value from the omdb/awards_summary metric" do
+      metrics = [
+        %{
+          metric_type: "awards_summary",
+          text_value: "Won 7 Oscars",
+          source: %{name: "omdb", id: nil}
+        }
+      ]
+
+      assert Presentation.omdb_awards(metrics) == "Won 7 Oscars"
+    end
+
+    test "returns nil when no awards_summary row exists" do
+      metrics = [
+        %{metric_type: "content_rating", text_value: "PG-13", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.omdb_awards(metrics) == nil
+    end
+
+    test "returns nil when text_value is empty" do
+      metrics = [
+        %{metric_type: "awards_summary", text_value: "", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.omdb_awards(metrics) == nil
+    end
+
+    test "returns nil when text_value is the OMDb N/A sentinel" do
+      metrics = [
+        %{metric_type: "awards_summary", text_value: "N/A", source: %{name: "omdb", id: nil}}
+      ]
+
+      assert Presentation.omdb_awards(metrics) == nil
+    end
+
+    test "returns nil for empty list or non-list input" do
+      assert Presentation.omdb_awards([]) == nil
+      assert Presentation.omdb_awards(%{omdb_data: %{"Awards" => "Won 2"}}) == nil
+      assert Presentation.omdb_awards(nil) == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First slice of #913 PR A — fixes the pre-existing wiring bug on the ShowV2 page and migrates the two text-valued presentation reads (`content_rating/1`, `omdb_awards/1`) from `omdb_data` JSONB to `external_metrics`.

The bug discovered during the #913 audit: `ExternalSources.get_movie_ratings/1` returned rows keyed `:rating_type`, but `ShowV2.Presentation.rating_value/3` matched `r[:metric_type] == type`. Keys never matched → ratings were silently never found → the show page fell back to direct JSONB reads. Nobody noticed because both paths rendered the same value.

## Changes

- **`lib/cinegraph/external_sources.ex`** — rename returned key `rating_type:` → `metric_type:` (line 189). Add `get_movie_metrics/2` for arbitrary metric_types including `text_value` (needed for content_rating + awards_summary).
- **`lib/cinegraph_web/live/movie_live/show_v2/data.ex`** — preload `metrics` (content_rating + awards_summary) alongside `ratings`. The `socket |> assign(data)` at `show_v2.ex:51` makes `@metrics` available in templates automatically.
- **`lib/cinegraph_web/live/movie_live/show_v2/presentation.ex`** — `content_rating/1` and `omdb_awards/1` now read from the metrics list via the new shared `find_metric/3` helper. The old JSONB pattern-match clause is gone. Both functions return `nil` for non-list input (so a caller mistakenly passing `@movie` fails closed, not silently).
- **`lib/cinegraph_web/live/movie_live/show_v2.ex`** — two template call sites (lines 222, 562) updated to pass `@metrics`.

## Tests

- `test/cinegraph/external_sources_test.exs` (new):
  - Regression guard: `get_movie_ratings/1` rows are keyed `:metric_type`, not `:rating_type`.
  - `get_movie_ratings/1` whitelist still filters to numeric rating types.
  - `get_movie_metrics/2` filters to requested metric_types and includes `text_value`.
- `test/cinegraph_web/live/movie_live/show_v2/presentation_test.exs` (new):
  - Pure-function unit tests for `rating_value/3`, `content_rating/1`, `omdb_awards/1`.
  - Edge cases: empty list, non-list input (no JSONB fallback), empty `text_value`.

## Data prerequisite

Session 1's direct-SQL backfill (#913 comment [4461223659](https://github.com/razrfly/cinegraph/issues/913#issuecomment-4461223659)) inserted 102,050 missing `external_metrics` rows on prod, including 76,288 `content_rating` rows. Every in-scope metric now has `src == dst`. After this PR deploys, the show page's reads against `external_metrics` will return the same values the JSONB fallback was rendering.

## Greppable invariant for this PR's scope

```
grep -nE "omdb_data|tmdb_data" \
  lib/cinegraph_web/live/movie_live/show_v2/presentation.ex \
  lib/cinegraph_web/live/movie_live/show_v2.ex
```

Returns only two hits, both in comments referencing what was migrated. No code reads JSONB inside `show_v2.ex` or its presentation module.

## Test plan

- [ ] CI green (project requires Elixir 1.19; local was 1.18 so I couldn't `mix test` against the new files — `Code.string_to_quoted!` parses all 6 changed files cleanly)
- [ ] Visual diff `/movies/:slug` on staging / prod read-only for 5 movie classes per the issue acceptance:
  - High-data canonical (Joker, Parasite) — content_rating + Awards still render
  - Movie that was in Session 1's backfill gap — proves backfill + migration both worked
  - Recent TMDb-only release — both functions return nil, template renders cleanly
  - Movie with only `awards_summary` (no `content_rating`) — fields are independent
  - Movie with historical `omdb_data["Rated"] == "N/A"` — confirms the migration renders nothing (not "N/A")
- [ ] Spot-check: docker exec rpc on prod to confirm `Presentation.rating_value/3` returns non-nil for a movie that has corresponding `external_metrics` rows. This is the proof the wiring bug is actually fixed.

## Out of scope (Session 3 / PR A pt 2 picks up)

- `lib/cinegraph_web/components/rating_components.ex` — imdbRating, Metascore, Rotten Tomatoes, TMDb vote_average
- `lib/cinegraph_web/components/seo.ex` — JSON-LD `aggregateRating` and `production_companies`
- `lib/cinegraph_web/live/director_live/show.ex:353`
- `lib/cinegraph_web/live/person_live/show*.heex` revenue reads
- `lib/cinegraph/people.ex:428` (`normalize_revenue`)
- `lib/cinegraph/calibration/recall_calculator.ex:289-290`
- PR B (drop JSONB from list queries) — that's Session 4

## References

- #913 — the meta issue (PR A pt 1 here)
- #917 — Session 1 worker code (sibling PR, can merge in either order — the data is already on prod via direct SQL)
- #910 — autonomy meta tracker
- Plan file: `~/.claude/plans/enchanted-booping-ullman.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Movie detail pages now surface content ratings and awards from external metric rows (improved, consistent metadata display).
  * Movie data loading now includes text-based external metrics for use in the UI.

* **Tests**
  * Added comprehensive tests for external metrics retrieval and presentation helpers, including filtering and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/918)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->