### PR TITLE
Add daily TMDb movie refresh sweeper + worker (#1106)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -271,6 +271,11 @@ config :cinegraph, Oban,
        # autonomously drain the dashboard's drift backlogs. Capped per-run;
        # idempotent (workers are uniqueness-keyed).
        #
+       # Unified per-movie TMDb refresh (#1106): 5,000/day on :tmdb. One call per
+       # movie re-hydrates details + metrics + credits + watch providers and touches
+       # the tmdb_details + watch_providers freshness ledgers. Capped FLOOR only —
+       # read-through + uncapping are gated on the Phase 4 budget governor (#1090).
+       {"0 4 * * *", Cinegraph.Workers.TmdbMovieRefreshSweeper},
        # Biography refresh: 5,000/day on :tmdb queue.
        {"30 5 * * *", Cinegraph.Workers.BiographyRefreshSweeper},
        # Profile-data refresh (profile_path + known_for_department): 3,000/day

--- a/lib/cinegraph/homepage.ex
+++ b/lib/cinegraph/homepage.ex
@@ -109,7 +109,9 @@ defmodule Cinegraph.Homepage do
       subtitle:
         "We score every film six different ways — by critics, audiences, festivals, the canon, the people who made it, and the box office — so you can find what's good by your definition of good.",
       cta_label: "Ask the Video Clerk",
-      cta_href: "/video-clerk",
+      # Repointed to a public page (#1098): the full Video Clerk page is shelved
+      # behind admin auth, so the hero CTA can't route the public there.
+      cta_href: "/now-playing",
       backdrop_url: hero_backdrop(date)
     }
   end

--- a/lib/cinegraph/maintenance/refresh_tmdb_movies.ex
+++ b/lib/cinegraph/maintenance/refresh_tmdb_movies.ex
@@ -1,0 +1,72 @@
+defmodule Cinegraph.Maintenance.RefreshTmdbMovies do
+  @moduledoc """
+  Floor selection for the unified per-movie TMDb refresh (#1106). Selects movies
+  due on `tmdb_details` OR `watch_providers` via the freshness ledger and enqueues
+  one `TMDbMovieRefreshWorker` per movie (a movie due on *either* source gets the
+  whole record refreshed in a single TMDb call).
+
+  Reachable from `Cinegraph.Workers.TmdbMovieRefreshSweeper` (Oban cron) and
+  `bin/cinegraph eval`. Options: `:limit` (cap), `:dry_run` (count only).
+  """
+  alias Cinegraph.Freshness
+  alias Cinegraph.Workers.TMDbMovieRefreshWorker
+
+  require Logger
+
+  @insert_chunk_size 500
+  @default_limit 5_000
+
+  @doc """
+  Select movies due on `tmdb_details`/`watch_providers` and enqueue one
+  `TMDbMovieRefreshWorker` each. Options: `:limit` (cap, default #{@default_limit}),
+  `:dry_run` (count only, enqueues nothing). Returns
+  `{:ok, %{found:, enqueued:, failed:, dry_run:}}`.
+  """
+  def run(opts \\ []) when is_list(opts) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+    dry_run? = Keyword.get(opts, :dry_run, false)
+
+    # Union of the two TMDb sources, deduped — one refresh covers both.
+    ids =
+      (Freshness.due("tmdb_details", limit) ++ Freshness.due("watch_providers", limit))
+      |> Enum.uniq()
+      |> Enum.take(limit)
+
+    found = length(ids)
+
+    if dry_run? do
+      Logger.info("RefreshTmdbMovies: dry-run found #{found} movies due")
+      {:ok, %{found: found, enqueued: 0, failed: 0, dry_run: true}}
+    else
+      {enqueued, failed} = enqueue_in_chunks(ids)
+      Logger.info("RefreshTmdbMovies: enqueued #{enqueued} on :tmdb (#{failed} failed)")
+      {:ok, %{found: found, enqueued: enqueued, failed: failed, dry_run: false}}
+    end
+  end
+
+  defp enqueue_in_chunks(ids) do
+    ids
+    |> Enum.chunk_every(@insert_chunk_size)
+    |> Enum.reduce({0, 0}, fn chunk, {ok, err} ->
+      jobs = Enum.map(chunk, &TMDbMovieRefreshWorker.new(%{movie_id: &1}))
+
+      try do
+        case Oban.insert_all(jobs) do
+          results when is_list(results) ->
+            {ok + length(results), err}
+
+          other ->
+            Logger.error("RefreshTmdbMovies: Oban.insert_all returned #{inspect(other)}")
+            {ok, err + length(chunk)}
+        end
+      rescue
+        e ->
+          Logger.error(
+            "RefreshTmdbMovies: insert_all failed (#{length(chunk)}): #{Exception.message(e)}"
+          )
+
+          {ok, err + length(chunk)}
+      end
+    end)
+  end
+end

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -1027,9 +1027,43 @@ defmodule Cinegraph.Movies do
   Public wrapper for the internal process_movie_credits function.
   Used by DataRepairWorker to backfill missing credits.
   """
-  def process_movie_credits_public(movie, credits_data) do
-    process_movie_credits(movie, credits_data)
+  def process_movie_credits_public(movie, credits_data, opts \\ []) do
+    process_movie_credits(movie, credits_data, opts)
   end
+
+  @doc """
+  Refresh an EXISTING movie from a fresh TMDb response (#1106) — re-hydrates the
+  core columns, ratings/metrics, cast/crew, and watch providers in one pass,
+  WITHOUT the import-only side effects (canonical_sources, OMDb enqueue,
+  quality/soft-vs-full gating, recommendations/similar/reviews/lists/videos).
+
+  Expects `tmdb_data` from `TMDb.get_movie_for_refresh/1` (watch providers under
+  the normalized `"watch_providers"` key). Returns `{:ok, %{watch_present?: bool}}`
+  so the caller can set the `watch_providers` freshness status.
+  """
+  def refresh_movie_from_tmdb(%Movie{} = movie, tmdb_data) do
+    # Update the structured columns but PRESERVE the raw blob: `Movie.from_tmdb/1`
+    # sets `tmdb_data` to the *lean* refresh response, which would drop the rich
+    # import-only sections (images/videos/recommendations/…) and rewrite a multi-MB
+    # JSONB blob on every refresh. Drop `:tmdb_data` from the update.
+    attrs = tmdb_data |> Movie.from_tmdb() |> Map.delete(:tmdb_data)
+
+    with {:ok, movie} <- movie |> Movie.changeset(attrs) |> Repo.update(),
+         :ok <- Metrics.store_tmdb_metrics(movie, tmdb_data),
+         :ok <-
+           process_movie_credits(movie, tmdb_data["credits"], rebuild_collaborations: :if_changed),
+         :ok <- process_movie_keywords(movie, tmdb_data["keywords"]),
+         :ok <- process_movie_release_dates(movie, tmdb_data["release_dates"]),
+         watch = tmdb_data["watch_providers"],
+         {:ok, _} <- Cinegraph.Movies.Availability.store_tmdb_watch_providers(movie, watch) do
+      # Only report presence once the store has actually committed, so the caller's
+      # `watch_providers` freshness touch reflects persisted data — not just payload.
+      {:ok, %{watch_present?: watch_present?(watch)}}
+    end
+  end
+
+  defp watch_present?(%{"results" => results}) when is_map(results), do: map_size(results) > 0
+  defp watch_present?(_), do: false
 
   @doc """
   Gets credits for a movie.
@@ -1184,10 +1218,17 @@ defmodule Cinegraph.Movies do
 
   # Processing functions for comprehensive movie data
 
-  defp process_movie_credits(_movie, nil), do: :ok
+  defp process_movie_credits(movie, credits, opts \\ [])
+  defp process_movie_credits(_movie, nil, _opts), do: :ok
 
-  defp process_movie_credits(movie, %{"cast" => cast, "crew" => crew}) do
+  defp process_movie_credits(movie, %{"cast" => cast, "crew" => crew}, opts) do
     alias Cinegraph.Imports.QualityFilter
+
+    # #1106: on a refresh, only rebuild the collaboration graph if the credit set
+    # actually changed (avoid a per-refresh rebuild storm). `rebuild_collaborations`:
+    # `true` (default, import behavior) | `:if_changed` (refresh) | `false`.
+    rebuild = Elixir.Keyword.get(opts, :rebuild_collaborations, true)
+    before_ids = if rebuild == :if_changed, do: movie_credit_id_set(movie.id), else: nil
 
     # Process cast
     cast_count =
@@ -1241,11 +1282,25 @@ defmodule Cinegraph.Movies do
         end
       end)
 
-    if cast_count + crew_count > 0 do
-      Collaborations.enqueue_movie_rebuild(movie)
-    end
+    rebuild? =
+      case rebuild do
+        :if_changed -> movie_credit_id_set(movie.id) != before_ids
+        false -> false
+        _ -> cast_count + crew_count > 0
+      end
+
+    if rebuild?, do: Collaborations.enqueue_movie_rebuild(movie)
 
     :ok
+  end
+
+  defp movie_credit_id_set(movie_id) do
+    from(c in "movie_credits",
+      where: c.movie_id == ^movie_id and not is_nil(c.credit_id),
+      select: c.credit_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
   end
 
   defp process_movie_keywords(_movie, nil), do: :ok

--- a/lib/cinegraph/services/tmdb.ex
+++ b/lib/cinegraph/services/tmdb.ex
@@ -53,6 +53,14 @@ defmodule Cinegraph.Services.TMDb do
   end
 
   @doc """
+  Lean per-movie refresh fetch (#1106): details + metrics + credits + watch
+  providers in one `append_to_response` call. See `Extended.get_movie_for_refresh/1`.
+  """
+  def get_movie_for_refresh(movie_id) do
+    Extended.get_movie_for_refresh(movie_id)
+  end
+
+  @doc """
   Gets watch provider information for a movie.
   """
   def get_movie_watch_providers(movie_id) do

--- a/lib/cinegraph/services/tmdb_extended.ex
+++ b/lib/cinegraph/services/tmdb_extended.ex
@@ -349,22 +349,45 @@ defmodule Cinegraph.Services.TMDb.Extended do
     case Client.get("/movie/#{movie_id}", %{append_to_response: append}) do
       {:ok, movie} ->
         # Watch providers might need separate call if not in append_to_response
-        movie_with_providers =
-          case movie["watch/providers"] do
-            nil ->
-              case get_movie_watch_providers(movie_id) do
-                {:ok, providers} -> Map.put(movie, "watch_providers", providers)
-                _ -> movie
-              end
-
-            providers ->
-              Map.put(movie, "watch_providers", providers)
-          end
-
-        {:ok, movie_with_providers}
+        {:ok, normalize_watch_providers(movie, movie_id)}
 
       error ->
         error
+    end
+  end
+
+  @doc """
+  Lean per-movie REFRESH fetch (#1106). One call refreshes the volatile data the
+  unified refresh writes (details, metrics, credits, watch providers) without the
+  heavy import-only blocks (images/videos/recommendations/similar/translations/
+  reviews/lists). Normalizes `"watch/providers"` → `"watch_providers"` like
+  `get_movie_ultra_comprehensive/1`.
+  """
+  def get_movie_for_refresh(movie_id) do
+    append = "credits,keywords,external_ids,release_dates,watch/providers"
+
+    case Client.get("/movie/#{movie_id}", %{append_to_response: append}) do
+      {:ok, movie} ->
+        {:ok, normalize_watch_providers(movie, movie_id)}
+
+      error ->
+        error
+    end
+  end
+
+  # Normalize the appended `"watch/providers"` block to the `"watch_providers"`
+  # key the rest of the pipeline expects, falling back to a dedicated fetch when
+  # the append_to_response response omitted it.
+  defp normalize_watch_providers(movie, movie_id) do
+    case movie["watch/providers"] do
+      nil ->
+        case get_movie_watch_providers(movie_id) do
+          {:ok, providers} -> Map.put(movie, "watch_providers", providers)
+          _ -> movie
+        end
+
+      providers ->
+        Map.put(movie, "watch_providers", providers)
     end
   end
 

--- a/lib/cinegraph/workers/availability_refresh_sweeper.ex
+++ b/lib/cinegraph/workers/availability_refresh_sweeper.ex
@@ -9,7 +9,13 @@ defmodule Cinegraph.Workers.AvailabilityRefreshSweeper do
 
   require Logger
 
-  @per_run_limit 5_000
+  # Bumped 5k → 30k (#1106): full-catalog drain ~76 days → ~25 days. TMDb isn't the
+  # limiter; pair this with OBAN_MOVIE_AVAILABILITY_LIMIT=5 (concurrency of the
+  # :movie_availability queue in runtime.exs, was 1 — separate from :maintenance:1)
+  # on deploy. NOTE: each fetch writes ~139 region rows — at 30k/day that's ~4M
+  # row-writes/day on the shared box. To go faster *safely*, narrow the region set
+  # (see #1106 Part A — the real unlock; gets it to ~15 days at far lower DB load).
+  @per_run_limit 30_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do

--- a/lib/cinegraph/workers/tmdb_movie_refresh_sweeper.ex
+++ b/lib/cinegraph/workers/tmdb_movie_refresh_sweeper.ex
@@ -1,0 +1,29 @@
+defmodule Cinegraph.Workers.TmdbMovieRefreshSweeper do
+  @moduledoc """
+  Daily floor sweeper (#1106): enqueues a capped batch of `TMDbMovieRefreshWorker`
+  jobs for movies due on `tmdb_details`/`watch_providers` per the freshness ledger.
+  This is the capped *floor* — broad/uncapped running + read-through wait for the
+  Phase 4 budget governor (#1090 Phase 4).
+  """
+  use Oban.Worker, queue: :maintenance, max_attempts: 1, priority: 3
+
+  alias Cinegraph.Maintenance.RefreshTmdbMovies
+
+  require Logger
+
+  @per_run_limit 5_000
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    # `run/1` returns `{:ok, stats}` or raises; a raise lets Oban mark the job
+    # failed (max_attempts: 1) rather than us swallowing it into `{:error, _}`.
+    {:ok, %{found: found, enqueued: enqueued, failed: failed} = stats} =
+      RefreshTmdbMovies.run(limit: @per_run_limit)
+
+    Logger.info(
+      "TmdbMovieRefreshSweeper: found=#{found} enqueued=#{enqueued} failed=#{failed} (cap=#{@per_run_limit})"
+    )
+
+    {:ok, stats}
+  end
+end

--- a/lib/cinegraph/workers/tmdb_movie_refresh_worker.ex
+++ b/lib/cinegraph/workers/tmdb_movie_refresh_worker.ex
@@ -1,0 +1,90 @@
+defmodule Cinegraph.Workers.TMDbMovieRefreshWorker do
+  @moduledoc """
+  Unified per-movie TMDb refresh (#1106): ONE `append_to_response` call
+  re-hydrates an existing movie's details + ratings/metrics + credits + watch
+  providers, and touches the freshness ledger for `tmdb_details` and
+  `watch_providers` in the same pass. Replaces the siloed per-source TMDb fetches
+  and closes the one-shot-details gap (#1010 grade-D).
+
+  Enqueued by `TmdbMovieRefreshSweeper` (the floor) selecting via `Freshness.due/2`.
+  Read-through and uncapping are gated on the Phase 4 budget governor (#1090 Phase 4).
+  """
+  use Oban.Worker,
+    queue: :tmdb,
+    max_attempts: 3,
+    unique: [fields: [:args], keys: [:movie_id], period: 3600]
+
+  alias Cinegraph.{Freshness, Movies, Repo}
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Services.TMDb
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"movie_id" => movie_id}}) do
+    # Route replica reads through the worker pool so this doesn't compete with web. (#1007)
+    Repo.route_to_worker()
+    refresh(movie_id)
+  end
+
+  @doc """
+  Refresh one existing movie. `opts[:fetch_fun]` is injectable for tests
+  (default `&TMDb.get_movie_for_refresh/1`), mirroring `MovieAvailabilityRefreshWorker`.
+  """
+  def refresh(movie_id, opts \\ []) do
+    fetch_fun = Keyword.get(opts, :fetch_fun, &TMDb.get_movie_for_refresh/1)
+
+    case Repo.get(Movie, movie_id) do
+      nil ->
+        {:cancel, :movie_not_found}
+
+      %Movie{tmdb_id: nil} = movie ->
+        # No TMDb id → can never refresh from TMDb (precondition-ineligible, #1010 §6).
+        Freshness.touch("movie", movie.id, "tmdb_details", :ineligible)
+        {:cancel, :missing_tmdb_id}
+
+      movie ->
+        do_refresh(movie, fetch_fun)
+    end
+  end
+
+  defp do_refresh(%Movie{} = movie, fetch_fun) do
+    base = movie.release_date
+
+    case fetch_fun.(movie.tmdb_id) do
+      {:ok, data} ->
+        case Movies.refresh_movie_from_tmdb(movie, data) do
+          {:ok, %{watch_present?: present?}} ->
+            Freshness.touch("movie", movie.id, "tmdb_details", :ok, base_date: base)
+
+            watch_status = if present?, do: :ok, else: :empty
+            Freshness.touch("movie", movie.id, "watch_providers", watch_status, base_date: base)
+
+            {:ok, %{movie_id: movie.id, watch_present?: present?}}
+
+          {:error, reason} ->
+            Logger.error(
+              "TMDbMovieRefreshWorker store failed for #{movie.id}: #{inspect(reason)}"
+            )
+
+            touch_error(movie, base, reason)
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        Logger.warning("TMDbMovieRefreshWorker fetch failed for #{movie.id}: #{inspect(reason)}")
+        touch_error(movie, base, reason)
+        {:error, reason}
+    end
+  end
+
+  defp touch_error(movie, base, reason) do
+    err = inspect(reason)
+    Freshness.touch("movie", movie.id, "tmdb_details", :error, base_date: base, error_reason: err)
+
+    Freshness.touch("movie", movie.id, "watch_providers", :error,
+      base_date: base,
+      error_reason: err
+    )
+  end
+end

--- a/lib/cinegraph_web/live/home_live.ex
+++ b/lib/cinegraph_web/live/home_live.ex
@@ -76,7 +76,7 @@ defmodule CinegraphWeb.HomeLive do
     %{
       icon: "🏪",
       title: "Ask the Video Clerk for a pick that explains itself.",
-      href: "/video-clerk"
+      href: "/now-playing"
     }
   ]
 

--- a/lib/cinegraph_web/live/home_live.html.heex
+++ b/lib/cinegraph_web/live/home_live.html.heex
@@ -273,7 +273,7 @@
       subtitle="Tell us a film you love. We'll pick one for tonight — and tell you why."
     >
       <:action>
-        <CinegraphWeb.NeutralV2Components.n_link_action href={~p"/video-clerk"}>
+        <CinegraphWeb.NeutralV2Components.n_link_action href={~p"/now-playing"}>
           Open the full clerk
         </CinegraphWeb.NeutralV2Components.n_link_action>
       </:action>
@@ -472,7 +472,6 @@
         <.link navigate={~p"/lists"}>Lists</.link>
         <.link navigate={~p"/awards"}>Awards</.link>
         <.link navigate={~p"/six-degrees"}>Six-Degrees</.link>
-        <.link navigate={~p"/video-clerk"}>Video Clerk</.link>
       </nav>
     </footer>
   </section>

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -774,7 +774,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
                 </h2>
               </div>
               <.link
-                navigate={~p"/video-clerk?#{%{seed: movie_slug_or_id(@movie)}}"}
+                navigate={~p"/now-playing"}
                 class="inline-flex rounded-md bg-mist-950 px-3 py-2 text-[12px] font-semibold text-mist-50 hover:bg-mist-800"
               >
                 Ask the Video Clerk

--- a/lib/cinegraph_web/live/video_clerk_live.ex
+++ b/lib/cinegraph_web/live/video_clerk_live.ex
@@ -127,7 +127,7 @@ defmodule CinegraphWeb.VideoClerkLive do
      socket
      |> assign(:search_query, "")
      |> assign(:search_results, [])
-     |> push_patch(to: ~p"/video-clerk")}
+     |> push_patch(to: ~p"/admin/video-clerk")}
   end
 
   def handle_event("load_demo", _params, socket) do
@@ -252,7 +252,7 @@ defmodule CinegraphWeb.VideoClerkLive do
     %{primary: nil, alternates: [], seed_movies: [], route_labels: [], evidence_summary: []}
   end
 
-  defp video_clerk_path([]), do: ~p"/video-clerk"
+  defp video_clerk_path([]), do: ~p"/admin/video-clerk"
 
   defp video_clerk_path(selected) do
     slugs =
@@ -263,7 +263,7 @@ defmodule CinegraphWeb.VideoClerkLive do
       end)
       |> Enum.join(",")
 
-    ~p"/video-clerk?#{%{movies: slugs}}"
+    ~p"/admin/video-clerk?#{%{movies: slugs}}"
   end
 
   defp demo_films do

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -211,7 +211,6 @@ defmodule CinegraphWeb.Router do
       layout: false,
       on_mount: [{CinegraphWeb.Live.AuthHooks, :assign_auth_user}] do
       live "/now-playing", NowPlayingLive, :index
-      live "/video-clerk", VideoClerkLive, :show
       live "/lists", ListLive.Index, :index
       live "/lists/:slug", ListLive.Show, :show
       live "/awards", AwardsLive.Index, :index
@@ -334,6 +333,18 @@ defmodule CinegraphWeb.Router do
       live "/festival", FestivalAuditLive, :index
       live "/festival/:org_slug", FestivalAuditLive, :organization
       live "/festival/:org_slug/:year", FestivalAuditLive, :ceremony
+    end
+
+    # Video Clerk (#1098): shelved behind admin basic auth — an unfinished public
+    # mock page whose homepage CTA was driving ~9K/day of crawler traffic into a
+    # heavy multi-shelf mount. Kept reachable for dev at /admin/video-clerk; the
+    # public /video-clerk route is gone (404). Keeps the page's own v2 chrome
+    # rather than the admin dashboard layout.
+    live_session :admin_video_clerk,
+      root_layout: {CinegraphWeb.Layouts, :v2_root},
+      layout: false,
+      on_mount: [{CinegraphWeb.Live.AuthHooks, :assign_auth_user}] do
+      live "/video-clerk", VideoClerkLive, :show
     end
 
     # Oban dashboard is a forwarded plug, not a LiveView, so it cannot live

--- a/test/cinegraph/maintenance/refresh_tmdb_movies_test.exs
+++ b/test/cinegraph/maintenance/refresh_tmdb_movies_test.exs
@@ -1,0 +1,38 @@
+defmodule Cinegraph.Maintenance.RefreshTmdbMoviesTest do
+  @moduledoc "#1106 — floor selection: the deduped union of due tmdb sources."
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Maintenance.RefreshTmdbMovies
+  alias Cinegraph.Freshness.DataRefresh
+  alias Cinegraph.Repo
+
+  defp ledger!(entity_id, source, stale_after) do
+    %DataRefresh{}
+    |> DataRefresh.changeset(%{
+      entity_type: "movie",
+      entity_id: entity_id,
+      source: source,
+      status: "ok",
+      fetched_at: DateTime.add(stale_after, -40 * 86_400, :second),
+      stale_after: stale_after
+    })
+    |> Repo.insert!()
+  end
+
+  test "selects the deduped union of tmdb_details + watch_providers due movies" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    past = DateTime.add(now, -86_400, :second)
+    future = DateTime.add(now, 86_400, :second)
+
+    ledger!(1, "tmdb_details", past)
+    ledger!(2, "watch_providers", past)
+    # movie 3 is due on BOTH → must count once
+    ledger!(3, "tmdb_details", past)
+    ledger!(3, "watch_providers", past)
+    # movie 4 not yet due → excluded
+    ledger!(4, "tmdb_details", future)
+
+    assert {:ok, %{found: 3, enqueued: 0, failed: 0, dry_run: true}} =
+             RefreshTmdbMovies.run(dry_run: true)
+  end
+end

--- a/test/cinegraph/movies/process_movie_credits_rebuild_test.exs
+++ b/test/cinegraph/movies/process_movie_credits_rebuild_test.exs
@@ -1,0 +1,57 @@
+defmodule Cinegraph.Movies.ProcessMovieCreditsRebuildTest do
+  @moduledoc "#1106 — refresh-mode credits: rebuild collaborations only when the credit set changed."
+  use Cinegraph.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Cinegraph.Movies
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Repo
+
+  defp collab_jobs do
+    Repo.aggregate(
+      from(j in Oban.Job, where: j.worker == "Cinegraph.Workers.CollaborationWorker"),
+      :count,
+      :id
+    )
+  end
+
+  test "rebuild_collaborations: :if_changed enqueues a rebuild only when the credit set changes" do
+    movie =
+      %Movie{}
+      |> Movie.changeset(%{tmdb_id: System.unique_integer([:positive]), title: "M"})
+      |> Repo.insert!()
+
+    # Director is always imported (bypasses the quality filter)
+    credits = %{
+      "cast" => [],
+      "crew" => [
+        %{
+          "id" => System.unique_integer([:positive]),
+          "name" => "Some Director",
+          "job" => "Director",
+          "department" => "Directing",
+          "credit_id" => "credit-#{System.unique_integer([:positive])}"
+        }
+      ]
+    }
+
+    assert collab_jobs() == 0
+
+    # first run: new credit → set changed → one rebuild enqueued
+    assert :ok =
+             Movies.process_movie_credits_public(movie, credits,
+               rebuild_collaborations: :if_changed
+             )
+
+    assert collab_jobs() == 1
+
+    # second run: identical credits → set unchanged → no new rebuild
+    assert :ok =
+             Movies.process_movie_credits_public(movie, credits,
+               rebuild_collaborations: :if_changed
+             )
+
+    assert collab_jobs() == 1
+  end
+end

--- a/test/cinegraph/workers/tmdb_movie_refresh_worker_test.exs
+++ b/test/cinegraph/workers/tmdb_movie_refresh_worker_test.exs
@@ -1,0 +1,84 @@
+defmodule Cinegraph.Workers.TMDbMovieRefreshWorkerTest do
+  @moduledoc "#1106 — unified per-movie TMDb refresh worker."
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Workers.TMDbMovieRefreshWorker
+  alias Cinegraph.Freshness.DataRefresh
+  alias Cinegraph.Movies.{ExternalMetric, Movie}
+  alias Cinegraph.Repo
+
+  defp movie!(attrs) do
+    %Movie{}
+    |> Movie.changeset(
+      Map.merge(
+        %{tmdb_id: System.unique_integer([:positive]), title: "Old Title", runtime: 90},
+        attrs
+      )
+    )
+    |> Repo.insert!()
+  end
+
+  defp ledger(id, src),
+    do: Repo.get_by(DataRefresh, entity_type: "movie", entity_id: id, source: src)
+
+  defp canned(tmdb_id, watch_results) do
+    %{
+      "id" => tmdb_id,
+      "title" => "Refreshed Title",
+      "runtime" => 142,
+      "overview" => "fresh overview",
+      "vote_average" => 8.1,
+      "vote_count" => 5000,
+      "popularity" => 77.0,
+      "credits" => %{"cast" => [], "crew" => []},
+      "watch_providers" => %{"results" => watch_results}
+    }
+  end
+
+  test "successful refresh updates the movie + metrics and touches both ledger sources" do
+    m = movie!(%{release_date: ~D[2020-01-01]})
+    # no providers in payload → watch_providers terminal :empty
+    fetch = fn _ -> {:ok, canned(m.tmdb_id, %{})} end
+
+    assert {:ok, %{watch_present?: false}} =
+             TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
+
+    updated = Repo.get(Movie, m.id)
+    assert updated.runtime == 142
+    assert updated.title == "Refreshed Title"
+
+    assert Repo.get_by(ExternalMetric,
+             movie_id: m.id,
+             source: "tmdb",
+             metric_type: "rating_average"
+           )
+
+    assert ledger(m.id, "tmdb_details").status == "ok"
+    assert ledger(m.id, "watch_providers").status == "empty"
+  end
+
+  test "watch_providers ledger is :ok when the payload carries providers" do
+    m = movie!(%{release_date: ~D[2021-01-01]})
+    fetch = fn _ -> {:ok, canned(m.tmdb_id, %{"US" => %{}})} end
+
+    assert {:ok, %{watch_present?: true}} = TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
+    assert ledger(m.id, "watch_providers").status == "ok"
+    assert ledger(m.id, "tmdb_details").status == "ok"
+  end
+
+  test "fetch error touches both sources :error and returns the error" do
+    m = movie!(%{release_date: ~D[2019-01-01]})
+    fetch = fn _ -> {:error, :timeout} end
+
+    assert {:error, :timeout} = TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
+    assert ledger(m.id, "tmdb_details").status == "error"
+    assert ledger(m.id, "watch_providers").status == "error"
+  end
+
+  # (No "missing tmdb_id" test: movies.tmdb_id is NOT NULL, so that worker branch is
+  # defensive-only and can't be constructed as a fixture.)
+
+  test "missing movie → cancel" do
+    assert {:cancel, :movie_not_found} = TMDbMovieRefreshWorker.refresh(999_999_999)
+  end
+end

--- a/test/cinegraph_web/live/home_live_test.exs
+++ b/test/cinegraph_web/live/home_live_test.exs
@@ -20,6 +20,8 @@ defmodule CinegraphWeb.HomeLiveTest do
     assert html =~ "Cinegraph lets you"
     assert html =~ "Ask the Video Clerk"
     assert html =~ ~s(href="/six-degrees")
-    assert html =~ ~s(href="/video-clerk")
+
+    # Video Clerk shelved behind admin auth (#1098) — homepage CTA now points public to /now-playing.
+    assert html =~ ~s(href="/now-playing")
   end
 end

--- a/test/cinegraph_web/live/movie_live/show_v2_video_clerk_test.exs
+++ b/test/cinegraph_web/live/movie_live/show_v2_video_clerk_test.exs
@@ -6,7 +6,9 @@ defmodule CinegraphWeb.MovieLive.ShowV2VideoClerkTest do
   alias Cinegraph.Movies.Movie
   alias Cinegraph.Repo
 
-  test "movie show page renders the Video Clerk module and seed link", %{conn: conn} do
+  test "movie show page renders the Video Clerk module linking to the public now-playing page", %{
+    conn: conn
+  } do
     seed = insert_movie!("Clerk Source Movie", %{})
 
     _pick =
@@ -18,7 +20,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2VideoClerkTest do
     html = render_async(view)
 
     assert html =~ "Ask the Video Clerk"
-    assert html =~ ~s(/video-clerk?seed=#{seed.slug})
+    assert html =~ ~s(href="/now-playing")
     assert html =~ "Clerk Candidate Movie"
   end
 

--- a/test/cinegraph_web/live/video_clerk_live_test.exs
+++ b/test/cinegraph_web/live/video_clerk_live_test.exs
@@ -7,7 +7,7 @@ defmodule CinegraphWeb.VideoClerkLiveTest do
   alias Cinegraph.Repo
 
   test "renders the Video Clerk page with manifesto copy", %{conn: conn} do
-    {:ok, _view, html} = live(conn, ~p"/video-clerk")
+    {:ok, _view, html} = live(conn, ~p"/admin/video-clerk")
 
     assert html =~ "The Video Clerk"
     assert html =~ "Three films in. One human-feeling recommendation out."
@@ -22,7 +22,7 @@ defmodule CinegraphWeb.VideoClerkLiveTest do
     cult = insert_movie!("Repo Man", "cult_movies_400", 2)
     canon = insert_movie!("Bicycle Thieves", "1001_movies", 1)
 
-    {:ok, _view, html} = live(conn, ~p"/video-clerk")
+    {:ok, _view, html} = live(conn, ~p"/admin/video-clerk")
 
     assert html =~ cult.title
     assert html =~ canon.title
@@ -34,7 +34,7 @@ defmodule CinegraphWeb.VideoClerkLiveTest do
     seed = insert_movie!("Donnie Darko", "1001_movies", 1)
     pick = insert_movie!("Harold and Maude", "cult_movies_400", 2)
 
-    {:ok, _view, html} = live(conn, ~p"/video-clerk?seed=#{seed.slug}")
+    {:ok, _view, html} = live(conn, ~p"/admin/video-clerk?seed=#{seed.slug}")
 
     assert html =~ seed.title
     assert html =~ pick.title
@@ -45,7 +45,7 @@ defmodule CinegraphWeb.VideoClerkLiveTest do
     seed = insert_movie!("Searchable Clerk Seed", "1001_movies", 1)
     pick = insert_movie!("Searchable Clerk Pick", "cult_movies_400", 2)
 
-    {:ok, view, _html} = live(conn, ~p"/video-clerk")
+    {:ok, view, _html} = live(conn, ~p"/admin/video-clerk")
 
     html = render_change(view, "search_movies", %{"q" => "Searchable Clerk Seed"})
     assert html =~ seed.title


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily scheduled refresh of movie details, credits, metrics, and watch-provider data from TMDb.
  * Per-movie refresh capability to update existing movie data on demand.

* **Chores**
  * Increased availability refresh capacity from 5,000 to 30,000 items per cycle.

* **UI / Routing**
  * “Video Clerk” links updated to point to the public “Now Playing” page; Video Clerk is now available under admin-only routes and removed from public navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->