### PR TITLE
new worker

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -292,6 +292,10 @@ config :cinegraph, Oban,
        {"45 6 * * *", Cinegraph.Workers.AvailabilityRefreshSweeper},
        # IMDb-id repair via TMDb fetches: 5,000/day on :tmdb.
        {"0 7 * * *", Cinegraph.Workers.ImdbIdRepairSweeper},
+       # imdb_id source-absent marking (#1109): weekly belt-and-suspenders on
+       # :maintenance (no API — writes ledger rows only). The inline touch on the
+       # fetch paths is the real steady state; this catches drift. Sun 03:30 UTC.
+       {"30 3 * * 0", Cinegraph.Workers.MarkImdbIdAbsentSweeper},
        # Collaboration graph repair: 5,000 movies/day enqueued.
        # Sweeper itself runs on :maintenance; the per-movie rebuilds it
        # enqueues run on :collaboration (concurrency 3).

--- a/lib/cinegraph/admin/job_registry.ex
+++ b/lib/cinegraph/admin/job_registry.ex
@@ -67,7 +67,7 @@ defmodule Cinegraph.Admin.JobRegistry do
 
   @entries [
     # =========================================================================
-    # Scheduled entries (25 — must match config.exs crontab exactly)
+    # Scheduled entries (27 — must match config.exs crontab exactly)
     # =========================================================================
 
     %{
@@ -198,6 +198,34 @@ defmodule Cinegraph.Admin.JobRegistry do
       mutating: true,
       description: "Monthly canonical IMDb-list refresh (blank/stale movie_lists)",
       destination: :imports,
+      doc_url: nil
+    },
+    %{
+      id: :tmdb_movie_refresh_sweeper,
+      label: "Unified TMDb movie refresh",
+      worker: Workers.TmdbMovieRefreshSweeper,
+      queue: :maintenance,
+      schedule: "0 4 * * *",
+      args: %{},
+      trigger_action: :enqueue_now,
+      mutating: true,
+      description:
+        "Unified per-movie TMDb refresh (#1106): 5,000/day floor — one call re-hydrates details + metrics + credits + watch + imdb_id",
+      destination: :movies,
+      doc_url: nil
+    },
+    %{
+      id: :mark_imdb_id_absent_sweeper,
+      label: "imdb_id source-absent marker",
+      worker: Workers.MarkImdbIdAbsentSweeper,
+      queue: :maintenance,
+      schedule: "30 3 * * 0",
+      args: %{},
+      trigger_action: :enqueue_now,
+      mutating: true,
+      description:
+        "Weekly (#1109): mark checked-but-null imdb_id movies source-absent in the ledger (no API)",
+      destination: :movies,
       doc_url: nil
     },
     %{

--- a/lib/cinegraph/freshness/policy.ex
+++ b/lib/cinegraph/freshness/policy.ex
@@ -30,7 +30,11 @@ defmodule Cinegraph.Freshness.Policy do
         {:age_tiered, :release_date, %{new: 7, recent: 30, catalog: 180, old: 365}},
       "omdb" => {:age_tiered, :release_date, %{new: 7, recent: 30, catalog: 90, old: 365}},
       "watch_providers" =>
-        {:age_tiered, :release_date, %{new: 3, recent: 7, catalog: 30, old: 90}}
+        {:age_tiered, :release_date, %{new: 3, recent: 7, catalog: 30, old: 90}},
+      # imdb_id rides the tmdb_details fetch (same TMDb top-level field) — identical
+      # TTL so the two couple and are serviced together. It never independently drives
+      # a refresh; this entry only lets `touch/5` resolve a TTL (#1109).
+      "imdb_id" => {:age_tiered, :release_date, %{new: 7, recent: 30, catalog: 180, old: 365}}
     },
     "person" => %{
       "tmdb_person" =>

--- a/lib/cinegraph/health/surface_area.ex
+++ b/lib/cinegraph/health/surface_area.ex
@@ -174,8 +174,28 @@ defmodule Cinegraph.Health.SurfaceArea do
     eligible = count(from(m in "movies"))
     fetched = count(from m in "movies", where: not is_nil(m.imdb_id) and m.imdb_id != "")
 
-    fetch_row("imdb_id", eligible, fetched, nil, max(eligible - fetched, 0),
-      note: "TMDb long tail has no IMDb ID at source — recovery yield ≈ 0 (#1090 ceiling)"
+    # #1109: a movie that's still null but HAS an `imdb_id` ledger `:empty` marker is
+    # source-absent — we fetched TMDb details (which carry the id) and it had none.
+    # Counts as terminal so the structural ceiling reads ~100%, not a 510k backlog.
+    source_absent =
+      count(
+        from m in "movies",
+          where: is_nil(m.imdb_id) or m.imdb_id == "",
+          where:
+            fragment(
+              "EXISTS (SELECT 1 FROM data_refreshes dr WHERE dr.entity_type = 'movie' AND dr.entity_id = ? AND dr.source = 'imdb_id' AND dr.status = 'empty')",
+              m.id
+            )
+      )
+
+    fetch_row(
+      "imdb_id",
+      eligible,
+      fetched,
+      source_absent,
+      max(eligible - fetched - source_absent, 0),
+      note:
+        "TMDb long tail has no IMDb ID at source — null-after-fetch marked source-absent (#1109)"
     )
   end
 

--- a/lib/cinegraph/maintenance/mark_imdb_id_absent.ex
+++ b/lib/cinegraph/maintenance/mark_imdb_id_absent.ex
@@ -1,0 +1,143 @@
+defmodule Cinegraph.Maintenance.MarkImdbIdAbsent do
+  @moduledoc """
+  Marks movies whose IMDb ID does not exist at the source as **source-absent**
+  in the freshness ledger (#1109), so `imdb_id` reads as terminal instead of a
+  permanent backlog.
+
+  `imdb_id` is read straight from the TMDb `/movie` top-level field
+  (`Movie.from_tmdb/1`) — there is no separate lookup. So a movie whose TMDb
+  details were fetched but whose `imdb_id` is still null/empty means the source
+  simply has none: that is terminal (source-absent), not work to do.
+
+  Eligible = `imdb_id` null/empty **and** a `tmdb_details` ledger attempt exists
+  (`ok|empty|ineligible` — we fetched details, so we saw the field) **and** no
+  `imdb_id` ledger row yet (idempotent: re-runs skip already-marked movies).
+
+  Writes `:empty` rows in bulk via `Repo.insert_all` — mirroring `Freshness.touch/5`'s
+  fields + conflict behavior, with the Policy `:empty` TTL — fast enough for the
+  one-shot 300–510k catch-up (row-by-row `touch` was too DB-chatty at that scale).
+
+  Movies that are null but were *never* fully detail-fetched (no `tmdb_details`
+  ledger row — e.g. discovery-only stubs whose payload never carried `imdb_id`)
+  are **deliberately excluded**: they are genuine backlog, not source-absent. They
+  remain `needs_fetch` until a full `/movie` fetch runs. NOTE (#1109): the existing
+  `RepairImdbIds → TMDbDetailsWorker` path can't complete those stubs — the worker
+  skips movies that already exist (`tmdb_details_worker.ex` `process_tmdb_movie/3`).
+  Completing stubs is a separate pre-existing gap (follow-up under #760/#1108), not
+  this module's job.
+
+  Reachable from:
+  - `Cinegraph.Workers.MarkImdbIdAbsentSweeper` (Oban Cron, weekly, belt-and-suspenders)
+  - `bin/cinegraph eval "Cinegraph.Maintenance.MarkImdbIdAbsent.run([])"` (one-shot prod)
+
+  ## Options
+    * `:limit` (positive integer) — cap the number of movies marked.
+    * `:dry_run` (boolean) — count only; write nothing.
+
+  ## Returns
+  `{:ok, %{found: integer, marked: integer, failed: integer, dry_run: boolean}}`
+  """
+
+  alias Cinegraph.Freshness.{DataRefresh, Policy}
+  alias Cinegraph.Repo
+
+  import Ecto.Query
+  require Logger
+
+  # Sub-batch under Postgres' 65,535 bind-param cap (~12 fields/row → ≤ ~5,400 rows).
+  @insert_chunk_size 4_000
+  # One-time catch-up of the checked-but-null set (~300–510k); no API, so high.
+  @default_limit 1_000_000
+
+  @spec run(keyword()) ::
+          {:ok,
+           %{
+             found: non_neg_integer(),
+             marked: non_neg_integer(),
+             failed: non_neg_integer(),
+             dry_run: boolean()
+           }}
+  def run(opts \\ []) when is_list(opts) do
+    limit =
+      case Keyword.get(opts, :limit, @default_limit) do
+        n when is_integer(n) and n > 0 -> n
+        other -> raise ArgumentError, ":limit must be a positive integer, got: #{inspect(other)}"
+      end
+
+    base =
+      from m in "movies",
+        where:
+          (is_nil(m.imdb_id) or m.imdb_id == "") and
+            fragment(
+              "EXISTS (SELECT 1 FROM data_refreshes dr WHERE dr.entity_type = 'movie' AND dr.entity_id = ? AND dr.source = 'tmdb_details' AND dr.status IN ('ok','empty','ineligible'))",
+              m.id
+            ) and
+            fragment(
+              "NOT EXISTS (SELECT 1 FROM data_refreshes dr WHERE dr.entity_type = 'movie' AND dr.entity_id = ? AND dr.source = 'imdb_id')",
+              m.id
+            ),
+        order_by: [asc: m.id],
+        limit: ^limit,
+        select: {m.id, m.release_date}
+
+    rows = Repo.replica().all(base)
+    found = length(rows)
+    dry_run? = Keyword.get(opts, :dry_run, false)
+
+    if dry_run? do
+      Logger.info("MarkImdbIdAbsent: dry-run found #{found} movies to mark source-absent")
+      {:ok, %{found: found, marked: 0, failed: 0, dry_run: true}}
+    else
+      {marked, failed} = mark_in_chunks(rows)
+      Logger.info("MarkImdbIdAbsent: marked #{marked} imdb_id source-absent (#{failed} failed)")
+      {:ok, %{found: found, marked: marked, failed: failed, dry_run: false}}
+    end
+  end
+
+  defp mark_in_chunks(rows) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    rows
+    |> Enum.chunk_every(@insert_chunk_size)
+    |> Enum.reduce({0, 0}, fn chunk, {ok, err} ->
+      entries = Enum.map(chunk, &entry(&1, now))
+
+      try do
+        # Mirror Freshness.touch/5 (#1109): status "empty", fetched_at nil, Policy :empty
+        # TTL, attempt_count 0, and the same on_conflict/conflict_target so a concurrent
+        # touch never duplicates. insert_all does NO casting — values are DB-ready.
+        {count, _} =
+          Repo.insert_all(DataRefresh, entries,
+            on_conflict: {:replace_all_except, [:id, :inserted_at]},
+            conflict_target: [:entity_type, :entity_id, :source]
+          )
+
+        {ok + count, err}
+      rescue
+        e ->
+          Logger.error(
+            "MarkImdbIdAbsent: insert_all failed for chunk of #{length(chunk)}: #{Exception.message(e)}"
+          )
+
+          {ok, err + length(chunk)}
+      end
+    end)
+  end
+
+  defp entry({movie_id, release_date}, now) do
+    %{
+      entity_type: "movie",
+      entity_id: movie_id,
+      source: "imdb_id",
+      status: "empty",
+      fetched_at: nil,
+      stale_after: Policy.stale_after("movie", "imdb_id", release_date, now, status: :empty),
+      attempt_count: 0,
+      last_attempt_at: now,
+      error_reason: nil,
+      metadata: %{},
+      inserted_at: now,
+      updated_at: now
+    }
+  end
+end

--- a/lib/cinegraph/maintenance/repair_imdb_ids.ex
+++ b/lib/cinegraph/maintenance/repair_imdb_ids.ex
@@ -11,6 +11,18 @@ defmodule Cinegraph.Maintenance.RepairImdbIds do
 
   Canonical-list movies are prioritised first.
 
+  #1109: skips movies already marked source-absent (`imdb_id` ledger `:empty`) — the
+  TMDb long tail has no IMDb id, and re-verification now rides the unified refresh
+  (#1106), which re-touches `imdb_id` on the `tmdb_details` cadence. This repair path
+  is therefore reduced to *never-checked* movies. Retirement candidate once #1106 is
+  the proven steady-state (tracked under #760) — not retired here.
+
+  KNOWN LIMITATION (#1109): the enqueued `TMDbDetailsWorker` skips movies that already
+  exist (`process_tmdb_movie/3`), so it cannot *complete* a discovery-only stub that's
+  already in the DB but lacks a full `/movie` fetch. Completing those stubs (so their
+  `imdb_id` resolves to present-or-source-absent) needs a refresh-style fetch, not this
+  create-path worker — a separate pre-existing gap, follow-up under #760/#1108.
+
   See #745 Phase 1.2.
 
   ## Options
@@ -40,7 +52,12 @@ defmodule Cinegraph.Maintenance.RepairImdbIds do
   def run(opts \\ []) when is_list(opts) do
     base =
       from m in "movies",
-        where: (is_nil(m.imdb_id) or m.imdb_id == "") and not is_nil(m.tmdb_id),
+        where:
+          (is_nil(m.imdb_id) or m.imdb_id == "") and not is_nil(m.tmdb_id) and
+            fragment(
+              "NOT EXISTS (SELECT 1 FROM data_refreshes dr WHERE dr.entity_type = 'movie' AND dr.entity_id = ? AND dr.source = 'imdb_id' AND dr.status = 'empty')",
+              m.id
+            ),
         order_by: [
           desc: fragment("? != '{}'::jsonb", m.canonical_sources),
           desc: m.id

--- a/lib/cinegraph/movies.ex
+++ b/lib/cinegraph/movies.ex
@@ -1038,8 +1038,9 @@ defmodule Cinegraph.Movies do
   quality/soft-vs-full gating, recommendations/similar/reviews/lists/videos).
 
   Expects `tmdb_data` from `TMDb.get_movie_for_refresh/1` (watch providers under
-  the normalized `"watch_providers"` key). Returns `{:ok, %{watch_present?: bool}}`
-  so the caller can set the `watch_providers` freshness status.
+  the normalized `"watch_providers"` key). Returns
+  `{:ok, %{watch_present?: bool, imdb_present?: bool}}`
+  so the caller can set the `watch_providers` and `imdb_id` freshness statuses.
   """
   def refresh_movie_from_tmdb(%Movie{} = movie, tmdb_data) do
     # Update the structured columns but PRESERVE the raw blob: `Movie.from_tmdb/1`
@@ -1058,7 +1059,7 @@ defmodule Cinegraph.Movies do
          {:ok, _} <- Cinegraph.Movies.Availability.store_tmdb_watch_providers(movie, watch) do
       # Only report presence once the store has actually committed, so the caller's
       # `watch_providers` freshness touch reflects persisted data — not just payload.
-      {:ok, %{watch_present?: watch_present?(watch)}}
+      {:ok, %{watch_present?: watch_present?(watch), imdb_present?: present?(movie.imdb_id)}}
     end
   end
 

--- a/lib/cinegraph/workers/mark_imdb_id_absent_sweeper.ex
+++ b/lib/cinegraph/workers/mark_imdb_id_absent_sweeper.ex
@@ -1,0 +1,31 @@
+defmodule Cinegraph.Workers.MarkImdbIdAbsentSweeper do
+  @moduledoc """
+  Weekly belt-and-suspenders sweep (#1109): marks `imdb_id` source-absent for
+  checked-but-null movies that slipped through the inline touch on the fetch
+  paths (#1106 refresh / import). The wire-forward touch is the real steady
+  state; this just catches drift.
+
+  Wraps `Cinegraph.Maintenance.MarkImdbIdAbsent.run/1`. No API hits (it only
+  writes ledger rows), so the per-run cap is generous.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1, priority: 3
+
+  alias Cinegraph.Maintenance.MarkImdbIdAbsent
+
+  require Logger
+
+  @per_run_limit 50_000
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    case MarkImdbIdAbsent.run(limit: @per_run_limit) do
+      {:ok, %{found: found, marked: marked, failed: failed} = stats} ->
+        Logger.info(
+          "MarkImdbIdAbsentSweeper: found=#{found} marked=#{marked} failed=#{failed} (cap=#{@per_run_limit})"
+        )
+
+        {:ok, stats}
+    end
+  end
+end

--- a/lib/cinegraph/workers/tmdb_details_worker.ex
+++ b/lib/cinegraph/workers/tmdb_details_worker.ex
@@ -146,6 +146,10 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
         # #1096 Phase B: first freshness signal for TMDb details (previously one-shot,
         # grade-D in the §4b provenance audit).
         Freshness.touch("movie", movie.id, "tmdb_details", :ok, base_date: movie.release_date)
+        # imdb_id rides the same response (#1109) — :ok if present, else source-absent.
+        Freshness.touch("movie", movie.id, "imdb_id", imdb_status(movie.imdb_id),
+          base_date: movie.release_date
+        )
 
         enrichment_queued =
           if movie.imdb_id do
@@ -187,6 +191,10 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
       {:ok, movie} ->
         Logger.info("Successfully soft imported movie: #{movie.title} (#{movie.tmdb_id})")
         Freshness.touch("movie", movie.id, "tmdb_details", :ok, base_date: movie.release_date)
+
+        Freshness.touch("movie", movie.id, "imdb_id", imdb_status(movie.imdb_id),
+          base_date: movie.release_date
+        )
 
         # Update job metadata with soft import details
         update_job_meta(job, %{
@@ -413,4 +421,10 @@ defmodule Cinegraph.Workers.TMDbDetailsWorker do
     error ->
       Logger.warning("Failed to update job meta: #{inspect(error)}")
   end
+
+  # imdb_id source-absent classification (#1109): present → :ok, null/blank → :empty.
+  defp imdb_status(imdb_id) when is_binary(imdb_id),
+    do: if(String.trim(imdb_id) != "", do: :ok, else: :empty)
+
+  defp imdb_status(_), do: :empty
 end

--- a/lib/cinegraph/workers/tmdb_movie_refresh_worker.ex
+++ b/lib/cinegraph/workers/tmdb_movie_refresh_worker.ex
@@ -2,8 +2,8 @@ defmodule Cinegraph.Workers.TMDbMovieRefreshWorker do
   @moduledoc """
   Unified per-movie TMDb refresh (#1106): ONE `append_to_response` call
   re-hydrates an existing movie's details + ratings/metrics + credits + watch
-  providers, and touches the freshness ledger for `tmdb_details` and
-  `watch_providers` in the same pass. Replaces the siloed per-source TMDb fetches
+  providers, and touches the freshness ledger for `tmdb_details`, `watch_providers`,
+  and `imdb_id` in the same pass. Replaces the siloed per-source TMDb fetches
   and closes the one-shot-details gap (#1010 grade-D).
 
   Enqueued by `TmdbMovieRefreshSweeper` (the floor) selecting via `Freshness.due/2`.
@@ -54,13 +54,17 @@ defmodule Cinegraph.Workers.TMDbMovieRefreshWorker do
     case fetch_fun.(movie.tmdb_id) do
       {:ok, data} ->
         case Movies.refresh_movie_from_tmdb(movie, data) do
-          {:ok, %{watch_present?: present?}} ->
+          {:ok, %{watch_present?: present?, imdb_present?: imdb_present?}} ->
             Freshness.touch("movie", movie.id, "tmdb_details", :ok, base_date: base)
 
             watch_status = if present?, do: :ok, else: :empty
             Freshness.touch("movie", movie.id, "watch_providers", watch_status, base_date: base)
 
-            {:ok, %{movie_id: movie.id, watch_present?: present?}}
+            # imdb_id rides this fetch (#1109): :ok if TMDb carried one, else source-absent.
+            imdb_status = if imdb_present?, do: :ok, else: :empty
+            Freshness.touch("movie", movie.id, "imdb_id", imdb_status, base_date: base)
+
+            {:ok, %{movie_id: movie.id, watch_present?: present?, imdb_present?: imdb_present?}}
 
           {:error, reason} ->
             Logger.error(
@@ -86,5 +90,7 @@ defmodule Cinegraph.Workers.TMDbMovieRefreshWorker do
       base_date: base,
       error_reason: err
     )
+
+    Freshness.touch("movie", movie.id, "imdb_id", :error, base_date: base, error_reason: err)
   end
 end

--- a/test/cinegraph/health/surface_area_test.exs
+++ b/test/cinegraph/health/surface_area_test.exs
@@ -183,6 +183,24 @@ defmodule Cinegraph.Health.SurfaceAreaTest do
     assert row.target == 95.0
   end
 
+  test "imdb_id counts null-after-fetch (an imdb_id :empty ledger marker) as source-absent/terminal (#1109)" do
+    # fetched: has an imdb_id
+    movie!(%{imdb_id: "tt100"})
+    # source-absent: null, with an imdb_id :empty marker (we fetched details, TMDb had none)
+    absent = movie!(%{imdb_id: nil})
+    Cinegraph.Freshness.touch("movie", absent.id, "imdb_id", :empty)
+    # needs-fetch: null, no marker (never checked)
+    movie!(%{imdb_id: nil})
+
+    row = row_for("imdb_id")
+    assert row.eligible == 3
+    assert row.fetched == 1
+    assert row.source_absent == 1
+    assert row.needs_fetch == 1
+    # terminal = (fetched + source_absent) / eligible = 2/3
+    assert row.terminal_pct == 66.67
+  end
+
   test "computed/supplemental sources carry no coverage number" do
     sources = SurfaceArea.report().sources
     collab = Enum.find(sources, &(&1.source == "collaborations"))

--- a/test/cinegraph/maintenance/mark_imdb_id_absent_test.exs
+++ b/test/cinegraph/maintenance/mark_imdb_id_absent_test.exs
@@ -1,0 +1,86 @@
+defmodule Cinegraph.Maintenance.MarkImdbIdAbsentTest do
+  @moduledoc "#1109 — mark checked-but-null imdb_id movies source-absent in the ledger."
+  use Cinegraph.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Cinegraph.Freshness
+  alias Cinegraph.Freshness.DataRefresh
+  alias Cinegraph.Maintenance.MarkImdbIdAbsent
+  alias Cinegraph.Movies.Movie
+  alias Cinegraph.Repo
+
+  defp movie!(imdb_id) do
+    %Movie{}
+    |> Movie.changeset(%{
+      tmdb_id: System.unique_integer([:positive]),
+      imdb_id: imdb_id,
+      title: "M #{System.unique_integer([:positive])}"
+    })
+    |> Repo.insert!()
+  end
+
+  defp imdb_marker(id),
+    do: Repo.get_by(DataRefresh, entity_type: "movie", entity_id: id, source: "imdb_id")
+
+  test "marks a null-imdb movie that has a tmdb_details attempt as source-absent" do
+    m = movie!(nil)
+    Freshness.touch("movie", m.id, "tmdb_details", :ok)
+
+    assert {:ok, %{found: 1, marked: 1, failed: 0, dry_run: false}} = MarkImdbIdAbsent.run()
+    assert imdb_marker(m.id).status == "empty"
+  end
+
+  test "treats all checked tmdb_details statuses (ok/empty/ineligible) as 'checked'" do
+    for status <- [:ok, :empty, :ineligible] do
+      m = movie!(nil)
+      Freshness.touch("movie", m.id, "tmdb_details", status)
+    end
+
+    assert {:ok, %{found: 3, marked: 3, failed: 0}} = MarkImdbIdAbsent.run()
+  end
+
+  test "marks a blank-string imdb_id (not just nil)" do
+    m = movie!("")
+    Freshness.touch("movie", m.id, "tmdb_details", :ok)
+
+    assert {:ok, %{found: 1, marked: 1}} = MarkImdbIdAbsent.run()
+    assert imdb_marker(m.id).status == "empty"
+  end
+
+  test "skips a null-imdb movie that was never detail-fetched" do
+    m = movie!(nil)
+
+    assert {:ok, %{found: 0}} = MarkImdbIdAbsent.run(dry_run: true)
+    assert imdb_marker(m.id) == nil
+  end
+
+  test "skips a movie that already has an imdb_id" do
+    m = movie!("tt0000001")
+    Freshness.touch("movie", m.id, "tmdb_details", :ok)
+
+    assert {:ok, %{found: 0}} = MarkImdbIdAbsent.run(dry_run: true)
+  end
+
+  test "is idempotent — re-run marks nothing new and creates no duplicate" do
+    m = movie!(nil)
+    Freshness.touch("movie", m.id, "tmdb_details", :ok)
+
+    assert {:ok, %{marked: 1}} = MarkImdbIdAbsent.run()
+    assert {:ok, %{found: 0, marked: 0}} = MarkImdbIdAbsent.run()
+
+    assert Repo.aggregate(
+             from(r in DataRefresh, where: r.entity_id == ^m.id and r.source == "imdb_id"),
+             :count,
+             :id
+           ) == 1
+  end
+
+  test "dry_run finds the set but writes nothing" do
+    m = movie!(nil)
+    Freshness.touch("movie", m.id, "tmdb_details", :ok)
+
+    assert {:ok, %{found: 1, marked: 0, dry_run: true}} = MarkImdbIdAbsent.run(dry_run: true)
+    assert imdb_marker(m.id) == nil
+  end
+end

--- a/test/cinegraph/maintenance/repair_imdb_ids_test.exs
+++ b/test/cinegraph/maintenance/repair_imdb_ids_test.exs
@@ -34,6 +34,15 @@ defmodule Cinegraph.Maintenance.RepairImdbIdsTest do
     # The query keeps the predicate defensively in case the constraint is
     # ever relaxed.
 
+    test "skips movies already marked imdb_id source-absent (#1109)" do
+      marked = insert_movie!(imdb_id: nil)
+      _unmarked = insert_movie!(imdb_id: nil)
+      Cinegraph.Freshness.touch("movie", marked.id, "imdb_id", :empty)
+
+      # only the unmarked null-id movie is selected for repair
+      assert {:ok, %{found: 1}} = RepairImdbIds.run(dry_run: true)
+    end
+
     test "respects :limit cap" do
       Enum.each(1..3, fn _ -> insert_movie!(imdb_id: nil) end)
 

--- a/test/cinegraph/workers/tmdb_movie_refresh_worker_test.exs
+++ b/test/cinegraph/workers/tmdb_movie_refresh_worker_test.exs
@@ -21,9 +21,10 @@ defmodule Cinegraph.Workers.TMDbMovieRefreshWorkerTest do
   defp ledger(id, src),
     do: Repo.get_by(DataRefresh, entity_type: "movie", entity_id: id, source: src)
 
-  defp canned(tmdb_id, watch_results) do
+  defp canned(tmdb_id, watch_results, imdb_id \\ nil) do
     %{
       "id" => tmdb_id,
+      "imdb_id" => imdb_id,
       "title" => "Refreshed Title",
       "runtime" => 142,
       "overview" => "fresh overview",
@@ -40,7 +41,8 @@ defmodule Cinegraph.Workers.TMDbMovieRefreshWorkerTest do
     # no providers in payload → watch_providers terminal :empty
     fetch = fn _ -> {:ok, canned(m.tmdb_id, %{})} end
 
-    assert {:ok, %{watch_present?: false}} =
+    # no providers AND no imdb_id in payload → both terminal :empty
+    assert {:ok, %{watch_present?: false, imdb_present?: false}} =
              TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
 
     updated = Repo.get(Movie, m.id)
@@ -55,24 +57,29 @@ defmodule Cinegraph.Workers.TMDbMovieRefreshWorkerTest do
 
     assert ledger(m.id, "tmdb_details").status == "ok"
     assert ledger(m.id, "watch_providers").status == "empty"
+    assert ledger(m.id, "imdb_id").status == "empty"
   end
 
-  test "watch_providers ledger is :ok when the payload carries providers" do
+  test "watch_providers + imdb_id ledgers are :ok when the payload carries them" do
     m = movie!(%{release_date: ~D[2021-01-01]})
-    fetch = fn _ -> {:ok, canned(m.tmdb_id, %{"US" => %{}})} end
+    fetch = fn _ -> {:ok, canned(m.tmdb_id, %{"US" => %{}}, "tt1234567")} end
 
-    assert {:ok, %{watch_present?: true}} = TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
+    assert {:ok, %{watch_present?: true, imdb_present?: true}} =
+             TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
+
     assert ledger(m.id, "watch_providers").status == "ok"
     assert ledger(m.id, "tmdb_details").status == "ok"
+    assert ledger(m.id, "imdb_id").status == "ok"
   end
 
-  test "fetch error touches both sources :error and returns the error" do
+  test "fetch error touches all three sources :error and returns the error" do
     m = movie!(%{release_date: ~D[2019-01-01]})
     fetch = fn _ -> {:error, :timeout} end
 
     assert {:error, :timeout} = TMDbMovieRefreshWorker.refresh(m.id, fetch_fun: fetch)
     assert ledger(m.id, "tmdb_details").status == "error"
     assert ledger(m.id, "watch_providers").status == "error"
+    assert ledger(m.id, "imdb_id").status == "error"
   end
 
   # (No "missing tmdb_id" test: movies.tmdb_id is NOT NULL, so that worker branch is


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled weekly maintenance job and worker to mark movies whose IMDb ID is confirmed absent (supports dry-run).

* **Improvements**
  * Freshness now records IMDb-ID availability alongside watch-provider signals; refresh flows return an IMDb-present flag.
  * Repair/backfill avoids reprocessing already-marked absent IMDb sources; health metrics count confirmed-absent toward terminal coverage.

* **Tests**
  * Added and expanded tests for marking, repair behavior, and multi-ledger freshness touches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->