### PR TITLE
Bump Erlang OTP from 28.0.1 → 28.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.19.0-otp-28
-erlang 28.0.1
+erlang 28.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
 #   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20260421-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.19.0-erlang-28.0.1-debian-bullseye-20260421-slim
+#   - Ex: hexpm/elixir:1.19.0-erlang-28.1-debian-bullseye-20260421-slim
 #
 ARG ELIXIR_VERSION=1.19.0
-ARG OTP_VERSION=28.0.1
+ARG OTP_VERSION=28.1
 ARG DEBIAN_VERSION=bullseye-20260421-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"


### PR DESCRIPTION
## Summary

Silences the boot-time warning Elixir 1.19 emits on Erlang 28.0:

```
warning! Erlang/OTP 28.0 detected.
Regexes will be re-compiled from source at runtime, which will cause
degraded performance. This can be fixed by using Erlang OTP 28.1+ or 27-.
```

## Changes (3 lines)

- `.tool-versions` — `erlang 28.0.1` → `erlang 28.1` (local dev via mise / asdf)
- `Dockerfile` — `ARG OTP_VERSION=28.0.1` → `ARG OTP_VERSION=28.1` + example comment (Kamal-built image)

## Verified locally

- `mise install` picks up 28.1 from `.tool-versions` cleanly
- `mix compile` / `mix phx.server` boot with no regex warning
- `hexpm/elixir:1.19.0-erlang-28.1-debian-bullseye-20260421-slim` confirmed available on Docker Hub

## Test plan

- [ ] CI green
- [ ] After merge, next Kamal deploy uses the 28.1 image — boot log clean of the regex warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Erlang version to 28.1 for runtime and build environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/921)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->