### PR TITLE
Drop tmdb_data/omdb_data from list-query result rows (#913 PR B)

### DIFF
--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -37,10 +37,23 @@ defmodule Cinegraph.Movies do
   hiding otherwise valid films.
   """
   def feature_film_query do
-    from m in Movie,
+    from(m in Movie,
       where: m.adult == false,
       where: m.import_status == "full",
       where: m.runtime > 45 or is_nil(m.runtime)
+    )
+    |> exclude_jsonb_blobs()
+  end
+
+  # #913 PR B: nil the two giant JSONB columns out of `Movie`-rooted list-query
+  # result rows so the BEAM stops loading multi-MB blobs per row under traffic.
+  # Schema unchanged — only the read projection changes. PR A (#918 + #919)
+  # already migrated every display read off these fields, so this is a no-op
+  # for the UI. `select_merge` on a struct overlay preserves preloads + joins
+  # and only overwrites the two named fields.
+  @doc false
+  def exclude_jsonb_blobs(query) do
+    from(m in query, select_merge: %{m | tmdb_data: nil, omdb_data: nil})
   end
 
   @doc """
@@ -94,6 +107,7 @@ defmodule Cinegraph.Movies do
 
     query
     |> Filters.apply_sorting(params)
+    |> exclude_jsonb_blobs()
     |> paginate(params)
   end
 
@@ -197,6 +211,7 @@ defmodule Cinegraph.Movies do
       order_by: ^[asc_nulls_last: position, asc: :release_date, asc: :title],
       limit: ^limit
     )
+    |> exclude_jsonb_blobs()
     |> Repo.replica().all()
   end
 
@@ -208,6 +223,7 @@ defmodule Cinegraph.Movies do
     Movie
     |> where([m], m.import_status == "soft")
     |> apply_sorting(params)
+    |> exclude_jsonb_blobs()
     |> paginate(params)
   end
 

--- a/lib/cinegraph/movies/discovery_rankings.ex
+++ b/lib/cinegraph/movies/discovery_rankings.ex
@@ -77,6 +77,7 @@ defmodule Cinegraph.Movies.DiscoveryRankings do
       )
       |> limit(^per_page)
       |> offset(^offset)
+      |> select_merge([m, _r], %{m | tmdb_data: nil, omdb_data: nil})
       |> Repo.replica().all()
 
     total_count = count_default()

--- a/lib/cinegraph/movies/search.ex
+++ b/lib/cinegraph/movies/search.ex
@@ -181,6 +181,11 @@ defmodule Cinegraph.Movies.Search do
         filtered_query
       end
 
+    # #913 PR B: drop the JSONB blobs from result rows so list traffic stops
+    # blowing the BEAM heap. PR A (#918 + #919) already moved every display
+    # read to external_metrics, so nilling these is a no-op for the UI.
+    sorted_query = Cinegraph.Movies.exclude_jsonb_blobs(sorted_query)
+
     # Convert params to Flop format
     flop_params = Params.to_flop_params(validated_params)
 
@@ -399,6 +404,9 @@ defmodule Cinegraph.Movies.Search do
     |> offset(^offset)
     |> select([sc, m], m)
     |> select_merge([sc, _m], %{
+      # #913 PR B: nil the JSONB blobs from the row projection.
+      tmdb_data: nil,
+      omdb_data: nil,
       overall_score: sc.overall_score,
       raw_cinegraph_score: sc.overall_score,
       score_confidence: sc.score_confidence,
@@ -469,6 +477,9 @@ defmodule Cinegraph.Movies.Search do
     |> offset(^offset)
     |> select([m, sc], m)
     |> select_merge([_m, sc], %{
+      # #913 PR B: nil the JSONB blobs from the row projection.
+      tmdb_data: nil,
+      omdb_data: nil,
       overall_score: nil,
       raw_cinegraph_score: sc.overall_score,
       cinegraph_display_score: nil,

--- a/test/cinegraph/movies/jsonb_exclusion_test.exs
+++ b/test/cinegraph/movies/jsonb_exclusion_test.exs
@@ -1,0 +1,142 @@
+defmodule Cinegraph.Movies.JsonbExclusionTest do
+  @moduledoc """
+  #913 PR B regression guards: every list-query leaf that returns `%Movie{}`
+  structs must nil out `tmdb_data` and `omdb_data` on the result projection.
+  Multi-MB JSONB blobs loaded into the BEAM heap were the OOM driver.
+
+  PR A (#918, #919) already moved every display read off these fields, so
+  nilling them on list results is a no-op for the UI.
+  """
+
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Movies
+  alias Cinegraph.Movies.{DiscoveryRankings, Movie}
+  alias Cinegraph.Movies.Query.Params
+
+  describe "Movies list-query JSONB exclusion (#913 PR B)" do
+    test "list_movies/1 returns Movie structs with tmdb_data and omdb_data nilled" do
+      insert_movie_with_blobs!("List Movies Blob")
+
+      [movie | _] = Movies.list_movies()
+
+      assert %Movie{} = movie
+      assert movie.tmdb_data == nil
+      assert movie.omdb_data == nil
+      # First-class columns must still be populated.
+      assert is_binary(movie.title)
+      assert is_integer(movie.tmdb_id)
+    end
+
+    test "recent_theatrical_releases/1 inherits the slim projection from feature_film_query/0" do
+      today = Date.utc_today()
+
+      insert_movie_with_blobs!("Recent Theatrical Blob",
+        release_date: Date.add(today, -7)
+      )
+
+      movies = Movies.recent_theatrical_releases(today: today, days: 30, limit: 5)
+
+      assert length(movies) > 0
+
+      for movie <- movies do
+        assert %Movie{} = movie
+        assert movie.tmdb_data == nil
+        assert movie.omdb_data == nil
+      end
+    end
+
+    test "list_canonical_shelf_movies/2 nils JSONB on shelf results" do
+      key = "test_shelf_#{System.unique_integer([:positive])}"
+
+      insert_movie_with_blobs!("Canonical Shelf Blob",
+        canonical_sources: %{key => %{"list_position" => "1"}}
+      )
+
+      [movie | _] = Movies.list_canonical_shelf_movies(key, 5)
+
+      assert %Movie{} = movie
+      assert movie.tmdb_data == nil
+      assert movie.omdb_data == nil
+    end
+
+    test "list_soft_imports/1 nils JSONB on soft-import results" do
+      insert_movie_with_blobs!("Soft Import Blob", import_status: "soft")
+
+      [movie | _] = Movies.list_soft_imports()
+
+      assert %Movie{} = movie
+      assert movie.tmdb_data == nil
+      assert movie.omdb_data == nil
+    end
+
+    test "feature_film_query/0 base inheritance — composed queries inherit the slim projection" do
+      import Ecto.Query
+
+      insert_movie_with_blobs!("Feature Film Inheritance Blob")
+
+      # Compose a custom query on top of feature_film_query/0 — the
+      # select_merge baked into the base must carry forward.
+      movies =
+        Movies.feature_film_query()
+        |> limit(5)
+        |> Cinegraph.Repo.all()
+
+      assert length(movies) > 0
+
+      for movie <- movies do
+        assert %Movie{} = movie
+        assert movie.tmdb_data == nil
+        assert movie.omdb_data == nil
+      end
+    end
+  end
+
+  describe "DiscoveryRankings.list_default/1 JSONB exclusion (#913 PR B — hottest path)" do
+    @describetag :skip
+    # Requires `movie_discovery_rankings_mv` to be populated; covered by the
+    # integration suite. Local CI runs against an empty MV. The `select_merge`
+    # is also exercised structurally by the parse + compile checks.
+    test "result rows have tmdb_data and omdb_data nilled" do
+      insert_movie_with_blobs!("Discovery Default Blob")
+
+      params = %Params{sort: "discovery_score_desc"}
+      {:ok, {movies, _meta}} = DiscoveryRankings.list_default(params)
+
+      assert length(movies) > 0
+
+      for movie <- movies do
+        assert %Movie{} = movie
+        assert movie.tmdb_data == nil
+        assert movie.omdb_data == nil
+      end
+    end
+  end
+
+  # Helpers — keep self-contained so the file isn't coupled to other test
+  # fixtures. The JSONB blobs we insert are sentinel maps that prove the
+  # select_merge nilled the column (not that the column was empty to begin
+  # with).
+  defp insert_movie_with_blobs!(title, attrs \\ []) do
+    base = %{
+      tmdb_id: System.unique_integer([:positive]),
+      title: title,
+      original_title: title,
+      release_date: ~D[2024-01-01],
+      tmdb_data: %{"vote_average" => 7.5, "marker" => "pr-b-must-be-nilled"},
+      omdb_data: %{"imdbRating" => "8.0", "marker" => "pr-b-must-be-nilled"},
+      import_status: Keyword.get(attrs, :import_status, "full"),
+      adult: false,
+      runtime: 120
+    }
+
+    attrs_map =
+      attrs
+      |> Keyword.drop([:import_status])
+      |> Enum.into(%{})
+
+    %Movie{}
+    |> Movie.changeset(Map.merge(base, attrs_map))
+    |> Repo.insert!()
+  end
+end

--- a/test/cinegraph/movies/jsonb_exclusion_test.exs
+++ b/test/cinegraph/movies/jsonb_exclusion_test.exs
@@ -93,23 +93,64 @@ defmodule Cinegraph.Movies.JsonbExclusionTest do
   end
 
   describe "DiscoveryRankings.list_default/1 JSONB exclusion (#913 PR B — hottest path)" do
-    @describetag :skip
-    # Requires `movie_discovery_rankings_mv` to be populated; covered by the
-    # integration suite. Local CI runs against an empty MV. The `select_merge`
-    # is also exercised structurally by the parse + compile checks.
-    test "result rows have tmdb_data and omdb_data nilled" do
-      insert_movie_with_blobs!("Discovery Default Blob")
+    # The MV is created empty by migration and refreshed by an Oban worker in
+    # prod. In tests we refresh inline (non-concurrently) so the MV picks up
+    # the row we just inserted. Non-concurrent REFRESH runs inside the sandbox
+    # transaction and rolls back with it — no cross-test pollution.
+    test "result rows have tmdb_data and omdb_data nilled (regression guard for the OOM path)" do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-      params = %Params{sort: "discovery_score_desc"}
-      {:ok, {movies, _meta}} = DiscoveryRankings.list_default(params)
+      movie =
+        insert_movie_with_blobs!("Discovery Default Blob",
+          # release_date must be ≤ CURRENT_DATE so the MV's is_released = true.
+          release_date: ~D[2024-01-01]
+        )
 
-      assert length(movies) > 0
+      # The MV's metric_pivot CTE looks for source="tmdb" rows at these three
+      # metric_types. Seed one so the movie has a non-NULL discovery score
+      # and rises above any stale rows that may exist in the shared schema.
+      Repo.insert_all(Cinegraph.Movies.ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "rating_votes",
+          value: 50_000.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "rating_average",
+          value: 8.5,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        },
+        %{
+          movie_id: movie.id,
+          source: "tmdb",
+          metric_type: "popularity_score",
+          value: 250.0,
+          fetched_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
 
-      for movie <- movies do
-        assert %Movie{} = movie
-        assert movie.tmdb_data == nil
-        assert movie.omdb_data == nil
-      end
+      Ecto.Adapters.SQL.query!(Repo, "REFRESH MATERIALIZED VIEW movie_discovery_rankings_mv")
+
+      params = %Params{sort: "discovery_score_desc", per_page: 50}
+      assert {:ok, {movies, _meta}} = DiscoveryRankings.list_default(params)
+
+      hit = Enum.find(movies, &(&1.id == movie.id))
+      assert hit, "inserted movie should appear in the default browse path"
+
+      assert %Movie{} = hit
+      assert hit.tmdb_data == nil
+      assert hit.omdb_data == nil
+      assert hit.title == "Discovery Default Blob"
     end
   end
 

--- a/test/cinegraph/movies/search_test.exs
+++ b/test/cinegraph/movies/search_test.exs
@@ -761,4 +761,37 @@ defmodule Cinegraph.Movies.SearchTest do
   end
 
   defp movie_titles(movies), do: Enum.map(movies, & &1.title)
+
+  describe "JSONB exclusion (#913 PR B)" do
+    test "search_movies/1 (Flop path) returns Movie structs with JSONB blobs nilled" do
+      movie =
+        %Movie{}
+        |> Movie.changeset(%{
+          tmdb_id: System.unique_integer([:positive]),
+          title: "Flop Path Blob Movie",
+          original_title: "Flop Path Blob Movie",
+          release_date: ~D[2024-01-01],
+          import_status: "full",
+          adult: false,
+          runtime: 120,
+          tmdb_data: %{"vote_average" => 7.5, "marker" => "pr-b-must-be-nilled"},
+          omdb_data: %{"imdbRating" => "8.0", "marker" => "pr-b-must-be-nilled"}
+        })
+        |> Repo.insert!()
+
+      # Force the generic query path (not the DiscoveryRankings shortcut) with
+      # a non-default sort. Flop's validate_and_run must preserve the
+      # select_merge baked in by Cinegraph.Movies.exclude_jsonb_blobs/1.
+      assert {:ok, {movies, _meta}} =
+               Search.search_movies(%{"sort" => "title_asc", "per_page" => "10"})
+
+      assert Enum.any?(movies, &(&1.id == movie.id))
+
+      for m <- movies do
+        assert %Movie{} = m
+        assert m.tmdb_data == nil
+        assert m.omdb_data == nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes the OOM driver from #913. Under traffic on 2026-05-15, ~65 slow movies-index queries/min × multi-MB JSONB blobs per row blew the BEAM heap past the Docker Desktop VM cap in ~25 seconds. The mechanism is `select_merge: %{m | tmdb_data: nil, omdb_data: nil}` on the hot list queries — schema unchanged, the two fields just arrive as `nil` on results.

Safe because **PR A (#918 + #919) is merged** and already migrated every display read off `tmdb_data` / `omdb_data` to `external_metrics`. Audit of non-display callers found none on the PR B target paths.

## Files changed

| File | Change |
|---|---|
| `lib/cinegraph/movies.ex` | New private helper `exclude_jsonb_blobs/1`; baked into `feature_film_query/0` (auto-cascades to `recent_theatrical_releases/1` + 7 homepage callers); explicit in `list_movies/1`, `list_canonical_shelf_movies/2`, `list_soft_imports/1` |
| `lib/cinegraph/movies/discovery_rankings.ex` | `list_default/1` (the hottest path on `/movies` V2) — inline `select_merge([m, _r], %{m \| tmdb_data: nil, omdb_data: nil})` |
| `lib/cinegraph/movies/search.ex` | `search_movies_generic_query/1` pipes through the helper before Flop; `fetch_plain_score_sort_{scoreable,insufficient}` add the two keys directly to their existing select_merge maps (first binding is `MovieScoreCache`, not `Movie`) |

## Explicitly out of scope (per #913 audit)

- `quick_search/2` — already slim
- `get_movie!` / `get_movie_by_slug!` — single-row loads, not hot path
- `lib/cinegraph/predictions/*` — runs its own queries that intentionally need `tmdb_data`; pre-existing tech debt
- Admin metrics with `m.tmdb_data->>'X'` SQL fragments — Postgres-side, never loads JSONB to BEAM

## Test plan

- [ ] CI green
- [ ] Local sanity in iex against dev DB:
  ```elixir
  movie = Cinegraph.Movies.list_movies() |> elem(0) |> hd()
  # tmdb_data and omdb_data must be nil; all other fields populated
  ```
  Repeat for `recent_theatrical_releases/1`, `list_canonical_shelf_movies/2`, `list_soft_imports/1`, `DiscoveryRankings.list_default/1`, `Search.search_movies/1`.
- [ ] Visual diff `/movies` V2 + each preset sort (cinegraph_editorial, critics_choice, crowd_pleaser, award_season, hidden_gems) — all return results, cards render with title / poster / rating, no 500s
- [ ] Visual diff `/movies/:slug` (V2) for a high-data movie — ratings strip, content rating, awards summary all populate (PR A acceptance carryover)
- [ ] Replica slow-query log post-deploy no longer shows `SELECT m0."tmdb_data"...` truncations on the movies-index pattern

## 24h observation window (closes #913)

The hard gates per the issue body. Capture at +0h, +6h, +12h, +24h:

```bash
# RestartCount (delta = 0)
ssh holden@192.168.1.205 "docker inspect --format '{{.RestartCount}}' \$(docker ps -q --filter name=cinegraph-web)"

# BEAM total memory (peak < 4 GiB)
ssh holden@192.168.1.205 "docker exec <id> /app/bin/cinegraph rpc ':erlang.memory(:total)'"

# Slow query rate per minute (target ≤13/min, was ~65/min)
ssh holden@192.168.1.205 "docker logs --since 60m <id> 2>&1 | grep -c '\[Repo.Replica\] Slow query'"
```

Post each checkpoint as a comment on #913. Close at +24h if all three gates green.

## Rollback

Pure code revert + `kamal deploy`. No data migration to undo.

Refs #913, follow-on to #918 (PR A pt 1) and #919 (PR A pt 2). Together these three PRs close #913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced payload size for movie listing and discovery responses by excluding large embedded JSON fields from returned movie records, improving list/query performance and bandwidth.

* **Tests**
  * Added tests that verify the JSON-field exclusion across list, search, discovery and related browse paths to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/920)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->