### PR TITLE
Silence "no route path" warnings from dev-only demo templates

### DIFF
--- a/lib/cinegraph_web/controllers/design_preview_html/show_v2.html.heex
+++ b/lib/cinegraph_web/controllers/design_preview_html/show_v2.html.heex
@@ -215,7 +215,7 @@
 
     <%!-- v1 ↔ v2 toggle pill --%>
     <a
-      href={~p"/design-preview"}
+      href="/design-preview"
       class="fixed bottom-4 right-4 z-50 inline-flex items-center gap-2 rounded-full bg-mist-950 px-4 py-2 text-xs font-medium text-mist-100 shadow-lg hover:bg-mist-800"
     >
       ← see v1 (cg tokens)

--- a/lib/cinegraph_web/controllers/oatmeal_demo_html/about.html.heex
+++ b/lib/cinegraph_web/controllers/oatmeal_demo_html/about.html.heex
@@ -17,14 +17,14 @@
     <header class="sticky top-0 z-10 bg-mist-100">
       <nav class="mx-auto flex h-[5.25rem] max-w-7xl items-center gap-4 px-6 lg:px-10">
         <div class="flex flex-1 gap-8 max-lg:hidden">
-          <a href={~p"/oatmeal-demo/pricing"} class="text-sm/7 font-medium text-mist-950">
+          <a href="/oatmeal-demo/pricing" class="text-sm/7 font-medium text-mist-950">
             Pricing
           </a>
-          <a href={~p"/oatmeal-demo/about"} class="text-sm/7 font-medium text-mist-950">About</a>
+          <a href="/oatmeal-demo/about" class="text-sm/7 font-medium text-mist-950">About</a>
           <a href="#" class="text-sm/7 font-medium text-mist-950">Docs</a>
         </div>
         <div class="flex items-center">
-          <a href={~p"/oatmeal-demo"} class="font-display text-2xl text-mist-950 italic">
+          <a href="/oatmeal-demo" class="font-display text-2xl text-mist-950 italic">
             Oatmeal
           </a>
         </div>
@@ -185,13 +185,13 @@
           </div>
           <div class="flex items-center gap-4">
             <a
-              href={~p"/oatmeal-demo"}
+              href="/oatmeal-demo"
               class="inline-flex shrink-0 items-center justify-center gap-1 rounded-full bg-mist-950 px-4 py-2 text-sm/7 font-medium text-mist-100 hover:bg-mist-800"
             >
               ← Back to home
             </a>
             <a
-              href={~p"/oatmeal-demo/pricing"}
+              href="/oatmeal-demo/pricing"
               class="inline-flex shrink-0 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm/7 font-medium text-mist-950 hover:bg-mist-950/10"
             >
               See pricing →

--- a/lib/cinegraph_web/controllers/oatmeal_demo_html/error_404.html.heex
+++ b/lib/cinegraph_web/controllers/oatmeal_demo_html/error_404.html.heex
@@ -26,13 +26,13 @@
         </p>
         <div class="flex items-center gap-4">
           <a
-            href={~p"/oatmeal-demo"}
+            href="/oatmeal-demo"
             class="inline-flex shrink-0 items-center justify-center gap-1 rounded-full bg-mist-950 px-4 py-2 text-sm/7 font-medium text-mist-100 hover:bg-mist-800"
           >
             ← Take me home
           </a>
           <a
-            href={~p"/oatmeal-demo/pricing"}
+            href="/oatmeal-demo/pricing"
             class="inline-flex shrink-0 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm/7 font-medium text-mist-950 hover:bg-mist-950/10"
           >
             See pricing

--- a/lib/cinegraph_web/controllers/oatmeal_demo_html/home.html.heex
+++ b/lib/cinegraph_web/controllers/oatmeal_demo_html/home.html.heex
@@ -878,7 +878,7 @@
     </footer>
 
     <a
-      href={~p"/oatmeal-demo/about"}
+      href="/oatmeal-demo/about"
       class="fixed bottom-4 right-4 z-50 inline-flex items-center gap-2 rounded-full bg-mist-950 px-4 py-2 text-xs font-medium text-mist-100 shadow-lg hover:bg-mist-800"
     >
       ← see about page →

--- a/lib/cinegraph_web/controllers/oatmeal_demo_html/pricing.html.heex
+++ b/lib/cinegraph_web/controllers/oatmeal_demo_html/pricing.html.heex
@@ -17,14 +17,14 @@
     <header class="sticky top-0 z-10 bg-mist-100">
       <nav class="mx-auto flex h-[5.25rem] max-w-7xl items-center gap-4 px-6 lg:px-10">
         <div class="flex flex-1 gap-8 max-lg:hidden">
-          <a href={~p"/oatmeal-demo/pricing"} class="text-sm/7 font-medium text-mist-950">
+          <a href="/oatmeal-demo/pricing" class="text-sm/7 font-medium text-mist-950">
             Pricing
           </a>
-          <a href={~p"/oatmeal-demo/about"} class="text-sm/7 font-medium text-mist-950">About</a>
+          <a href="/oatmeal-demo/about" class="text-sm/7 font-medium text-mist-950">About</a>
           <a href="#" class="text-sm/7 font-medium text-mist-950">Docs</a>
         </div>
         <div class="flex items-center">
-          <a href={~p"/oatmeal-demo"} class="font-display text-2xl text-mist-950 italic">
+          <a href="/oatmeal-demo" class="font-display text-2xl text-mist-950 italic">
             Oatmeal
           </a>
         </div>


### PR DESCRIPTION
## Summary

Every prod build (incl. \`kamal deploy\`'s \`mix compile\` / \`mix assets.deploy\` / \`mix release\` steps) emits 12+ repeated warnings:

```
warning: no route path for CinegraphWeb.Router matches "/oatmeal-demo"
warning: no route path for CinegraphWeb.Router matches "/oatmeal-demo/about"
warning: no route path for CinegraphWeb.Router matches "/oatmeal-demo/pricing"
warning: no route path for CinegraphWeb.Router matches "/design-preview"
```

## Root cause

The routes live behind \`if Mix.env() != :prod\` in \`router.ex:45-53\`. Production builds (\`MIX_ENV=prod\`) compile with those routes absent — but the demo templates reference them via verified-routes \`~p"/oatmeal-demo"\`, which checks the route table at compile time.

## Fix

12 occurrences across 5 demo-only templates: swap \`href={~p\"/path\"}\` → \`href=\"/path\"\`. The routes still exist in dev (so the demo pages still work for design preview); plain strings skip the verified-routes lookup so prod compiles clean.

Trade-off: lose verified-routes typo detection in these templates. Acceptable for dead-end demo pages that don't share links with the rest of the app.

## Files touched

- \`lib/cinegraph_web/controllers/oatmeal_demo_html/about.html.heex\`
- \`lib/cinegraph_web/controllers/oatmeal_demo_html/pricing.html.heex\`
- \`lib/cinegraph_web/controllers/oatmeal_demo_html/error_404.html.heex\`
- \`lib/cinegraph_web/controllers/oatmeal_demo_html/home.html.heex\`
- \`lib/cinegraph_web/controllers/design_preview_html/show_v2.html.heex\`

## Test plan

- [x] Local \`MIX_ENV=prod mix compile --force\` no longer surfaces any \`/oatmeal-demo\` or \`/design-preview\` route warnings
- [ ] CI green
- [ ] Next \`kamal deploy\` builds clean (3 fewer pages of repeated warnings in \`mix compile\` / \`mix assets.deploy\` / \`mix release\` stages)

## Out of scope

- \`sweet_xml\` typing warning at \`lib/sweet_xml.ex:246\` — comes from a dependency, not our code. Wait for upstream fix.
- \`Failed to lookup telemetry handlers\` during \`appsignal\` install — happens during \`mix deps.compile\` build-time only; harmless, telemetry starts normally at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal routing implementation across multiple pages to use simplified path references instead of route helper expressions. No visible changes to end-user functionality or navigation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/922)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->