### PR TITLE
now playing ups

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -33,6 +33,13 @@ cinegraph_base_url =
 
 config :cinegraph, :cinegraph_base_url, cinegraph_base_url
 
+wombie_base_url =
+  if config_env() == :dev,
+    do: env!("WOMBIE_BASE_URL", :string, "https://wombie.com"),
+    else: System.get_env("WOMBIE_BASE_URL") || "https://wombie.com"
+
+config :cinegraph, :wombie_base_url, wombie_base_url
+
 crawlbase_api_key =
   if config_env() == :dev,
     do: env!("CRAWLBASE_API_KEY", :string, ""),

--- a/lib/cinegraph/homepage.ex
+++ b/lib/cinegraph/homepage.ex
@@ -486,7 +486,7 @@ defmodule Cinegraph.Homepage do
   end
 
   defp theater_movies(date) do
-    movies = Movies.now_playing_movies() |> Enum.take(8)
+    movies = Cinegraph.Movies.Cache.now_playing_movies() |> Enum.take(8)
 
     if length(movies) >= 4 do
       Enum.map(movies, &film_card(&1))

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -94,8 +94,7 @@ defmodule Cinegraph.Movies do
         left_join: s in assoc(m, :score_cache),
         where: m.now_playing_last_seen >= ^stamp_cutoff,
         order_by: [desc_nulls_last: s.overall_score, desc: m.release_date, asc: m.id],
-        preload: [score_cache: s],
-        limit: ^limit
+        preload: [score_cache: s]
       )
 
     base
@@ -110,9 +109,11 @@ defmodule Cinegraph.Movies do
     |> Repo.replica().all()
     |> then(fn movies ->
       if region do
-        Enum.filter(movies, &region_active?(&1, region, stamp_cutoff))
-      else
         movies
+        |> Enum.filter(&region_active?(&1, region, stamp_cutoff))
+        |> Enum.take(limit)
+      else
+        Enum.take(movies, limit)
       end
     end)
   end
@@ -140,14 +141,39 @@ defmodule Cinegraph.Movies do
     end)
   end
 
-  @doc "Returns true if any region has a fresh now_playing timestamp."
+  @doc """
+  Returns true if the movie is currently playing in theaters.
+
+  Prefers per-region JSONB data when available. Falls back to the global
+  `now_playing_last_seen` stamp for movies where the sweeper has run but
+  the per-region map hasn't been populated yet (e.g. immediately after
+  clearing bad data or on first sweep after migration).
+  """
   def currently_in_theaters?(movie, cutoff \\ nil) do
-    active_now_playing_regions(movie, cutoff) != []
+    cutoff = cutoff || DateTime.add(DateTime.utc_now(), -3, :day)
+
+    if movie.now_playing_region_last_seen do
+      active_now_playing_regions(movie, cutoff) != []
+    else
+      global_stamp_fresh?(movie.now_playing_last_seen, cutoff)
+    end
   end
 
   @doc "Returns true if the given region has a fresh now_playing timestamp."
   def region_active?(movie, region, cutoff \\ nil) do
     region in active_now_playing_regions(movie, cutoff)
+  end
+
+  defp global_stamp_fresh?(nil, _cutoff), do: false
+
+  defp global_stamp_fresh?(%DateTime{} = ts, cutoff),
+    do: DateTime.compare(ts, cutoff) in [:gt, :eq]
+
+  defp global_stamp_fresh?(%NaiveDateTime{} = ts, cutoff) do
+    ts
+    |> DateTime.from_naive!("Etc/UTC")
+    |> DateTime.compare(cutoff)
+    |> Kernel.in([:gt, :eq])
   end
 
   @doc """

--- a/lib/cinegraph/workers/now_playing_sweeper.ex
+++ b/lib/cinegraph/workers/now_playing_sweeper.ex
@@ -114,37 +114,41 @@ defmodule Cinegraph.Workers.NowPlayingSweeper do
 
     existing_map = Map.new(existing)
     existing_tmdb_ids = Map.keys(existing_map)
-
-    {stamped, _} =
-      from(m in Movie, where: m.tmdb_id in ^existing_tmdb_ids)
-      |> Repo.update_all(set: [now_playing_last_seen: now])
-
     now_iso = DateTime.to_iso8601(now)
 
-    Enum.each(region_map, fn {region, region_ids} ->
-      region_tmdb_ids =
-        region_ids
-        |> MapSet.to_list()
-        |> Enum.filter(&Map.has_key?(existing_map, &1))
+    {:ok, stamped} =
+      Repo.transaction(fn ->
+        {stamped, _} =
+          from(m in Movie, where: m.tmdb_id in ^existing_tmdb_ids)
+          |> Repo.update_all(set: [now_playing_last_seen: now])
 
-      unless region_tmdb_ids == [] do
-        region_json = Jason.encode!(%{region => now_iso})
+        Enum.each(region_map, fn {region, region_ids} ->
+          region_tmdb_ids =
+            region_ids
+            |> MapSet.to_list()
+            |> Enum.filter(&Map.has_key?(existing_map, &1))
 
-        from(m in Movie,
-          where: m.tmdb_id in ^region_tmdb_ids,
-          update: [
-            set: [
-              now_playing_region_last_seen:
-                fragment(
-                  "COALESCE(now_playing_region_last_seen, '{}'::jsonb) || ?::jsonb",
-                  ^region_json
-                )
-            ]
-          ]
-        )
-        |> Repo.update_all([])
-      end
-    end)
+          unless region_tmdb_ids == [] do
+            region_data = %{region => now_iso}
+
+            from(m in Movie,
+              where: m.tmdb_id in ^region_tmdb_ids,
+              update: [
+                set: [
+                  now_playing_region_last_seen:
+                    fragment(
+                      "COALESCE(now_playing_region_last_seen, '{}'::jsonb) || ?",
+                      type(^region_data, :map)
+                    )
+                ]
+              ]
+            )
+            |> Repo.update_all([])
+          end
+        end)
+
+        stamped
+      end)
 
     unknown_ids = all_ids -- existing_tmdb_ids
 

--- a/lib/cinegraph_web/helpers/wombie_links.ex
+++ b/lib/cinegraph_web/helpers/wombie_links.ex
@@ -1,0 +1,26 @@
+defmodule CinegraphWeb.Helpers.WombieLinks do
+  @moduledoc """
+  Builds Wombie.com deep-links with UTM attribution for cross-site referral tracking.
+
+  Uses the slug-based URL format (`/movies/{slug}-{tmdb_id}`) until #875 Phase B
+  ships on Wombie and adds a stable `/movies/tmdb/:id` resolver.
+  """
+
+  @doc """
+  Returns a Wombie showtimes URL for the given movie and campaign surface.
+
+  ## Campaigns
+    - `"now_playing"` — now-playing feed card
+    - `"movie_show"` — movie detail page band
+    - `"graphql"` — API consumers
+  """
+  def showtimes_url(movie, campaign \\ "now_playing") do
+    base =
+      :cinegraph
+      |> Application.get_env(:wombie_base_url, "https://wombie.com")
+      |> String.trim_trailing("/")
+
+    "#{base}/movies/#{movie.slug}-#{movie.tmdb_id}" <>
+      "?utm_source=cinegraph&utm_medium=referral&utm_campaign=#{campaign}"
+  end
+end

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -46,9 +46,19 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
   def handle_params(%{"slug" => slug}, _uri, socket) do
     case Data.load_movie(slug) do
       {:ok, data} ->
+        in_theaters = Cinegraph.Movies.currently_in_theaters?(data.movie)
+
         {:noreply,
          socket
          |> assign(data)
+         |> assign(:in_theaters, in_theaters)
+         |> assign(
+           :wombie_url,
+           if(in_theaters,
+             do: CinegraphWeb.Helpers.WombieLinks.showtimes_url(data.movie, "movie_show"),
+             else: nil
+           )
+         )
          |> assign(:video_clerk_recommendation, empty_video_clerk_recommendation())
          |> maybe_start_video_clerk_recommendation(data.movie.id)
          |> assign_availability(data.movie, socket.assigns[:availability_browser_region])
@@ -320,6 +330,29 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
         </div>
       </div>
     </section>
+
+    <%!-- In Theaters Now — absent entirely when not currently playing --%>
+    <div :if={@in_theaters} class="border-b border-mist-950/8 bg-white">
+      <div class="mx-auto w-full max-w-2xl px-6 md:max-w-3xl lg:max-w-7xl lg:px-10 py-4 flex items-center gap-4">
+        <div class="w-[3px] self-stretch rounded-full bg-indigo-500 shrink-0"></div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[12px] font-semibold tracking-[.06em] uppercase text-indigo-600 mb-0.5">
+            Currently in theaters
+          </p>
+          <p class="text-[13px] text-mist-600">
+            Confirmed playing now across TMDB regions
+          </p>
+        </div>
+        <a
+          href={@wombie_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="shrink-0 inline-flex items-center gap-1.5 rounded-[6px] border border-indigo-200 bg-indigo-50 px-3 py-1.5 text-[13px] font-semibold text-indigo-700 hover:bg-indigo-100 transition-colors"
+        >
+          🎬 Find Showtimes on Wombie
+        </a>
+      </div>
+    </div>
 
     <main class="mx-auto w-full max-w-2xl px-6 md:max-w-3xl lg:max-w-7xl lg:px-10 py-12 lg:py-16">
       <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_180px] lg:gap-12 lg:items-start">

--- a/lib/cinegraph_web/live/now_playing_live.ex
+++ b/lib/cinegraph_web/live/now_playing_live.ex
@@ -5,25 +5,74 @@ defmodule CinegraphWeb.NowPlayingLive do
   Data comes from `Movies.Cache.now_playing_movies/1`, which is stamped every
   6 hours by `NowPlayingSweeper`. Films absent from all TMDB regions for more
   than 3 days drop off automatically — no manual curation required.
+
+  The list is split into two sections at render time:
+    - New Releases  — released within the last 18 months, sorted newest first
+    - Classic Screenings — older films currently playing (re-releases, anniversary
+      runs, repertoire cinema), sorted by CineGraph score, shown on demand
   """
   use CinegraphWeb, :live_view
 
   alias Cinegraph.Movies.{Cache, Movie}
+  alias CinegraphWeb.Helpers.WombieLinks
+
+  # Films released more than this many days ago are "classic screenings"
+  @new_release_days 548
 
   @impl true
   def mount(_params, _session, socket) do
     movies = Cache.now_playing_movies()
-    film_cards = Enum.map(movies, &build_film_card/1)
+    cutoff = Date.add(Date.utc_today(), -@new_release_days)
+
+    {new_movies, classic_movies} =
+      Enum.split_with(movies, fn m ->
+        m.release_date && Date.compare(m.release_date, cutoff) in [:gt, :eq]
+      end)
+
+    new_releases = Enum.sort_by(new_movies, & &1.release_date, {:desc, Date})
+    classic_screenings = Enum.sort_by(classic_movies, &score_for_sort/1, :desc)
+
+    last_updated_at =
+      movies
+      |> Enum.map(& &1.now_playing_last_seen)
+      |> Enum.reject(&is_nil/1)
+      |> case do
+        [] -> nil
+        stamps -> Enum.max(stamps, DateTime)
+      end
 
     {:ok,
      socket
      |> assign(:page_title, "Now Playing")
-     |> assign(:film_cards, film_cards)
-     |> assign(:movie_count, length(movies))}
+     |> assign(:new_release_cards, Enum.map(new_releases, &build_film_card/1))
+     |> assign(:classic_cards, Enum.map(classic_screenings, &build_film_card/1))
+     |> assign(:last_updated_at, last_updated_at)
+     |> assign(:show_classics, false)}
   end
 
   @impl true
   def handle_params(_params, _uri, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("toggle_classics", _params, socket) do
+    {:noreply, update(socket, :show_classics, &(!&1))}
+  end
+
+  def format_freshness(nil), do: nil
+
+  def format_freshness(dt) do
+    hours = div(DateTime.diff(DateTime.utc_now(), dt, :second), 3600)
+
+    cond do
+      hours < 1 -> "just now"
+      hours == 1 -> "1 hour ago"
+      hours < 24 -> "#{hours} hours ago"
+      true -> "#{div(hours, 24)} days ago"
+    end
+  end
+
+  defp score_for_sort(%{score_cache: %{overall_score: s}}) when is_number(s), do: s
+  defp score_for_sort(_), do: -1.0
 
   defp build_film_card(movie) do
     score =
@@ -40,7 +89,8 @@ defmodule CinegraphWeb.NowPlayingLive do
       poster_url: Movie.poster_url(movie, "w342"),
       score: score,
       lens_key: score && :overall,
-      score_tooltip: "Cinegraph score"
+      score_tooltip: "Cinegraph score",
+      wombie_url: WombieLinks.showtimes_url(movie, "now_playing")
     }
   end
 end

--- a/lib/cinegraph_web/live/now_playing_live.html.heex
+++ b/lib/cinegraph_web/live/now_playing_live.html.heex
@@ -17,21 +17,103 @@
     </p>
   </header>
 
-  <%= if Enum.empty?(@film_cards) do %>
+  <%= if Enum.empty?(@new_release_cards) && Enum.empty?(@classic_cards) do %>
     <div class="rounded-[10px] border border-mist-950/10 bg-mist-50 px-8 py-16 text-center">
       <p class="text-[15px] text-mist-600">
         No theatrical data yet — the sweeper runs every 6 hours.
       </p>
     </div>
   <% else %>
-    <p class="mb-6 text-[13px] text-mist-500">
-      {@movie_count} {if @movie_count == 1, do: "film", else: "films"} in theaters now
-    </p>
-    <div class="grid grid-cols-2 gap-[18px] sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
-      <CinegraphWeb.NeutralV2Components.n_film_card
-        :for={film <- @film_cards}
-        film={film}
-      />
+    <%!-- New Releases --%>
+    <section class="mb-16">
+      <div class="flex items-baseline justify-between mb-6">
+        <div>
+          <CinegraphWeb.NeutralV2Components.n_eyebrow class="mb-1">
+            New Releases
+          </CinegraphWeb.NeutralV2Components.n_eyebrow>
+          <p class="text-[13px] text-mist-500">
+            {length(@new_release_cards)} {if length(@new_release_cards) == 1,
+              do: "film",
+              else: "films"} · newest first
+            <%= if freshness = format_freshness(@last_updated_at) do %>
+              · updated {freshness}
+            <% end %>
+          </p>
+        </div>
+      </div>
+      <%= if Enum.empty?(@new_release_cards) do %>
+        <p class="text-[14px] text-mist-400 italic">No new releases in the current data.</p>
+      <% else %>
+        <div class="grid grid-cols-2 gap-[18px] sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+          <div :for={film <- @new_release_cards} class="flex flex-col">
+            <CinegraphWeb.NeutralV2Components.n_film_card film={film} />
+            <a
+              :if={film[:wombie_url]}
+              href={film[:wombie_url]}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="mt-[5px] text-[11.5px] text-indigo-600 hover:text-indigo-800 font-medium truncate"
+            >
+              Showtimes on Wombie →
+            </a>
+          </div>
+        </div>
+      <% end %>
+    </section>
+
+    <%!-- Classic Screenings --%>
+    <%= if Enum.any?(@classic_cards) do %>
+      <section>
+        <div class="flex items-center justify-between py-4 border-t border-mist-950/10">
+          <div>
+            <CinegraphWeb.NeutralV2Components.n_eyebrow class="mb-1">
+              Classic Screenings
+            </CinegraphWeb.NeutralV2Components.n_eyebrow>
+            <p class="text-[13px] text-mist-500">
+              {length(@classic_cards)} older {if length(@classic_cards) == 1,
+                do: "film",
+                else: "films"} · anniversary runs &amp; repertoire cinema
+            </p>
+          </div>
+          <button
+            phx-click="toggle_classics"
+            class="shrink-0 text-[12.5px] font-medium text-mist-700 hover:text-mist-950 border border-mist-950/15 rounded-[6px] px-3 py-1.5 transition-colors"
+          >
+            {if @show_classics, do: "Hide", else: "Show #{length(@classic_cards)}"}
+          </button>
+        </div>
+        <%= if @show_classics do %>
+          <div class="mt-6 grid grid-cols-2 gap-[18px] sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+            <div :for={film <- @classic_cards} class="flex flex-col">
+              <CinegraphWeb.NeutralV2Components.n_film_card film={film} />
+              <a
+                :if={film[:wombie_url]}
+                href={film[:wombie_url]}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="mt-[5px] text-[11.5px] text-indigo-600 hover:text-indigo-800 font-medium truncate"
+              >
+                Showtimes on Wombie →
+              </a>
+            </div>
+          </div>
+        <% end %>
+      </section>
+    <% end %>
+
+    <%!-- Footer CTA --%>
+    <div class="mt-16 rounded-[10px] border border-indigo-200 bg-indigo-50 px-6 py-5 flex items-center justify-between gap-4">
+      <p class="text-[14px] text-indigo-900 font-medium">
+        🎬 Find showtimes and plan with friends at wombie.com
+      </p>
+      <a
+        href="https://wombie.com?utm_source=cinegraph&utm_medium=referral&utm_campaign=now_playing_footer"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="shrink-0 text-[13px] font-semibold text-indigo-700 hover:text-indigo-900 border-b border-indigo-300 whitespace-nowrap"
+      >
+        Open Wombie →
+      </a>
     </div>
   <% end %>
 </div>

--- a/lib/cinegraph_web/resolvers/movie_resolver.ex
+++ b/lib/cinegraph_web/resolvers/movie_resolver.ex
@@ -75,8 +75,15 @@ defmodule CinegraphWeb.Resolvers.MovieResolver do
 
   @doc false
   def now_playing_movies(_, args, _) do
-    limit = Map.get(args, :limit, 100)
-    recency_days = Map.get(args, :recency_days)
+    limit = args |> Map.get(:limit, 100) |> max(0) |> min(500)
+
+    recency_days =
+      case Map.get(args, :recency_days) do
+        nil -> nil
+        n when is_integer(n) and n >= 0 -> n
+        _ -> nil
+      end
+
     region = Map.get(args, :region)
     stamp_cutoff = DateTime.add(DateTime.utc_now(), -3, :day)
 

--- a/lib/cinegraph_web/schema/movie_types.ex
+++ b/lib/cinegraph_web/schema/movie_types.ex
@@ -146,7 +146,10 @@ defmodule CinegraphWeb.Schema.MovieTypes do
 
     field :cinegraph_url, :string do
       resolve(fn movie, _, _ ->
-        base = Application.get_env(:cinegraph, :cinegraph_base_url, "")
+        base =
+          :cinegraph
+          |> Application.get_env(:cinegraph_base_url, "")
+          |> String.trim_trailing("/")
 
         path =
           if movie.slug && movie.slug != "",
@@ -160,6 +163,17 @@ defmodule CinegraphWeb.Schema.MovieTypes do
     field :is_currently_in_theaters, :boolean do
       resolve(fn movie, _, _ ->
         {:ok, Cinegraph.Movies.currently_in_theaters?(movie)}
+      end)
+    end
+
+    field :wombie_url, :string,
+      description: "Showtimes link on wombie.com — nil when movie is not currently in theaters" do
+      resolve(fn movie, _, _ ->
+        if Cinegraph.Movies.currently_in_theaters?(movie) do
+          {:ok, CinegraphWeb.Helpers.WombieLinks.showtimes_url(movie, "graphql")}
+        else
+          {:ok, nil}
+        end
       end)
     end
 

--- a/priv/repo/migrations/20260524000001_add_missing_movie_lookup_indexes.exs
+++ b/priv/repo/migrations/20260524000001_add_missing_movie_lookup_indexes.exs
@@ -1,0 +1,35 @@
+defmodule Cinegraph.Repo.Migrations.AddMissingMovieLookupIndexes do
+  use Ecto.Migration
+
+  # CREATE INDEX CONCURRENTLY cannot run inside a transaction
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # Every movie show page calls get_movie_by_slug!/1 → WHERE slug = $1
+    # Without this index: ~2,000ms sequential scan on 1.1M rows
+    create_if_not_exists unique_index(:movies, [:slug],
+      concurrently: true,
+      name: :movies_slug_index
+    )
+
+    # tmdb_id lookups (import workers, GraphQL, now-playing sweeper)
+    # Without this index: ~3,600ms sequential scan on 1.1M rows
+    create_if_not_exists unique_index(:movies, [:tmdb_id],
+      concurrently: true,
+      name: :movies_tmdb_id_index
+    )
+
+    # id lookups — Repo.get!(Movie, id) had no primary key to use
+    create_if_not_exists unique_index(:movies, [:id],
+      concurrently: true,
+      name: :movies_id_unique_index
+    )
+  end
+
+  def down do
+    drop_if_exists index(:movies, [:slug], name: :movies_slug_index)
+    drop_if_exists index(:movies, [:tmdb_id], name: :movies_tmdb_id_index)
+    drop_if_exists index(:movies, [:id], name: :movies_id_unique_index)
+  end
+end

--- a/test/cinegraph_web/helpers/wombie_links_test.exs
+++ b/test/cinegraph_web/helpers/wombie_links_test.exs
@@ -1,0 +1,42 @@
+defmodule CinegraphWeb.Helpers.WombieLinksTest do
+  use ExUnit.Case, async: true
+
+  alias CinegraphWeb.Helpers.WombieLinks
+
+  @movie %{slug: "inception", tmdb_id: 27_205}
+
+  test "builds slug-based URL with default now_playing campaign" do
+    url = WombieLinks.showtimes_url(@movie)
+    assert url =~ "wombie.com/movies/inception-27205"
+    assert url =~ "utm_campaign=now_playing"
+    assert url =~ "utm_source=cinegraph"
+    assert url =~ "utm_medium=referral"
+  end
+
+  test "uses provided campaign" do
+    url = WombieLinks.showtimes_url(@movie, "movie_show")
+    assert url =~ "utm_campaign=movie_show"
+  end
+
+  test "graphql campaign" do
+    url = WombieLinks.showtimes_url(@movie, "graphql")
+    assert url =~ "utm_campaign=graphql"
+  end
+
+  test "trims trailing slash from base URL" do
+    Application.put_env(:cinegraph, :wombie_base_url, "https://wombie.com/")
+    url = WombieLinks.showtimes_url(@movie)
+    refute url =~ "wombie.com//movies"
+    assert url =~ "wombie.com/movies/inception-27205"
+  after
+    Application.delete_env(:cinegraph, :wombie_base_url)
+  end
+
+  test "uses configured base URL" do
+    Application.put_env(:cinegraph, :wombie_base_url, "https://staging.wombie.com")
+    url = WombieLinks.showtimes_url(@movie)
+    assert url =~ "staging.wombie.com/movies/inception-27205"
+  after
+    Application.delete_env(:cinegraph, :wombie_base_url)
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Wombie showtimes links—users can now find tickets directly from the Now Playing page and individual movie pages.
  * Categorized Now Playing movies into "New Releases" and "Classic Screenings" with a toggle to show/hide classics.
  * Added "In Theaters Now" section on movie detail pages with showtimes availability.
  * Display freshness indicators showing when movie data was last updated.

* **Bug Fixes**
  * Improved regional theater availability detection and data validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/cinegraph/pull/947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->