### PR TITLE
Fix PSQW cron arg mismatches — remove 3 always-discarding entries (#928)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -237,24 +237,17 @@ config :cinegraph, Oban,
        # remained orphaned (gives the refetches 24h to land).
        {"0 4 * * 0", Cinegraph.Workers.ZeroCreditsCleanupSweeper},
        {"0 4 * * 1", Cinegraph.Workers.ZeroCreditsCleanupDeleteSweeper},
-       # PQS staleness recurring recalc (#745 Phase 1.4) — re-enabled.
-       # Each entry is a separate cron-fire of `PersonQualityScoreWorker`
-       # with a different batch shape; the worker has dedicated clauses
-       # for each.
-       {"0 3 * * *", Cinegraph.Workers.PersonQualityScoreWorker,
-        args: %{
-          "batch" => "daily_incremental",
-          "trigger" => "daily_scheduled",
-          "min_credits" => 1
-        }},
+       # PQS recurring recalc — only the two functional cron entries (weekly_full,
+       # monthly_deep) remain. Removed in #928: daily_incremental, health_check,
+       # stale_cleanup — those args don't match any worker perform/1 clause and
+       # discarded 100% every fire. For autonomous stale-score handling, see
+       # `Cinegraph.Metrics.PQSScheduler` (schedule_daily_incremental/0,
+       # schedule_stale_cleanup/1, check_system_health/0) which look up the
+       # right person_ids before enqueueing.
        {"0 2 * * SUN", Cinegraph.Workers.PersonQualityScoreWorker,
         args: %{"batch" => "weekly_full", "trigger" => "weekly_scheduled", "min_credits" => 5}},
        {"0 1 1-7 * SUN", Cinegraph.Workers.PersonQualityScoreWorker,
-        args: %{"batch" => "monthly_deep", "trigger" => "monthly_scheduled", "min_credits" => 1}},
-       {"0 */6 * * *", Cinegraph.Workers.PersonQualityScoreWorker,
-        args: %{"batch" => "health_check", "trigger" => "health_scheduled"}},
-       {"0 */12 * * *", Cinegraph.Workers.PersonQualityScoreWorker,
-        args: %{"batch" => "stale_cleanup", "trigger" => "stale_scheduled", "max_age_days" => 7}}
+        args: %{"batch" => "monthly_deep", "trigger" => "monthly_scheduled", "min_credits" => 1}}
      ]}
   ]
 


### PR DESCRIPTION
Three of the five PersonQualityScoreWorker cron entries in
config/config.exs supplied args that don't match any perform/1 clause
in the worker:

- daily_incremental: clause requires "person_ids" key (cron sends without)
- health_check: no clause at all (was removed in favor of PQSScheduler,
  cron entry never updated)
- stale_cleanup: clause requires "person_ids" key (same as daily_incremental)

Result: ~6-8 discards/day, surfaced by #927's 24h autonomous-pipeline
soak. Removing the cron entries stops the noise without functional
regression — the affected paths were already non-functional on prod.

PQSScheduler.get_cron_config/0 (lib/cinegraph/metrics/pqs_scheduler.ex)
has the correct invocation path for autonomous stale-cleanup; wiring
that up is tracked in #929 as a follow-up.

Closes #928. Discovered in #927.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted background job scheduling to remove three recurring quality assessment tasks while retaining the two primary weekly and monthly comprehensive recalculation schedules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->