### PR TITLE
Fix OMDb/TMDb skip-when-enriched fail-open (#924 re-audit P1)

### DIFF
--- a/lib/cinegraph/api_processors/omdb.ex
+++ b/lib/cinegraph/api_processors/omdb.ex
@@ -55,8 +55,17 @@ defmodule Cinegraph.ApiProcessors.OMDb do
 
   # Private functions
 
+  # #923: Movie schema marks omdb_data load_in_query: false. has_data?/1 below
+  # pattern-matches on %Movie{omdb_data: data} so the field MUST be selected
+  # here — without the explicit opt-in, should_skip_processing? always falls
+  # open and the OMDb API gets called even for already-enriched movies,
+  # burning quota.
   defp get_movie(movie_id) do
-    case Repo.get(Movie, movie_id) do
+    case Repo.one(
+           from m in Movie,
+             where: m.id == ^movie_id,
+             select_merge: %{omdb_data: m.omdb_data}
+         ) do
       nil -> {:error, :movie_not_found}
       movie -> {:ok, movie}
     end

--- a/lib/cinegraph/api_processors/tmdb.ex
+++ b/lib/cinegraph/api_processors/tmdb.ex
@@ -11,6 +11,7 @@ defmodule Cinegraph.ApiProcessors.TMDb do
   alias Cinegraph.Repo
   alias Cinegraph.Movies
   alias Cinegraph.Movies.Movie
+  import Ecto.Query
   require Logger
 
   @impl true
@@ -53,8 +54,16 @@ defmodule Cinegraph.ApiProcessors.TMDb do
 
   # Private functions
 
+  # #923: Movie schema marks tmdb_data load_in_query: false. has_data?/1 above
+  # pattern-matches on %Movie{tmdb_data: data} so the field MUST be selected
+  # here — without the explicit opt-in, fetch_and_update_movie always falls
+  # open and the TMDb API gets called even for already-enriched movies.
   defp get_movie(movie_id) do
-    case Repo.get(Movie, movie_id) do
+    case Repo.one(
+           from m in Movie,
+             where: m.id == ^movie_id,
+             select_merge: %{tmdb_data: m.tmdb_data}
+         ) do
       nil -> {:error, :movie_not_found}
       movie -> {:ok, movie}
     end

--- a/lib/cinegraph/workers/omdb_enrichment_worker.ex
+++ b/lib/cinegraph/workers/omdb_enrichment_worker.ex
@@ -12,61 +12,58 @@ defmodule Cinegraph.Workers.OMDbEnrichmentWorker do
     # 1 hour uniqueness
     unique: [fields: [:args], keys: [:movie_id], period: 3600]
 
-  alias Cinegraph.Movies
   alias Cinegraph.Metrics
   alias Cinegraph.ApiProcessors.OMDb
   require Logger
 
   @impl Oban.Worker
+  # #923: do NOT add an outer "already has omdb_data?" guard here — the schema
+  # marks omdb_data load_in_query: false, so any naive `Movies.get_movie!/1`
+  # would silently see nil and call the OMDb API for every job, burning quota.
+  # OMDb.process_movie/2 owns the skip decision: it selects omdb_data
+  # explicitly AND verifies a matching external_metrics row exists.
   def perform(%Oban.Job{args: %{"movie_id" => movie_id} = args}) do
     Logger.info("OMDb Enrichment Worker processing movie #{movie_id}")
-
-    try do
-      movie = Movies.get_movie!(movie_id)
-
-      force = Map.get(args, "force", false)
-
-      if movie.omdb_data && !force do
-        Logger.info("Movie #{movie_id} already has OMDb data, skipping")
-        :ok
-      else
-        process_omdb_data(movie, args)
-      end
-    rescue
-      Ecto.NoResultsError ->
-        Logger.error("Movie #{movie_id} not found")
-        {:error, :movie_not_found}
-    end
+    force = Map.get(args, "force", false)
+    process_omdb_data(movie_id, force)
   end
 
-  defp process_omdb_data(movie, _args) do
-    case OMDb.process_movie(movie.id) do
+  defp process_omdb_data(movie_id, force) do
+    case OMDb.process_movie(movie_id, force_refresh: force) do
       {:ok, updated_movie} ->
-        Logger.info("Successfully enriched movie #{movie.id} with OMDb data")
+        Logger.info("Successfully enriched movie #{movie_id} with OMDb data")
         {:ok, updated_movie}
+
+      {:error, :movie_not_found} ->
+        Logger.error("Movie #{movie_id} not found")
+        {:error, :movie_not_found}
+
+      {:error, :invalid_imdb_id} ->
+        Logger.info("Invalid IMDb ID for movie #{movie_id}, skipping")
+        :ok
 
       {:error, :rate_limited} ->
         # OMDb has strict rate limits (1000/day for free tier)
         # Reschedule for later
-        Logger.warning("OMDb rate limited, rescheduling movie #{movie.id}")
+        Logger.warning("OMDb rate limited, rescheduling movie #{movie_id}")
         # Retry in 1 hour
         {:snooze, 3600}
 
       {:error, reason} when reason in ["Error getting data.", "Incorrect IMDb ID."] ->
-        Logger.info("OMDb unavailable for movie #{movie.id} (#{reason}), recording fetch attempt")
-        record_fetch_attempt(movie.id, reason)
+        Logger.info("OMDb unavailable for movie #{movie_id} (#{reason}), recording fetch attempt")
+        record_fetch_attempt(movie_id, reason)
         :ok
 
       {:error, %Jason.DecodeError{}} ->
         Logger.warning(
-          "OMDb returned malformed JSON for movie #{movie.id}, recording fetch attempt"
+          "OMDb returned malformed JSON for movie #{movie_id}, recording fetch attempt"
         )
 
-        record_fetch_attempt(movie.id, "malformed_response")
+        record_fetch_attempt(movie_id, "malformed_response")
         :ok
 
       {:error, reason} ->
-        Logger.error("Failed to enrich movie #{movie.id} with OMDb: #{inspect(reason)}")
+        Logger.error("Failed to enrich movie #{movie_id} with OMDb: #{inspect(reason)}")
         {:error, reason}
     end
   end

--- a/test/cinegraph/movies/jsonb_exclusion_test.exs
+++ b/test/cinegraph/movies/jsonb_exclusion_test.exs
@@ -114,6 +114,65 @@ defmodule Cinegraph.Movies.JsonbExclusionTest do
     end
   end
 
+  describe "OMDb processor opts in to omdb_data (#923 — re-audit P1 regression guard)" do
+    # Re-audit of #924 caught: OMDbEnrichmentWorker did
+    # `movie = Movies.get_movie!(movie_id); if movie.omdb_data && !force`,
+    # but with load_in_query: false on the schema field that guard ALWAYS sees
+    # nil and re-calls the OMDb API for every job. The worker now delegates
+    # the skip decision to OMDb.process_movie/2, whose `get_movie/1` opts back
+    # in to omdb_data via select_merge. This test pins that opt-in: if the
+    # select_merge regresses, this test hits the OMDb client which raises
+    # "OMDB_API_KEY not configured" in the test env.
+    test "OMDb.process_movie/2 skips already-enriched movie via inner guard" do
+      imdb_id = "tt#{:rand.uniform(89_999_999) + 10_000_000}"
+
+      movie =
+        insert_movie_with_blobs!("OMDb Skip Blob",
+          imdb_id: imdb_id
+        )
+
+      now_naive = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      now_utc = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      # should_skip_processing? requires BOTH has_data?(movie) AND a matching
+      # external_metrics row — seed one for source="omdb".
+      Repo.insert_all(Cinegraph.Movies.ExternalMetric, [
+        %{
+          movie_id: movie.id,
+          source: "omdb",
+          metric_type: "rating_average",
+          value: 8.5,
+          fetched_at: now_utc,
+          inserted_at: now_naive,
+          updated_at: now_naive
+        }
+      ])
+
+      # Capture pre-call state. If the skip path doesn't trigger,
+      # OMDb.Client.get_movie_by_imdb_id raises ("OMDB_API_KEY not configured"
+      # in test env) AND/OR new external_metrics rows are written.
+      metrics_before = Repo.aggregate(Cinegraph.Movies.ExternalMetric, :count, :id)
+      reloaded_before = Repo.get!(Movie, movie.id)
+
+      assert {:ok, returned} = Cinegraph.ApiProcessors.OMDb.process_movie(movie.id)
+
+      # Skip path returns the loaded movie. With select_merge in get_movie/1,
+      # the opt-in omdb_data must survive the load — if it doesn't, the bug
+      # this test guards against is back.
+      assert returned.id == movie.id
+      assert returned.omdb_data["marker"] == "pr-b-must-be-nilled"
+
+      metrics_after = Repo.aggregate(Cinegraph.Movies.ExternalMetric, :count, :id)
+      reloaded_after = Repo.get!(Movie, movie.id)
+
+      assert metrics_after == metrics_before,
+             "skip path must not insert external_metrics rows"
+
+      assert reloaded_after.updated_at == reloaded_before.updated_at,
+             "skip path must not update the movie row"
+    end
+  end
+
   describe "Predictions opt-in to tmdb_data (#923 — Greptile P1 regression guard)" do
     # PR #924 review caught: get_movie_scoring_details/2 used `Repo.get!(Movie)`
     # without an explicit select_merge, so post-load_in_query the function


### PR DESCRIPTION
With load_in_query: false on omdb_data/tmdb_data, bare Repo.get(Movie, id)
returns a struct where those fields are silently nil. Three sites depended
on reading them back on a loaded struct and were therefore failing open —
calling the OMDb/TMDb APIs (and burning quota) for every job, even on
already-enriched movies.

- ApiProcessors.OMDb.get_movie/1: opt back in to omdb_data via select_merge
  so has_data?/1's pattern match works and should_skip_processing?
  correctly short-circuits.
- ApiProcessors.TMDb.get_movie/1: same fix for tmdb_data.
- Workers.OMDbEnrichmentWorker: drop the redundant outer
  "movie.omdb_data && !force" guard that ALSO failed open. The inner
  OMDb.process_movie/2 owns the skip decision (it selects omdb_data
  explicitly AND verifies an external_metrics row exists). Pass
  force_refresh through so the inner guard sees it.
- Regression test in jsonb_exclusion_test.exs proves the skip path via
  observable state (no external_metrics writes, no movie row update)
  rather than log scraping — if select_merge regresses, the OMDb client
  raises "OMDB_API_KEY not configured" in the test env.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed data loading for enriched movie metadata to prevent unintended re-processing of already-enriched movies.
  * Enhanced error handling and rate-limiting management in external API enrichment workflows.

* **Tests**
  * Added regression test to ensure movie enrichment skip logic functions correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/925)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->