### PR TITLE
Migrate remaining display JSONB reads to external_metrics (#913 PR A pt 2)

### DIFF
--- a/lib/cinegraph/calibration/recall_calculator.ex
+++ b/lib/cinegraph/calibration/recall_calculator.ex
@@ -283,31 +283,20 @@ defmodule Cinegraph.Calibration.RecallCalculator do
 
   defp analyze_genre_gaps(missed_ids, _references) when missed_ids == [], do: []
 
+  # #913 PR A pt 2: was reading tmdb_data->'genres' via SQL fragment. Genres
+  # live in the `genres` table joined through `movie_genres`; query that
+  # directly instead of the JSONB blob.
   defp analyze_genre_gaps(missed_ids, _references) do
-    from(m in Movie,
-      where: m.id in ^missed_ids,
-      where: not is_nil(m.tmdb_data),
-      select: fragment("?->'genres'", m.tmdb_data)
+    from(g in Cinegraph.Movies.Genre,
+      join: mg in "movie_genres",
+      on: mg.genre_id == g.id,
+      where: mg.movie_id in ^missed_ids,
+      group_by: g.name,
+      order_by: [desc: count(mg.movie_id)],
+      limit: 3,
+      select: {g.name, count(mg.movie_id)}
     )
     |> Repo.all()
-    |> Enum.flat_map(fn genres ->
-      case genres do
-        genres when is_list(genres) ->
-          Enum.map(genres, fn g ->
-            cond do
-              is_map(g) -> Map.get(g, "name") || Map.get(g, :name)
-              true -> nil
-            end
-          end)
-
-        _ ->
-          []
-      end
-    end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.frequencies()
-    |> Enum.sort_by(fn {_, count} -> count end, :desc)
-    |> Enum.take(3)
     |> Enum.map(fn {genre, count} ->
       %{
         category: "genre",

--- a/lib/cinegraph/external_sources.ex
+++ b/lib/cinegraph/external_sources.ex
@@ -172,9 +172,11 @@ defmodule Cinegraph.ExternalSources do
         where: em.metric_type in ["rating_average", "tomatometer", "metascore", "audience_score"],
         order_by: [desc: em.fetched_at]
 
+    normalized_sources = normalize_source_names(source_names)
+
     query =
-      if source_names do
-        from em in query, where: em.source in ^source_names
+      if normalized_sources != [] do
+        from em in query, where: em.source in ^normalized_sources
       else
         query
       end
@@ -226,9 +228,11 @@ defmodule Cinegraph.ExternalSources do
         where: em.metric_type in ^metric_types,
         order_by: [desc: em.fetched_at]
 
+    normalized_sources = normalize_source_names(source_names)
+
     query =
-      if source_names do
-        from em in query, where: em.source in ^source_names
+      if normalized_sources != [] do
+        from em in query, where: em.source in ^normalized_sources
       else
         query
       end
@@ -251,6 +255,11 @@ defmodule Cinegraph.ExternalSources do
       }
     end)
   end
+
+  defp normalize_source_names(nil), do: []
+  defp normalize_source_names(names) when is_list(names), do: names
+  defp normalize_source_names(name) when is_binary(name), do: [name]
+  defp normalize_source_names(_), do: []
 
   @doc """
   Gets normalized scores across all sources for a movie from external_metrics.

--- a/lib/cinegraph/people.ex
+++ b/lib/cinegraph/people.ex
@@ -422,29 +422,64 @@ defmodule Cinegraph.People do
     end
   end
 
+  # #913 PR A pt 2: was iterating movies and reading movie.tmdb_data["revenue"]
+  # per row. Now a single query against external_metrics. The four
+  # `normalize_revenue/1` clauses that handled int/float/string/nil JSONB
+  # values are gone — external_metrics stores `value` as float, so the only
+  # transformation needed is `trunc(sum)`.
   defp calculate_total_revenue(movies) do
-    movies
-    |> Enum.map(fn movie ->
-      normalize_revenue(movie.tmdb_data["revenue"])
-    end)
-    |> Enum.sum()
-  end
+    movie_ids = movies |> Enum.map(& &1.id) |> Enum.uniq()
 
-  defp normalize_revenue(nil), do: 0
-  defp normalize_revenue(revenue) when is_integer(revenue), do: revenue
-  defp normalize_revenue(revenue) when is_float(revenue), do: trunc(revenue)
+    if movie_ids == [] do
+      0
+    else
+      sum =
+        Repo.replica().one(
+          from em in Cinegraph.Movies.ExternalMetric,
+            where:
+              em.movie_id in ^movie_ids and
+                em.source == "tmdb" and
+                em.metric_type == "revenue_worldwide",
+            select: sum(em.value)
+        )
 
-  defp normalize_revenue(revenue) when is_binary(revenue) do
-    # Handle string revenue values (may contain commas, spaces, etc.)
-    cleaned = String.replace(revenue, ~r/[^\d.]/, "")
-
-    case Float.parse(cleaned) do
-      {value, _} -> trunc(value)
-      :error -> 0
+      case sum do
+        nil -> 0
+        s when is_number(s) -> trunc(s)
+      end
     end
   end
 
-  defp normalize_revenue(_), do: 0
+  @doc """
+  Builds a `%{movie_id => revenue_int}` map for the given movie IDs.
+
+  Reads TMDb `revenue_worldwide` rows from `external_metrics` so templates
+  can render per-credit revenue without touching `tmdb_data` JSONB.
+  """
+  def revenue_map_for_movie_ids([]), do: %{}
+
+  def revenue_map_for_movie_ids(movie_ids) when is_list(movie_ids) do
+    ids = movie_ids |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    if ids == [] do
+      %{}
+    else
+      from(em in Cinegraph.Movies.ExternalMetric,
+        where:
+          em.movie_id in ^ids and
+            em.source == "tmdb" and
+            em.metric_type == "revenue_worldwide",
+        distinct: em.movie_id,
+        order_by: [asc: em.movie_id, desc: em.fetched_at, desc: em.id],
+        select: {em.movie_id, em.value}
+      )
+      |> Repo.replica().all()
+      |> Map.new(fn {id, value} ->
+        revenue = if is_number(value), do: trunc(value), else: 0
+        {id, revenue}
+      end)
+    end
+  end
 
   defp calculate_average_rating(movies) do
     ratings =

--- a/lib/cinegraph/people.ex
+++ b/lib/cinegraph/people.ex
@@ -422,32 +422,16 @@ defmodule Cinegraph.People do
     end
   end
 
-  # #913 PR A pt 2: was iterating movies and reading movie.tmdb_data["revenue"]
-  # per row. Now a single query against external_metrics. The four
-  # `normalize_revenue/1` clauses that handled int/float/string/nil JSONB
-  # values are gone — external_metrics stores `value` as float, so the only
-  # transformation needed is `trunc(sum)`.
+  # Delegates to `revenue_map_for_movie_ids/1` so the per-movie deduplication
+  # (DISTINCT ON, latest fetched_at wins) lives in exactly one place. A plain
+  # `sum()` over external_metrics would double-count any movie with multiple
+  # `revenue_worldwide` rows from re-fetches.
   defp calculate_total_revenue(movies) do
-    movie_ids = movies |> Enum.map(& &1.id) |> Enum.uniq()
-
-    if movie_ids == [] do
-      0
-    else
-      sum =
-        Repo.replica().one(
-          from em in Cinegraph.Movies.ExternalMetric,
-            where:
-              em.movie_id in ^movie_ids and
-                em.source == "tmdb" and
-                em.metric_type == "revenue_worldwide",
-            select: sum(em.value)
-        )
-
-      case sum do
-        nil -> 0
-        s when is_number(s) -> trunc(s)
-      end
-    end
+    movies
+    |> Enum.map(& &1.id)
+    |> revenue_map_for_movie_ids()
+    |> Map.values()
+    |> Enum.sum()
   end
 
   @doc """

--- a/lib/cinegraph_web/components/rating_components.ex
+++ b/lib/cinegraph_web/components/rating_components.ex
@@ -487,112 +487,33 @@ defmodule CinegraphWeb.RatingComponents do
     """
   end
 
-  # Build hero ratings from movie data (with URLs where available)
+  # #913 PR A pt 2: build entirely from movie.external_ratings (the preloaded
+  # ExternalSources.get_movie_ratings/1 shape, keyed by :metric_type since
+  # Session 2). No more JSONB reads — IMDb/Metacritic/RT/TMDb all flow through
+  # external_metrics now. URLs derive from first-class imdb_id/tmdb_id columns.
   defp build_hero_ratings(movie) do
-    ratings = []
-
-    # Get external IDs for building URLs
     imdb_id = Map.get(movie, :imdb_id)
     tmdb_id = Map.get(movie, :tmdb_id)
 
-    # IMDb from omdb_data
-    ratings =
-      case get_in(movie.omdb_data || %{}, ["imdbRating"]) do
-        nil ->
-          ratings
-
-        "N/A" ->
-          ratings
-
-        value ->
-          url = if imdb_id, do: "https://www.imdb.com/title/#{imdb_id}/", else: nil
-          ratings ++ [%{source: "imdb", value: value, url: url}]
+    external_ratings =
+      case Map.get(movie, :external_ratings) do
+        list when is_list(list) -> list
+        _ -> []
       end
 
-    # Metacritic from omdb_data (no reliable URL without their slug)
-    ratings =
-      case get_in(movie.omdb_data || %{}, ["Metascore"]) do
-        nil -> ratings
-        "N/A" -> ratings
-        value -> ratings ++ [%{source: "metacritic", value: value, url: nil}]
-      end
-
-    # Rotten Tomatoes from omdb_data Ratings array (no reliable URL without their slug)
-    ratings =
-      case find_omdb_rating(movie.omdb_data, "Rotten Tomatoes") do
-        nil -> ratings
-        value -> ratings ++ [%{source: "rotten_tomatoes", value: parse_rt_value(value), url: nil}]
-      end
-
-    # TMDb from tmdb_data
-    ratings =
-      case get_in(movie.tmdb_data || %{}, ["vote_average"]) do
-        nil ->
-          ratings
-
-        0 ->
-          ratings
-
-        value when value == 0.0 ->
-          ratings
-
-        value ->
-          url = if tmdb_id, do: "https://www.themoviedb.org/movie/#{tmdb_id}", else: nil
-          ratings ++ [%{source: "tmdb", value: value, url: url}]
-      end
-
-    # Add from external_ratings if available (for Letterboxd, etc.)
-    ratings =
-      if Map.has_key?(movie, :external_ratings) && is_list(movie.external_ratings) do
-        Enum.reduce(movie.external_ratings, ratings, fn rating, acc ->
-          source_name =
-            rating.metadata["source_name"] ||
-              (rating.source && rating.source.name) ||
-              "Unknown"
-
-          source_key = normalize_source(source_name)
-
-          # Skip if we already have this source from omdb/tmdb
-          if Enum.any?(acc, fn r -> r.source == source_key end) do
-            acc
-          else
-            acc ++ [%{source: source_key, value: rating.value}]
-          end
-        end)
-      else
-        ratings
-      end
-
-    ratings
+    external_ratings
+    |> Enum.map(fn rating ->
+      source_name = get_in(rating, [:source, :name]) || "unknown"
+      source_key = source_name |> normalize_source() |> derive_hero_source_key(rating[:metric_type])
+      url = build_rating_url(source_key, imdb_id, tmdb_id)
+      %{source: source_key, value: rating[:value], url: url}
+    end)
+    |> Enum.reject(fn r -> is_nil(r.value) or r.value == 0 or r.value == 0.0 end)
+    |> Enum.uniq_by(& &1.source)
   end
 
-  defp find_omdb_rating(nil, _source), do: nil
-
-  defp find_omdb_rating(omdb_data, source) do
-    case omdb_data["Ratings"] do
-      nil ->
-        nil
-
-      ratings when is_list(ratings) ->
-        Enum.find_value(ratings, fn
-          %{"Source" => ^source, "Value" => value} -> value
-          _ -> nil
-        end)
-
-      _ ->
-        nil
-    end
-  end
-
-  defp parse_rt_value(value) when is_binary(value) do
-    # Handle "92%" format
-    case Integer.parse(String.replace(value, "%", "")) do
-      {num, _} -> num
-      :error -> value
-    end
-  end
-
-  defp parse_rt_value(value), do: value
+  defp derive_hero_source_key("rotten_tomatoes", "audience_score"), do: "rotten_tomatoes_audience"
+  defp derive_hero_source_key(source_key, _metric_type), do: source_key
 
   # Private helper functions
 

--- a/lib/cinegraph_web/components/seo.ex
+++ b/lib/cinegraph_web/components/seo.ex
@@ -489,10 +489,26 @@ defmodule CinegraphWeb.SEO do
 
   defp get_genres(_), do: []
 
-  # Extract rating from external metrics or tmdb_data
+  # #913 PR A pt 2: reads from preloaded :external_metrics association on the
+  # movie. The previous "external_metrics" clause matched on `vote_average`/
+  # `vote_count` keys that the current ExternalMetric schema doesn't have
+  # (`source`/`metric_type`/`value`), so it was dead and we silently fell
+  # back to tmdb_data JSONB. Seo_helpers now preloads the association.
   defp get_rating(%{external_metrics: metrics}) when is_list(metrics) do
-    case Enum.find(metrics, &(&1.source == "tmdb")) do
-      %{vote_average: avg, vote_count: count} when is_number(avg) and is_number(count) ->
+    avg_metric =
+      Enum.find(metrics, &(&1.source == "tmdb" and &1.metric_type == "rating_average"))
+
+    votes_metric =
+      Enum.find(metrics, &(&1.source == "tmdb" and &1.metric_type == "rating_votes"))
+
+    case avg_metric do
+      %{value: avg} when is_number(avg) ->
+        count =
+          case votes_metric do
+            %{value: c} when is_number(c) -> trunc(c)
+            _ -> 0
+          end
+
         {Float.round(avg, 1), count}
 
       _ ->
@@ -500,21 +516,12 @@ defmodule CinegraphWeb.SEO do
     end
   end
 
-  defp get_rating(%{tmdb_data: %{"vote_average" => avg, "vote_count" => count}})
-       when is_number(avg) and is_number(count) do
-    {Float.round(avg, 1), count}
-  end
-
   defp get_rating(_), do: {0, 0}
 
-  # Extract production companies
+  # Extract production companies. #913 PR A pt 2: dropped tmdb_data fallback —
+  # the relational association is always available now (seo_helpers preloads).
   defp get_production_companies(%{production_companies: companies}) when is_list(companies) do
     Enum.map(companies, & &1.name)
-  end
-
-  defp get_production_companies(%{tmdb_data: %{"production_companies" => companies}})
-       when is_list(companies) do
-    Enum.map(companies, & &1["name"])
   end
 
   defp get_production_companies(_), do: []

--- a/lib/cinegraph_web/live/director_live/show.ex
+++ b/lib/cinegraph_web/live/director_live/show.ex
@@ -28,15 +28,18 @@ defmodule CinegraphWeb.DirectorLive.Show do
             Enum.any?(director.crew_credits, &(&1.job == "Director"))
 
         if is_director do
+          revenue_map = build_revenue_map(director)
+
           socket =
             socket
             |> assign(:page_title, "Director Analysis: #{director.name}")
             |> assign(:director, director)
-            |> assign(:director_stats, get_director_stats(director))
+            |> assign(:revenue_map, revenue_map)
+            |> assign(:director_stats, get_director_stats(director, revenue_map))
             |> assign(:frequent_actors, get_frequent_actors(id))
-            |> assign(:genre_analysis, analyze_genres(director))
+            |> assign(:genre_analysis, analyze_genres(director, revenue_map))
             |> assign(:rating_trends, get_rating_trends(director))
-            |> assign(:box_office_trends, get_box_office_trends(director))
+            |> assign(:box_office_trends, get_box_office_trends(director, revenue_map))
             |> assign(:collaboration_network, get_collaboration_network(id))
 
           {:noreply, socket}
@@ -53,11 +56,20 @@ defmodule CinegraphWeb.DirectorLive.Show do
 
   # Private functions
 
-  defp get_director_stats(director) do
+  defp build_revenue_map(director) do
+    crew = Map.get(director, :crew_credits, []) || []
+    cast = Map.get(director, :cast_credits, []) || []
+
+    (crew ++ cast)
+    |> Enum.map(& &1.movie_id)
+    |> People.revenue_map_for_movie_ids()
+  end
+
+  defp get_director_stats(director, revenue_map) do
     directing_credits = Enum.filter(director.crew_credits, &(&1.job == "Director"))
     movies = Enum.map(directing_credits, & &1.movie) |> Enum.uniq_by(& &1.id)
 
-    total_revenue = Enum.sum(Enum.map(movies, &revenue/1))
+    total_revenue = Enum.sum(Enum.map(movies, &revenue(&1, revenue_map)))
     avg_rating = calculate_average_rating(movies)
 
     %{
@@ -67,7 +79,7 @@ defmodule CinegraphWeb.DirectorLive.Show do
       avg_rating: avg_rating,
       highest_rated:
         Enum.max_by(movies, &(Cinegraph.Movies.Movie.vote_average(&1) || 0), fn -> nil end),
-      highest_grossing: Enum.max_by(movies, &revenue/1, fn -> nil end),
+      highest_grossing: Enum.max_by(movies, &revenue(&1, revenue_map), fn -> nil end),
       years_active: calculate_years_active(movies)
     }
   end
@@ -87,7 +99,7 @@ defmodule CinegraphWeb.DirectorLive.Show do
     end)
   end
 
-  defp analyze_genres(director) do
+  defp analyze_genres(director, revenue_map) do
     directing_credits = Enum.filter(director.crew_credits, &(&1.job == "Director"))
     movies = Enum.map(directing_credits, & &1.movie)
 
@@ -112,7 +124,7 @@ defmodule CinegraphWeb.DirectorLive.Show do
           end)
 
         avg_rating = calculate_average_rating(genre_movies)
-        total_revenue = Enum.sum(Enum.map(genre_movies, &revenue/1))
+        total_revenue = Enum.sum(Enum.map(genre_movies, &revenue(&1, revenue_map)))
 
         %{
           genre: genre,
@@ -188,7 +200,7 @@ defmodule CinegraphWeb.DirectorLive.Show do
     end
   end
 
-  defp get_box_office_trends(director) do
+  defp get_box_office_trends(director, revenue_map) do
     directing_credits =
       director.crew_credits
       |> Enum.filter(&(&1.job == "Director"))
@@ -197,7 +209,7 @@ defmodule CinegraphWeb.DirectorLive.Show do
     movies_with_revenue =
       directing_credits
       |> Enum.map(& &1.movie)
-      |> Enum.filter(fn m -> revenue(m) > 0 && m.release_date end)
+      |> Enum.filter(fn m -> revenue(m, revenue_map) > 0 && m.release_date end)
 
     if length(movies_with_revenue) > 0 do
       # Calculate cumulative box office
@@ -206,17 +218,17 @@ defmodule CinegraphWeb.DirectorLive.Show do
         |> Enum.scan(%{year: nil, total: 0}, fn movie, acc ->
           %{
             year: movie.release_date.year,
-            total: acc.total + revenue(movie),
+            total: acc.total + revenue(movie, revenue_map),
             movie: movie.title
           }
         end)
 
       %{
         cumulative_revenue: cumulative,
-        highest_year: find_highest_revenue_year(movies_with_revenue),
+        highest_year: find_highest_revenue_year(movies_with_revenue, revenue_map),
         average_per_film:
           div(
-            Enum.sum(Enum.map(movies_with_revenue, &revenue/1)),
+            Enum.sum(Enum.map(movies_with_revenue, &revenue(&1, revenue_map))),
             length(movies_with_revenue)
           )
       }
@@ -338,21 +350,15 @@ defmodule CinegraphWeb.DirectorLive.Show do
     end
   end
 
-  defp find_highest_revenue_year(movies) do
+  defp find_highest_revenue_year(movies, revenue_map) do
     movies
     |> Enum.group_by(& &1.release_date.year)
     |> Enum.map(fn {year, year_movies} ->
-      {year, Enum.sum(Enum.map(year_movies, &revenue/1))}
+      {year, Enum.sum(Enum.map(year_movies, &revenue(&1, revenue_map)))}
     end)
     |> Enum.max_by(fn {_year, revenue} -> revenue end, fn -> {nil, 0} end)
     |> elem(0)
   end
 
-  # Helper to extract revenue from movie, checking tmdb_data
-  defp revenue(movie) do
-    case movie.tmdb_data do
-      %{"revenue" => rev} when is_number(rev) -> rev
-      _ -> 0
-    end
-  end
+  defp revenue(movie, revenue_map), do: Map.get(revenue_map, movie.id, 0)
 end

--- a/lib/cinegraph_web/live/movie_live/show.ex
+++ b/lib/cinegraph_web/live/movie_live/show.ex
@@ -196,6 +196,11 @@ defmodule CinegraphWeb.MovieLive.Show do
     # Load external sources data
     external_ratings = ExternalSources.get_movie_ratings(id)
 
+    # #913 PR A pt 2: text-typed metrics (content_rating, awards_summary) come
+    # from external_metrics now, not omdb_data JSONB.
+    metrics_list =
+      ExternalSources.get_movie_metrics(id, ["content_rating", "awards_summary"], ["omdb"])
+
     # Load ALL other connected data
     keywords = Movies.get_movie_keywords(id)
     videos = Movies.get_movie_videos(id)
@@ -240,6 +245,7 @@ defmodule CinegraphWeb.MovieLive.Show do
     |> Map.put(:cultural_lists, cultural_lists)
     |> Map.put(:all_festival_nominations, all_festival_nominations)
     |> Map.put(:external_ratings, external_ratings)
+    |> Map.put(:metrics, metrics_list)
     |> Map.put(:keywords, keywords)
     |> Map.put(:videos, videos)
     |> Map.put(:release_dates, release_dates)

--- a/lib/cinegraph_web/live/movie_live/show.html.heex
+++ b/lib/cinegraph_web/live/movie_live/show.html.heex
@@ -78,7 +78,7 @@
               {@movie.runtime} min
             </span>
           <% end %>
-          <%= if (rating = get_in(@movie.omdb_data, ["Rated"])) && rating != "N/A" do %>
+          <%= if rating = CinegraphWeb.MovieLive.ShowV2.Presentation.content_rating(@movie.metrics) do %>
             <span class="bg-white/20 backdrop-blur px-3 py-1 rounded-full">
               {rating}
             </span>
@@ -848,7 +848,8 @@
       <% total_wins = Enum.sum(Enum.map(all_noms, & &1.total_wins)) %>
       <% total_nominations = Enum.sum(Enum.map(all_noms, & &1.total_nominations)) %>
 
-      <%= if length(all_noms) > 0 || (@movie.omdb_data && @movie.omdb_data["Awards"] && @movie.omdb_data["Awards"] != "N/A") do %>
+      <% awards_summary = CinegraphWeb.MovieLive.ShowV2.Presentation.omdb_awards(@movie.metrics) %>
+      <%= if length(all_noms) > 0 || awards_summary do %>
         <div class="bg-gradient-to-r from-amber-50 to-yellow-50 border border-amber-200 rounded-lg shadow p-6 mb-8">
           <div class="flex items-start gap-4">
             <div class="text-4xl">🏆</div>
@@ -868,8 +869,8 @@
                   </span>
                 <% end %>
               </div>
-              <%= if @movie.omdb_data && @movie.omdb_data["Awards"] && @movie.omdb_data["Awards"] != "N/A" do %>
-                <p class="text-amber-700 mt-3 text-sm">{@movie.omdb_data["Awards"]}</p>
+              <%= if awards_summary do %>
+                <p class="text-amber-700 mt-3 text-sm">{awards_summary}</p>
                 <p class="text-xs text-amber-600 mt-1">Additional data from OMDb / IMDb</p>
               <% end %>
             </div>
@@ -1022,7 +1023,7 @@
         </div>
       <% end %>
 
-      <%= if length(@movie.all_festival_nominations) == 0 && length(@movie.cultural_lists) == 0 && (!@movie.omdb_data || !@movie.omdb_data["Awards"] || @movie.omdb_data["Awards"] == "N/A") do %>
+      <%= if length(@movie.all_festival_nominations) == 0 && length(@movie.cultural_lists) == 0 && is_nil(awards_summary) do %>
         <div class="bg-white rounded-lg shadow p-6">
           <p class="text-gray-600 text-center">
             No awards or cultural list appearances recorded.

--- a/lib/cinegraph_web/live/person_live/show.ex
+++ b/lib/cinegraph_web/live/person_live/show.ex
@@ -69,6 +69,7 @@ defmodule CinegraphWeb.PersonLive.Show do
     collaboration_stats = get_collaboration_stats(person.id)
     frequent_collaborators = get_frequent_collaborators(person)
     award_stats = Festivals.get_person_nomination_stats(person.id)
+    revenue_map = build_revenue_map(person)
 
     socket
     |> assign(:person, person)
@@ -76,11 +77,21 @@ defmodule CinegraphWeb.PersonLive.Show do
     |> assign(:collaboration_stats, collaboration_stats)
     |> assign(:frequent_collaborators, frequent_collaborators)
     |> assign(:award_stats, award_stats)
+    |> assign(:revenue_map, revenue_map)
     |> assign(:show_six_degrees, false)
     |> assign(:six_degrees_target, nil)
     |> assign(:six_degrees_path, nil)
     |> assign(:six_degrees_loading, false)
     |> assign_person_seo(person)
+  end
+
+  defp build_revenue_map(person) do
+    cast = Map.get(person, :cast_credits, []) || []
+    crew = Map.get(person, :crew_credits, []) || []
+
+    (cast ++ crew)
+    |> Enum.map(& &1.movie_id)
+    |> People.revenue_map_for_movie_ids()
   end
 
   @impl true

--- a/lib/cinegraph_web/live/person_live/show.html.heex
+++ b/lib/cinegraph_web/live/person_live/show.html.heex
@@ -543,10 +543,7 @@
                           {Float.round(vote_avg, 1)}
                         </div>
                       <% end %>
-                      <% revenue =
-                        if Map.has_key?(credit.movie.tmdb_data || %{}, "revenue"),
-                          do: credit.movie.tmdb_data["revenue"],
-                          else: nil %>
+                      <% revenue = Map.get(@revenue_map, credit.movie_id) %>
                       <%= if revenue && revenue > 0 do %>
                         <div class="text-sm font-medium text-green-700 bg-green-50 px-2 py-1 rounded-lg">
                           ${div(revenue, 1_000_000)}M

--- a/lib/cinegraph_web/live/person_live/show_legacy.ex
+++ b/lib/cinegraph_web/live/person_live/show_legacy.ex
@@ -44,18 +44,29 @@ defmodule CinegraphWeb.PersonLive.ShowLegacy do
     career_stats = People.get_career_stats(person.id)
     collaboration_stats = get_collaboration_stats(person.id)
     frequent_collaborators = get_frequent_collaborators(person)
+    revenue_map = build_revenue_map(person)
 
     socket
     |> assign(:person, person)
     |> assign(:career_stats, career_stats)
     |> assign(:collaboration_stats, collaboration_stats)
     |> assign(:frequent_collaborators, frequent_collaborators)
+    |> assign(:revenue_map, revenue_map)
     |> assign(:show_six_degrees, false)
     |> assign(:six_degrees_target, nil)
     |> assign(:six_degrees_path, nil)
     |> assign(:six_degrees_loading, false)
     |> assign(:page_title, "#{person.name} (Legacy)")
     |> assign_person_seo(person)
+  end
+
+  defp build_revenue_map(person) do
+    cast = Map.get(person, :cast_credits, []) || []
+    crew = Map.get(person, :crew_credits, []) || []
+
+    (cast ++ crew)
+    |> Enum.map(& &1.movie_id)
+    |> People.revenue_map_for_movie_ids()
   end
 
   @impl true

--- a/lib/cinegraph_web/live/person_live/show_legacy.html.heex
+++ b/lib/cinegraph_web/live/person_live/show_legacy.html.heex
@@ -430,10 +430,7 @@
                   <%= if vote_avg do %>
                     <span>★ {Float.round(vote_avg, 1)}</span>
                   <% end %>
-                  <% revenue =
-                    if Map.has_key?(credit.movie.tmdb_data || %{}, "revenue"),
-                      do: credit.movie.tmdb_data["revenue"],
-                      else: nil %>
+                  <% revenue = Map.get(@revenue_map, credit.movie_id) %>
                   <%= if revenue && revenue > 0 do %>
                     <span>${div(revenue, 1_000_000)}M</span>
                   <% end %>

--- a/lib/cinegraph_web/seo_helpers.ex
+++ b/lib/cinegraph_web/seo_helpers.ex
@@ -14,6 +14,7 @@ defmodule CinegraphWeb.SEOHelpers do
   """
 
   import Phoenix.Component, only: [assign: 3]
+  alias Cinegraph.Repo
   alias CinegraphWeb.SEO
 
   @site_url "https://cinegraph.org"
@@ -27,6 +28,12 @@ defmodule CinegraphWeb.SEOHelpers do
     title = movie_title(movie)
     description = movie_description(movie)
     image = movie_image_url(movie)
+
+    # #913 PR A pt 2: SEO.movie_schema/1 reads aggregateRating from
+    # :external_metrics and productionCompany from :production_companies, both
+    # of which need to be preloaded for the schema to populate (it now refuses
+    # to fall back to JSONB).
+    movie = Repo.replica().preload(movie, [:external_metrics, :production_companies])
 
     socket
     |> assign(:page_title, movie.title)

--- a/test/cinegraph/external_sources_test.exs
+++ b/test/cinegraph/external_sources_test.exs
@@ -64,6 +64,36 @@ defmodule Cinegraph.ExternalSourcesTest do
       assert length(rows) == 1
       assert hd(rows).metric_type == "rating_average"
     end
+
+    test "accepts a single source name as a binary filter" do
+      movie = insert_movie!()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "imdb",
+          metric_type: "rating_average",
+          value: 8.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "rating_average",
+          value: 7.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      [row] = ExternalSources.get_movie_ratings(movie.id, "imdb")
+      assert row.source.name == "imdb"
+      assert row.value == 8.0
+    end
   end
 
   describe "get_movie_metrics/2" do
@@ -144,6 +174,36 @@ defmodule Cinegraph.ExternalSourcesTest do
       ])
 
       [row] = ExternalSources.get_movie_metrics(movie.id, ["content_rating"], ["omdb"])
+      assert row.text_value == "PG-13"
+      assert row.source.name == "omdb"
+    end
+
+    test "accepts a single source name as a binary filter" do
+      movie = insert_movie!()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "omdb",
+          metric_type: "content_rating",
+          text_value: "PG-13",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "other_source",
+          metric_type: "content_rating",
+          text_value: "R",
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      [row] = ExternalSources.get_movie_metrics(movie.id, ["content_rating"], "omdb")
       assert row.text_value == "PG-13"
       assert row.source.name == "omdb"
     end

--- a/test/cinegraph/people_revenue_test.exs
+++ b/test/cinegraph/people_revenue_test.exs
@@ -2,7 +2,7 @@ defmodule Cinegraph.PeopleRevenueTest do
   use Cinegraph.DataCase, async: true
 
   alias Cinegraph.People
-  alias Cinegraph.Movies.{ExternalMetric, Movie}
+  alias Cinegraph.Movies.{Credit, ExternalMetric, Movie, Person}
 
   describe "revenue_map_for_movie_ids/1 (#913 PR A pt 2)" do
     test "sums revenue_worldwide rows from external_metrics into a movie_id => value map" do
@@ -112,6 +112,78 @@ defmodule Cinegraph.PeopleRevenueTest do
       assert result[movie.id] == 10_000_000
       assert map_size(result) == 1
     end
+
+    test "picks the latest fetched_at when multiple revenue_worldwide rows exist for a movie" do
+      # Regression guard for the Greptile finding on PR 919 — older bare
+      # `sum(em.value)` double-counted re-fetched movies. The DISTINCT ON path
+      # should keep only the newest row per movie.
+      movie = insert_movie!()
+
+      old = ~U[2024-01-01 00:00:00Z]
+      new = ~U[2025-06-01 00:00:00Z]
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 100_000_000.0,
+          fetched_at: old,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 175_000_000.0,
+          fetched_at: new,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      result = People.revenue_map_for_movie_ids([movie.id])
+      assert result[movie.id] == 175_000_000
+    end
+  end
+
+  describe "get_career_stats/1 total_revenue (#913 PR A pt 2 — regression guard)" do
+    test "does not double-count movies with multiple revenue_worldwide rows" do
+      person = insert_person!()
+      movie = insert_movie!()
+      insert_cast_credit!(person, movie)
+
+      old = ~U[2024-01-01 00:00:00Z]
+      new = ~U[2025-06-01 00:00:00Z]
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 100_000_000.0,
+          fetched_at: old,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 175_000_000.0,
+          fetched_at: new,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      stats = People.get_career_stats(person.id)
+      # Must be 175M (newest row), not 275M (sum of both rows).
+      assert stats.total_revenue == 175_000_000
+    end
   end
 
   defp insert_movie!(attrs \\ %{}) do
@@ -126,5 +198,33 @@ defmodule Cinegraph.PeopleRevenueTest do
       |> Repo.insert()
 
     movie
+  end
+
+  defp insert_person!(attrs \\ %{}) do
+    base = %{
+      tmdb_id: System.unique_integer([:positive]),
+      name: "Test Person #{System.unique_integer([:positive])}"
+    }
+
+    {:ok, person} =
+      %Person{}
+      |> Person.changeset(Map.merge(base, attrs))
+      |> Repo.insert()
+
+    person
+  end
+
+  defp insert_cast_credit!(person, movie) do
+    {:ok, credit} =
+      %Credit{}
+      |> Credit.changeset(%{
+        person_id: person.id,
+        movie_id: movie.id,
+        credit_type: "cast",
+        credit_id: "test-#{System.unique_integer([:positive])}"
+      })
+      |> Repo.insert()
+
+    credit
   end
 end

--- a/test/cinegraph/people_revenue_test.exs
+++ b/test/cinegraph/people_revenue_test.exs
@@ -1,0 +1,130 @@
+defmodule Cinegraph.PeopleRevenueTest do
+  use Cinegraph.DataCase, async: true
+
+  alias Cinegraph.People
+  alias Cinegraph.Movies.{ExternalMetric, Movie}
+
+  describe "revenue_map_for_movie_ids/1 (#913 PR A pt 2)" do
+    test "sums revenue_worldwide rows from external_metrics into a movie_id => value map" do
+      movie_a = insert_movie!()
+      movie_b = insert_movie!()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie_a.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 100_000_000.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie_b.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 250_000_000.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        # Different metric_type — must be ignored
+        %{
+          movie_id: movie_a.id,
+          source: "tmdb",
+          metric_type: "budget",
+          value: 50_000_000.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        # Different source — must be ignored
+        %{
+          movie_id: movie_a.id,
+          source: "omdb",
+          metric_type: "revenue_worldwide",
+          value: 999.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      result = People.revenue_map_for_movie_ids([movie_a.id, movie_b.id])
+
+      assert result[movie_a.id] == 100_000_000
+      assert result[movie_b.id] == 250_000_000
+    end
+
+    test "returns %{} for empty input" do
+      assert People.revenue_map_for_movie_ids([]) == %{}
+    end
+
+    test "returns %{} when no matching rows exist" do
+      movie = insert_movie!()
+      assert People.revenue_map_for_movie_ids([movie.id]) == %{}
+    end
+
+    test "omits movies with no revenue_worldwide row" do
+      movie_a = insert_movie!()
+      movie_b = insert_movie!()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie_a.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 42_000_000.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      result = People.revenue_map_for_movie_ids([movie_a.id, movie_b.id])
+
+      assert result[movie_a.id] == 42_000_000
+      refute Map.has_key?(result, movie_b.id)
+    end
+
+    test "deduplicates the input id list and ignores nils" do
+      movie = insert_movie!()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "revenue_worldwide",
+          value: 10_000_000.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      result = People.revenue_map_for_movie_ids([movie.id, nil, movie.id])
+      assert result[movie.id] == 10_000_000
+      assert map_size(result) == 1
+    end
+  end
+
+  defp insert_movie!(attrs \\ %{}) do
+    base = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: "Test Movie #{System.unique_integer([:positive])}"
+    }
+
+    {:ok, movie} =
+      %Movie{}
+      |> Movie.changeset(Map.merge(base, attrs))
+      |> Repo.insert()
+
+    movie
+  end
+end

--- a/test/cinegraph_web/components/rating_components_test.exs
+++ b/test/cinegraph_web/components/rating_components_test.exs
@@ -1,0 +1,162 @@
+defmodule CinegraphWeb.RatingComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias CinegraphWeb.RatingComponents
+
+  # `hero_ratings_row/1` calls into private `build_hero_ratings/1`, so testing
+  # the rendered component covers the migration from JSONB → external_ratings
+  # without exposing private functions.
+
+  describe "hero_ratings_row/1 (#913 PR A pt 2 — reads external_ratings only)" do
+    test "renders badges for imdb / tmdb / rotten_tomatoes / metacritic from external_ratings" do
+      movie = %{
+        imdb_id: "tt0111161",
+        tmdb_id: 278,
+        external_ratings: [
+          %{
+            metric_type: "rating_average",
+            value: 9.3,
+            metadata: %{},
+            source: %{name: "imdb", id: nil}
+          },
+          %{
+            metric_type: "rating_average",
+            value: 8.7,
+            metadata: %{},
+            source: %{name: "tmdb", id: nil}
+          },
+          %{
+            metric_type: "tomatometer",
+            value: 91.0,
+            metadata: %{},
+            source: %{name: "rotten_tomatoes", id: nil}
+          },
+          %{
+            metric_type: "metascore",
+            value: 82.0,
+            metadata: %{},
+            source: %{name: "metacritic", id: nil}
+          }
+        ]
+      }
+
+      html = render_component(&RatingComponents.hero_ratings_row/1, movie: movie)
+
+      # IMDb URL is derived from imdb_id, not omdb_data
+      assert html =~ "https://www.imdb.com/title/tt0111161/"
+      # TMDb URL is derived from tmdb_id
+      assert html =~ "https://www.themoviedb.org/movie/278"
+      # Each source's name appears in the hover popover
+      assert html =~ "IMDb"
+      assert html =~ "TMDb"
+      assert html =~ "Tomatometer"
+      assert html =~ "Metacritic"
+    end
+
+    test "returns empty output when external_ratings is empty" do
+      movie = %{imdb_id: nil, tmdb_id: nil, external_ratings: []}
+      html = render_component(&RatingComponents.hero_ratings_row/1, movie: movie)
+      # The component returns "" when there are no ratings → no badge markup
+      refute html =~ "inline-flex"
+    end
+
+    test "rejects zero values" do
+      movie = %{
+        imdb_id: nil,
+        tmdb_id: 1,
+        external_ratings: [
+          %{
+            metric_type: "rating_average",
+            value: 0.0,
+            metadata: %{},
+            source: %{name: "tmdb", id: nil}
+          },
+          %{
+            metric_type: "rating_average",
+            value: 7.5,
+            metadata: %{},
+            source: %{name: "imdb", id: nil}
+          }
+        ]
+      }
+
+      html = render_component(&RatingComponents.hero_ratings_row/1, movie: movie)
+
+      # IMDb at 7.5 renders
+      assert html =~ "7.5/10"
+      # TMDb at 0.0 is rejected — its hover popover should not appear
+      # (look for the TMDb name in popover, which only shows when rendered)
+      refute html =~ ~s(<span class="font-bold text-sm">TMDb</span>)
+    end
+
+    test "is resilient when movie has no external_ratings key at all" do
+      movie = %{imdb_id: nil, tmdb_id: nil}
+      html = render_component(&RatingComponents.hero_ratings_row/1, movie: movie)
+      refute html =~ "inline-flex"
+    end
+
+    test "deduplicates by source when multiple metrics share a source name" do
+      # If external_ratings had two rows for the same source (e.g., a duplicate
+      # rating_votes / rating_average pair both normalizing to "imdb"), only
+      # one badge should render.
+      movie = %{
+        imdb_id: "tt0000001",
+        tmdb_id: nil,
+        external_ratings: [
+          %{
+            metric_type: "rating_average",
+            value: 8.0,
+            metadata: %{},
+            source: %{name: "imdb", id: nil}
+          },
+          %{
+            metric_type: "rating_average",
+            value: 9.0,
+            metadata: %{},
+            source: %{name: "imdb", id: nil}
+          }
+        ]
+      }
+
+      html = render_component(&RatingComponents.hero_ratings_row/1, movie: movie)
+      # Count occurrences of the IMDb URL — should appear once per badge
+      occurrences =
+        html
+        |> String.split("https://www.imdb.com/title/tt0000001/")
+        |> length()
+        |> Kernel.-(1)
+
+      assert occurrences == 1
+    end
+
+    test "keeps Rotten Tomatoes audience score separate from tomatometer for raw source names" do
+      movie = %{
+        imdb_id: nil,
+        tmdb_id: nil,
+        external_ratings: [
+          %{
+            metric_type: "tomatometer",
+            value: 91.0,
+            metadata: %{},
+            source: %{name: "Rotten Tomatoes", id: nil}
+          },
+          %{
+            metric_type: "audience_score",
+            value: 88.0,
+            metadata: %{},
+            source: %{name: "Rotten Tomatoes", id: nil}
+          }
+        ]
+      }
+
+      html = render_component(&RatingComponents.hero_ratings_row/1, movie: movie)
+
+      assert html =~ "Tomatometer"
+      assert html =~ "Audience Score"
+      assert html =~ "91%"
+      assert html =~ "88%"
+    end
+  end
+end

--- a/test/cinegraph_web/components/seo_test.exs
+++ b/test/cinegraph_web/components/seo_test.exs
@@ -118,4 +118,127 @@ defmodule CinegraphWeb.SEOTest do
       refute html =~ ~S|property="og:image:height"|
     end
   end
+
+  describe "movie_schema/1 (#913 PR A pt 2 — reads external_metrics, not JSONB)" do
+    test "populates aggregateRating from external_metrics" do
+      movie = %{
+        id: 1,
+        title: "Test Movie",
+        slug: "test-movie",
+        original_title: "Test Movie",
+        overview: nil,
+        release_date: nil,
+        runtime: nil,
+        poster_path: nil,
+        original_language: nil,
+        imdb_id: nil,
+        tmdb_id: nil,
+        origin_country: nil,
+        external_metrics: [
+          %{source: "tmdb", metric_type: "rating_average", value: 8.456},
+          %{source: "tmdb", metric_type: "rating_votes", value: 12_345.0}
+        ],
+        production_companies: []
+      }
+
+      schema = SEO.movie_schema(movie)
+
+      assert schema["aggregateRating"]["@type"] == "AggregateRating"
+      # Float.round to 1 decimal place
+      assert schema["aggregateRating"]["ratingValue"] == 8.5
+      # trunc on float
+      assert schema["aggregateRating"]["ratingCount"] == 12_345
+      assert schema["aggregateRating"]["bestRating"] == 10
+    end
+
+    test "omits aggregateRating when external_metrics is empty" do
+      movie = %{
+        id: 1,
+        title: "Test Movie",
+        slug: "test-movie",
+        original_title: "Test Movie",
+        overview: nil,
+        release_date: nil,
+        runtime: nil,
+        poster_path: nil,
+        original_language: nil,
+        imdb_id: nil,
+        tmdb_id: nil,
+        origin_country: nil,
+        external_metrics: [],
+        production_companies: []
+      }
+
+      refute Map.has_key?(SEO.movie_schema(movie), "aggregateRating")
+    end
+
+    test "omits aggregateRating when rating_average is missing" do
+      movie = %{
+        id: 1,
+        title: "Test Movie",
+        slug: "test-movie",
+        original_title: "Test Movie",
+        overview: nil,
+        release_date: nil,
+        runtime: nil,
+        poster_path: nil,
+        original_language: nil,
+        imdb_id: nil,
+        tmdb_id: nil,
+        origin_country: nil,
+        # rating_votes alone is not enough
+        external_metrics: [%{source: "tmdb", metric_type: "rating_votes", value: 12_345.0}],
+        production_companies: []
+      }
+
+      refute Map.has_key?(SEO.movie_schema(movie), "aggregateRating")
+    end
+
+    test "populates productionCompany from production_companies association" do
+      movie = %{
+        id: 1,
+        title: "Test Movie",
+        slug: "test-movie",
+        original_title: "Test Movie",
+        overview: nil,
+        release_date: nil,
+        runtime: nil,
+        poster_path: nil,
+        original_language: nil,
+        imdb_id: nil,
+        tmdb_id: nil,
+        origin_country: nil,
+        external_metrics: [],
+        production_companies: [
+          %{name: "A24"},
+          %{name: "Plan B Entertainment"}
+        ]
+      }
+
+      schema = SEO.movie_schema(movie)
+      assert schema["productionCompany"]["@type"] == "Organization"
+      assert schema["productionCompany"]["name"] == "A24"
+    end
+
+    test "omits productionCompany when association is empty" do
+      movie = %{
+        id: 1,
+        title: "Test Movie",
+        slug: "test-movie",
+        original_title: "Test Movie",
+        overview: nil,
+        release_date: nil,
+        runtime: nil,
+        poster_path: nil,
+        original_language: nil,
+        imdb_id: nil,
+        tmdb_id: nil,
+        origin_country: nil,
+        external_metrics: [],
+        production_companies: []
+      }
+
+      refute Map.has_key?(SEO.movie_schema(movie), "productionCompany")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Finishes #913 PR A by porting every BEAM-side read of `tmdb_data` / `omdb_data` to `external_metrics` across web layer, People context, and calibration
- 11 source files migrated, 3 test files added/extended
- Greppable invariant (zero `(tmdb|omdb)_data[...]` reads in scope) is **green** modulo one explanatory code comment

## Files changed
- `lib/cinegraph/calibration/recall_calculator.ex` — genre gaps via `movie_genres` join
- `lib/cinegraph_web/components/seo.ex` + `seo_helpers.ex` — `movie_schema` aggregateRating + productionCompany from preloaded associations
- `lib/cinegraph/people.ex` — `calculate_total_revenue` single query; new `revenue_map_for_movie_ids/1`; 4 `normalize_revenue` clauses deleted
- `lib/cinegraph_web/live/person_live/show{,_legacy}.{ex,html.heex}` — preload `@revenue_map`
- `lib/cinegraph_web/live/director_live/show.ex` — `revenue_map` threaded through stats helpers
- `lib/cinegraph_web/components/rating_components.ex` — `build_hero_ratings` reads only `external_ratings`; `find_omdb_rating` + `parse_rt_value` removed
- `lib/cinegraph_web/live/movie_live/show.{ex,html.heex}` — preload `:metrics`, delegate Rated/Awards rendering to V2 `Presentation` helpers

## Test plan
- [ ] CI green on Elixir 1.19
- [ ] Visual diff: `/movies/:slug` (V2), `/movies/:id/legacy`, `/people/:slug`, `/people/:id/legacy`, `/directors/:id` on 3-5 records each
  - Ratings strip (IMDb / TMDb / Metacritic / RT badges with URLs)
  - Person credit revenue column still renders
  - Director total revenue / highest-grossing year / avg-rating per genre populate
  - SEO JSON-LD `aggregateRating` + `productionCompany` match pre-PR output
- [ ] Run greppable invariant locally: `grep -rnE '(tmdb|omdb)_data\[|get_in.*[ot]mdb_data|\.(tmdb|omdb)_data\b|movie\.(tmdb|omdb)_data' lib/cinegraph_web/ lib/cinegraph/people.ex lib/cinegraph/calibration/ | grep -v lib/cinegraph_web/live/metrics_live/`

Refs #913, follow-on to #918 (PR A pt 1) and #917 (Session 1 backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new metrics API for flexible filtering by metric type and source.
  * Introduced cached revenue lookups for improved performance in director and person profiles.

* **Bug Fixes**
  * Revenue calculations now use external data sources instead of legacy TMDB fallback, improving accuracy.
  * Genre analysis now consistently queries from production database.
  * Content ratings and awards data properly sourced from external metrics across all views.

* **Refactor**
  * Standardized rating and metric retrieval with consistent source filtering.
  * Consolidated data loading in director/person profiles using preloaded associations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/919)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->