### PR TITLE
fixes on omdb

### DIFF
--- a/lib/cinegraph/database/materialized_views.ex
+++ b/lib/cinegraph/database/materialized_views.ex
@@ -92,12 +92,30 @@ defmodule Cinegraph.Database.MaterializedViews do
   end
 
   @doc """
-  Refresh every materialized view in `public`. Returns `%{name => result}`.
+  Refresh every materialized view in `public`. Returns `%{name => result}` where each
+  result is `:ok | {:skipped, reason} | {:error, message}`.
+
+  **Per-view isolation (#1088):** a `refresh!` that raises for ONE view must never abort
+  the others. Each view is wrapped here so a single broken matview (e.g. a SQL underflow
+  in its defining query) degrades to one `{:error, _}` entry instead of crashing the whole
+  sweep and leaving every healthy view stale. `refresh!/2` itself still raises — isolation
+  lives only in this aggregate.
 
   Accepts the same options as `refresh!/2`.
   """
   def refresh_all!(opts \\ []) do
-    Map.new(list_public(), fn name -> {name, refresh!(name, opts)} end)
+    Map.new(list_public(), fn name ->
+      result =
+        try do
+          refresh!(name, opts)
+        rescue
+          e ->
+            Logger.error("MaterializedViews: refresh failed for #{name}: #{Exception.message(e)}")
+            {:error, Exception.message(e)}
+        end
+
+      {name, result}
+    end)
   end
 
   @doc """

--- a/lib/cinegraph/movies/query/custom_sorting.ex
+++ b/lib/cinegraph/movies/query/custom_sorting.ex
@@ -12,7 +12,8 @@ defmodule Cinegraph.Movies.Query.CustomSorting do
                       (votes × votes_weight) + (rating × rating_weight)
 
   Where:
-    - recency = exp(-decay_rate × days_since_release)
+    - recency = exp(-decay_rate × days_since_release), exponent clamped to ≥ -700 so very
+      old / garbage-dated rows can't trigger PostgreSQL's `exp()` underflow error (#1088)
     - popularity = ln(popularity + 1) / ln(max_expected)
     - votes = ln(votes + 1) / ln(max_expected)
     - rating = avg_rating / 10 (only if votes >= min_threshold)
@@ -85,7 +86,7 @@ defmodule Cinegraph.Movies.Query.CustomSorting do
          """
          (
            ?::float * COALESCE(
-             EXP(-1.0 * ?::float * GREATEST(0.0, (CURRENT_DATE - COALESCE(?, CURRENT_DATE))::float)),
+             EXP(GREATEST(-700.0, -1.0 * ?::float * GREATEST(0.0, (CURRENT_DATE - COALESCE(?, CURRENT_DATE))::float))),
              0.5
            )
            +

--- a/lib/cinegraph/workers/data_repair_worker.ex
+++ b/lib/cinegraph/workers/data_repair_worker.ex
@@ -475,7 +475,10 @@ defmodule Cinegraph.Workers.DataRepairWorker do
   end
 
   defp process_metric_batch(movies, source) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    # `inserted_at`/`updated_at` come from `timestamps()` → :naive_datetime. `insert_all`
+    # does NO casting, so a DateTime here raises Ecto.ChangeError and the whole backfill
+    # discards (this silently broke the #1053 materialization since #1054 — debt never moved).
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
     rows =
       movies
@@ -484,6 +487,13 @@ defmodule Cinegraph.Workers.DataRepairWorker do
         |> extract_metric_rows(source)
         |> Enum.map(fn row ->
           row
+          # `from_omdb`/`from_tmdb` shape rows for the CHANGESET path, which casts. `insert_all`
+          # does not — so `value` arrives as an integer (e.g. imdbVotes) against a :float column
+          # and raises. Coerce here so the materialization matches the column types exactly.
+          |> Map.update(:value, nil, fn
+            v when is_integer(v) -> v * 1.0
+            v -> v
+          end)
           |> Map.put(:inserted_at, now)
           |> Map.put(:updated_at, now)
         end)

--- a/lib/cinegraph/workers/materialized_view_refresh_sweeper.ex
+++ b/lib/cinegraph/workers/materialized_view_refresh_sweeper.ex
@@ -23,11 +23,19 @@ defmodule Cinegraph.Workers.MaterializedViewRefreshSweeper do
 
     refreshed = for {name, :ok} <- results, do: name
     skipped = for {name, {:skipped, _reason}} <- results, do: name
+    failed = for {name, {:error, msg}} <- results, do: {name, msg}
 
     Logger.info(
-      "MaterializedViewRefreshSweeper: refreshed=#{length(refreshed)} skipped=#{inspect(skipped)}"
+      "MaterializedViewRefreshSweeper: refreshed=#{length(refreshed)} " <>
+        "skipped=#{inspect(skipped)} failed=#{inspect(Enum.map(failed, &elem(&1, 0)))}"
     )
 
-    {:ok, %{refreshed: refreshed, skipped: skipped}}
+    # Healthy views are already refreshed (refresh_all! isolates per view, #1088). Surface any
+    # failure so it lands in oban_jobs.errors / AppSignal instead of a silent no-op discard —
+    # one broken matview no longer starves the rest.
+    case failed do
+      [] -> {:ok, %{refreshed: refreshed, skipped: skipped}}
+      _ -> {:error, %{refreshed: refreshed, skipped: skipped, failed: failed}}
+    end
   end
 end

--- a/priv/repo/migrations/20260608090000_clamp_discovery_rankings_recency.exs
+++ b/priv/repo/migrations/20260608090000_clamp_discovery_rankings_recency.exs
@@ -1,0 +1,158 @@
+defmodule Cinegraph.Repo.Migrations.ClampDiscoveryRankingsRecency do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # #1088: `movie_discovery_rankings_mv`'s recency term was `EXP(-0.01 * days_since_release)`.
+  # PostgreSQL `exp(float8)` RAISES `22003 numeric_value_out_of_range: underflow` (it does NOT
+  # return 0) once the argument drops below ≈ -745 — i.e. any film >~204y old or with a garbage
+  # sentinel release_date (year 1 → EXP(-7390)). The `COALESCE(..., 0.5)` can't catch a raised
+  # error, so a single such row aborted every REFRESH — the daily sweeper discarded for days and
+  # NO public matview refreshed. Clamp the exponent to >= -700 (exp(-700) ≈ 1e-304, in range;
+  # ancient films → recency ≈ 0, which is the intended semantics). Postgres has no
+  # CREATE OR REPLACE MATERIALIZED VIEW, so we DROP + CREATE and recreate all three indexes.
+  #
+  # Body is identical to 20260501120000 except the clamped recency_component line.
+
+  def up do
+    execute "DROP MATERIALIZED VIEW IF EXISTS movie_discovery_rankings_mv"
+    execute(create_sql(clamped_recency()))
+    execute(create_indexes())
+  end
+
+  def down do
+    # DROP MATERIALIZED VIEW cascades its indexes, so no separate index drops needed.
+    execute "DROP MATERIALIZED VIEW IF EXISTS movie_discovery_rankings_mv"
+    execute(create_sql(unclamped_recency()))
+    execute(create_indexes())
+  end
+
+  # exp can never underflow: argument floored at -700.
+  defp clamped_recency do
+    "EXP(GREATEST(-700.0, -1.0 * 0.01::float * GREATEST(0.0, (CURRENT_DATE - COALESCE(m.release_date, CURRENT_DATE))::float)))"
+  end
+
+  # original (raises on ancient/sentinel dates) — used only by `down`.
+  defp unclamped_recency do
+    "EXP(-1.0 * 0.01::float * GREATEST(0.0, (CURRENT_DATE - COALESCE(m.release_date, CURRENT_DATE))::float))"
+  end
+
+  defp create_sql(recency_expr) do
+    """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS movie_discovery_rankings_mv AS
+    WITH latest_tmdb_metrics AS (
+      SELECT DISTINCT ON (movie_id, metric_type)
+        movie_id,
+        metric_type,
+        value
+      FROM external_metrics
+      WHERE source = 'tmdb'
+        AND metric_type IN ('popularity_score', 'rating_votes', 'rating_average')
+      ORDER BY movie_id, metric_type, fetched_at DESC NULLS LAST, id DESC
+    ),
+    metric_pivot AS (
+      SELECT
+        movie_id,
+        MAX(value) FILTER (WHERE metric_type = 'popularity_score') AS popularity_score,
+        MAX(value) FILTER (WHERE metric_type = 'rating_votes') AS rating_votes,
+        MAX(value) FILTER (WHERE metric_type = 'rating_average') AS rating_average
+      FROM latest_tmdb_metrics
+      GROUP BY movie_id
+    ),
+    scored AS (
+      SELECT
+        m.id AS movie_id,
+        m.release_date,
+        m.import_status,
+        m.poster_path,
+        m.poster_path IS NOT NULL AND m.poster_path <> '' AS has_poster,
+        COALESCE(m.release_date <= CURRENT_DATE, false) AS is_released,
+        mp.popularity_score,
+        mp.rating_average,
+        mp.rating_votes,
+        COALESCE(
+          #{recency_expr},
+          0.5
+        ) AS recency_component,
+        COALESCE(
+          LN(GREATEST(mp.popularity_score::float, 1.0) + 1.0) / LN(1000.0),
+          0.0
+        ) AS popularity_component,
+        COALESCE(
+          LN(GREATEST(mp.rating_votes::float, 1.0) + 1.0) / LN(100000.0),
+          0.0
+        ) AS votes_component,
+        COALESCE(
+          CASE
+            WHEN mp.rating_votes IS NOT NULL
+             AND mp.rating_average IS NOT NULL
+             AND mp.rating_votes >= 10::float THEN mp.rating_average::float / 10.0
+            WHEN mp.rating_votes IS NOT NULL
+             AND mp.rating_average IS NOT NULL THEN 0.5
+            ELSE NULL
+          END,
+          0.5
+        ) AS rating_component,
+        CURRENT_DATE AS calculated_for_date,
+        NOW()::timestamp without time zone AS refreshed_at
+      FROM movies m
+      LEFT JOIN metric_pivot mp ON mp.movie_id = m.id
+    )
+    SELECT
+      movie_id,
+      release_date,
+      import_status,
+      poster_path,
+      has_poster,
+      is_released,
+      popularity_score,
+      rating_average,
+      rating_votes,
+      recency_component,
+      popularity_component,
+      votes_component,
+      rating_component,
+      (
+        0.35::float * recency_component +
+        0.35::float * popularity_component +
+        0.20::float * votes_component +
+        0.10::float * rating_component
+      ) AS default_discovery_score,
+      CASE
+        WHEN rating_votes >= 1000 AND rating_average >= 7.0 THEN 'strong_signal'
+        WHEN rating_votes >= 10 THEN 'rated'
+        WHEN popularity_score IS NOT NULL THEN 'popular'
+        ELSE 'limited_signal'
+      END AS quality_bucket,
+      calculated_for_date,
+      refreshed_at
+    FROM scored
+    """
+  end
+
+  defp create_indexes do
+    """
+    DO $$
+    BEGIN
+      CREATE UNIQUE INDEX IF NOT EXISTS movie_discovery_rankings_mv_movie_id_idx
+        ON movie_discovery_rankings_mv (movie_id);
+      CREATE INDEX IF NOT EXISTS movie_discovery_rankings_mv_default_rank_idx
+        ON movie_discovery_rankings_mv (
+          default_discovery_score DESC NULLS LAST,
+          release_date DESC NULLS LAST,
+          movie_id
+        )
+        WHERE import_status = 'full' AND is_released = true;
+      CREATE INDEX IF NOT EXISTS movie_discovery_rankings_mv_poster_rank_idx
+        ON movie_discovery_rankings_mv (
+          has_poster,
+          default_discovery_score DESC NULLS LAST,
+          release_date DESC NULLS LAST,
+          movie_id
+        )
+        WHERE import_status = 'full' AND is_released = true;
+    END $$;
+    """
+  end
+end

--- a/test/cinegraph/database/materialized_views_test.exs
+++ b/test/cinegraph/database/materialized_views_test.exs
@@ -1,0 +1,50 @@
+defmodule Cinegraph.Database.MaterializedViewsTest do
+  @moduledoc """
+  #1088 regression: `refresh_all!/1` must isolate per-view failures. Before the fix, one
+  matview whose refresh raised (e.g. an `exp()` underflow in its defining query) aborted the
+  ENTIRE sweep — every healthy view went stale and the sweeper discarded silently.
+  """
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Database.MaterializedViews
+
+  # Both created WITH NO DATA so `refresh!` takes the non-concurrent populate branch
+  # (CONCURRENTLY can't run inside the test sandbox transaction). The "bad" one's query
+  # underflows on refresh exactly like the prod `movie_discovery_rankings_mv` did.
+  defp create_test_matviews! do
+    suffix = System.unique_integer([:positive])
+    good = "t_mv_good_#{suffix}"
+    bad = "t_mv_bad_#{suffix}"
+
+    Repo.query!(~s|CREATE MATERIALIZED VIEW "#{good}" AS SELECT 1 AS id WITH NO DATA|)
+
+    Repo.query!(
+      ~s|CREATE MATERIALIZED VIEW "#{bad}" AS SELECT exp(-1000.0::float8) AS x, 1 AS id WITH NO DATA|
+    )
+
+    {good, bad}
+  end
+
+  test "refresh_all!/1 isolates a failing view — healthy views still refresh, no raise" do
+    {good, bad} = create_test_matviews!()
+
+    # Must NOT raise even though `bad` underflows on refresh.
+    results = MaterializedViews.refresh_all!()
+
+    assert results[good] == :ok, "a healthy view must refresh despite a sibling failing"
+    assert {:error, msg} = results[bad]
+    assert msg =~ "underflow", "the failing view is reported with its error, not silently dropped"
+
+    # Both views were processed — iteration didn't abort at the failure.
+    assert Map.has_key?(results, good) and Map.has_key?(results, bad)
+  end
+
+  test "MaterializedViewRefreshSweeper surfaces partial failure as {:error, …}" do
+    {_good, bad} = create_test_matviews!()
+
+    assert {:error, %{failed: failed}} =
+             Cinegraph.Workers.MaterializedViewRefreshSweeper.perform(%Oban.Job{args: %{}})
+
+    assert Enum.any?(failed, fn {name, _msg} -> name == bad end)
+  end
+end

--- a/test/cinegraph/workers/data_repair_worker_test.exs
+++ b/test/cinegraph/workers/data_repair_worker_test.exs
@@ -1,0 +1,78 @@
+defmodule Cinegraph.Workers.DataRepairWorkerTest do
+  @moduledoc """
+  #1053 regression: the external_metrics materialization (`backfill_external_metrics_omdb`)
+  re-derives `external_metrics` from stored `omdb_data` blobs via `insert_all`. It silently
+  discarded on prod from #1054 until 2026-06-08 because `inserted_at`/`updated_at` were built
+  as `DateTime` while the columns are `:naive_datetime` (insert_all does no casting → ChangeError).
+  This test exercises the real insert_all path so the type mismatch can't reappear.
+  """
+  use Cinegraph.DataCase, async: false
+  use Oban.Testing, repo: Cinegraph.Repo
+
+  alias Cinegraph.Movies.{ExternalMetric, Movie}
+  alias Cinegraph.Repo
+  alias Cinegraph.Workers.DataRepairWorker
+
+  defp movie_with_omdb!(blob) do
+    %Movie{}
+    |> Movie.changeset(%{
+      tmdb_id: System.unique_integer([:positive]),
+      title: "Repair #{System.unique_integer([:positive])}",
+      import_status: "full",
+      imdb_id: "tt#{System.unique_integer([:positive])}"
+    })
+    |> Repo.insert!()
+    # omdb_data is load_in_query: false — set it directly
+    |> Ecto.Changeset.change(omdb_data: blob)
+    |> Repo.update!()
+  end
+
+  test "backfill_external_metrics_omdb materializes rows from the blob via insert_all" do
+    movie = movie_with_omdb!(%{"imdbRating" => "8.5", "imdbVotes" => "12,345"})
+
+    assert :ok =
+             perform_job(DataRepairWorker, %{
+               "repair_type" => "backfill_external_metrics_omdb",
+               "batch_size" => 200,
+               "last_id" => 0,
+               "total_processed" => 0,
+               "total_inserted" => 0
+             })
+
+    rows = Repo.all(from e in ExternalMetric, where: e.movie_id == ^movie.id)
+    assert Enum.any?(rows, &(&1.source == "imdb" and &1.metric_type == "rating_average"))
+
+    # imdbVotes parses to an integer (12_345) but the column is :float — insert_all does no
+    # casting, so process_metric_batch/2 must coerce it. Assert that coercion actually happened.
+    votes_row = Enum.find(rows, &(&1.source == "imdb" and &1.metric_type == "rating_votes"))
+    assert votes_row
+    assert is_float(votes_row.value)
+
+    # timestamps must be the schema's :naive_datetime (the bug shipped a DateTime here)
+    sample = hd(rows)
+    assert %NaiveDateTime{} = sample.inserted_at
+    assert %NaiveDateTime{} = sample.updated_at
+  end
+
+  test "the backfill is idempotent — a second pass inserts nothing new" do
+    movie = movie_with_omdb!(%{"imdbRating" => "7.0"})
+
+    args = %{
+      "repair_type" => "backfill_external_metrics_omdb",
+      "batch_size" => 200,
+      "last_id" => 0,
+      "total_processed" => 0,
+      "total_inserted" => 0
+    }
+
+    assert :ok = perform_job(DataRepairWorker, args)
+    before = Repo.aggregate(from(e in ExternalMetric, where: e.movie_id == ^movie.id), :count)
+
+    assert :ok = perform_job(DataRepairWorker, args)
+
+    after_count =
+      Repo.aggregate(from(e in ExternalMetric, where: e.movie_id == ^movie.id), :count)
+
+    assert before == after_count
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented underflow in discovery score recency to avoid EXP() errors for very old dates.
  * Made materialized view refresh resilient: a failing view no longer aborts the whole sweep and failures are reported per-view.
  * Fixed external-metrics backfill type handling so inserted values and timestamps match expected column types.

* **Tests**
  * Added regression tests covering partial materialized-view failures and external-metrics backfill behavior (types and idempotency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->