### PR TITLE
Homiosdasis.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,13 @@ config :cinegraph,
   # Minimum confidence threshold for fuzzy matching movies (0.0 - 1.0)
   # Movies found with confidence below this threshold will be skipped
   fuzzy_match_min_confidence: 0.7,
+  # Layer 3 read-through refresh (#1108 §10b/§4) — default OFF; flip via READ_THROUGH_ENABLED.
+  read_through_enabled: false,
+  # Per-queue daily completed-job ceilings for the read-through spend-guard.
+  read_through_daily_caps: %{tmdb: 40_000, omdb: 90_000},
+  # Skip read-through enqueue when the target queue is this deep
+  # (available + scheduled + executing + retryable).
+  read_through_queue_limit: 1_000,
   # Scraping adapter chains per source — tried in order until one succeeds
   scraping_strategies: %{
     oscars: [:crawlbase],
@@ -296,6 +303,10 @@ config :cinegraph, Oban,
        # :maintenance (no API — writes ledger rows only). The inline touch on the
        # fetch paths is the real steady state; this catches drift. Sun 03:30 UTC.
        {"30 3 * * 0", Cinegraph.Workers.MarkImdbIdAbsentSweeper},
+       # Surface-area report warmer (#1108 §10c): every 30 min keeps the heavy
+       # SurfaceArea.report() warm in :health_cache (35-min TTL) so /admin/homeostasis
+       # cold-paint is sub-second. Off-minute to avoid the :00 fleet pile-up.
+       {"7,37 * * * *", Cinegraph.Workers.SurfaceAreaCacheWarmer},
        # Collaboration graph repair: 5,000 movies/day enqueued.
        # Sweeper itself runs on :maintenance; the per-movie rebuilds it
        # enqueues run on :collaboration (concurrency 3).

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -380,6 +380,15 @@ if config_env() == :prod do
 
   config :cinegraph, Oban, oban_config
 
+  # Read-through refresh master switch (#1108 §4) — default OFF; flip via env.
+  read_through_enabled =
+    (System.get_env("READ_THROUGH_ENABLED") || "")
+    |> String.trim()
+    |> String.downcase()
+    |> Kernel.in(~w(true 1))
+
+  config :cinegraph, :read_through_enabled, read_through_enabled
+
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you
   # want to use a different value for prod and you most likely don't want

--- a/lib/cinegraph/admin/job_registry.ex
+++ b/lib/cinegraph/admin/job_registry.ex
@@ -67,7 +67,7 @@ defmodule Cinegraph.Admin.JobRegistry do
 
   @entries [
     # =========================================================================
-    # Scheduled entries (27 — must match config.exs crontab exactly)
+    # Scheduled entries (28 — must match config.exs crontab exactly)
     # =========================================================================
 
     %{
@@ -158,6 +158,20 @@ defmodule Cinegraph.Admin.JobRegistry do
       trigger_action: :enqueue_now,
       mutating: false,
       description: "Pre-compute drift checks every 30 minutes (Cachex 35-min TTL)",
+      destination: :system,
+      doc_url: nil
+    },
+    %{
+      id: :surface_area_cache_warmer,
+      label: "Surface-area cache warmer",
+      worker: Workers.SurfaceAreaCacheWarmer,
+      queue: :maintenance,
+      schedule: "7,37 * * * *",
+      args: %{},
+      trigger_action: :enqueue_now,
+      mutating: false,
+      description:
+        "Warm SurfaceArea.report() in :health_cache every 30 min for /admin/homeostasis",
       destination: :system,
       doc_url: nil
     },

--- a/lib/cinegraph/freshness.ex
+++ b/lib/cinegraph/freshness.ex
@@ -108,6 +108,48 @@ defmodule Cinegraph.Freshness do
     |> Repo.all()
   end
 
+  @doc """
+  The registered sources for `entity_type` that are currently stale for
+  `entity_id` — computed in ONE query (read-through hot path, #1108 §10b).
+  Missing ledger row = stale; `ineligible` = not stale; else `stale_after < now`.
+  """
+  def stale_sources(entity_type, entity_id) do
+    et = to_string(entity_type)
+    sources = Policy.registry() |> Map.get(et, %{}) |> Map.keys()
+    now = DateTime.utc_now()
+
+    tracked =
+      from(r in DataRefresh,
+        where: r.entity_type == ^et and r.entity_id == ^entity_id and r.source in ^sources,
+        select: {r.source, r.status, r.stale_after}
+      )
+      |> Repo.all()
+      |> Map.new(fn {src, status, sa} -> {src, {status, sa}} end)
+
+    Enum.filter(sources, fn src ->
+      case Map.get(tracked, src) do
+        nil -> true
+        {"ineligible", _} -> false
+        {_status, nil} -> true
+        {_status, sa} -> DateTime.compare(sa, now) == :lt
+      end
+    end)
+  end
+
+  @doc "Count of rows currently due for `source` (`stale_after < now AND status <> 'ineligible'`)."
+  def due_count(source) do
+    now = DateTime.utc_now()
+    src = to_string(source)
+
+    from(r in DataRefresh,
+      where:
+        r.source == ^src and r.status != "ineligible" and not is_nil(r.stale_after) and
+          r.stale_after < ^now,
+      select: count(r.id)
+    )
+    |> Repo.one()
+  end
+
   # --- status resolution -----------------------------------------------------
 
   defp resolve(:ok, et, src, base_date, now, _prev, _prev_fetched, meta) do

--- a/lib/cinegraph/freshness/read_through.ex
+++ b/lib/cinegraph/freshness/read_through.ex
@@ -1,0 +1,101 @@
+defmodule Cinegraph.Freshness.ReadThrough do
+  @moduledoc """
+  Demand-driven (read-through) refresh (#1108 §10b / #1010 Tier 1).
+
+  When a movie/person page is viewed, `refresh_if_stale/1` checks the freshness
+  ledger and, for each stale source the `SpendGuard` allows, enqueues the
+  already-proven refresh worker so the page self-freshens over time:
+
+    * movie — any of `tmdb_details|watch_providers|imdb_id` stale → one
+      `TMDbMovieRefreshWorker` (it re-hydrates all three in one call); `omdb`
+      stale → one `OMDbEnrichmentWorker`. (≤2/view.)
+    * person — `tmdb_person` stale → one `PersonTmdbRefreshWorker`.
+
+  All workers are uniqueness-keyed (1h), so navigation churn collapses to one
+  real job per entity per hour. `last_checked_at` is stamped on the entity's
+  existing ledger rows on every evaluation (even when skipped) — the
+  "viewed-but-stale" canary the dashboard reads. Off entirely unless
+  `SpendGuard.enabled?`.
+  """
+
+  import Ecto.Query
+
+  alias Cinegraph.Freshness
+  alias Cinegraph.Freshness.{DataRefresh, SpendGuard}
+  alias Cinegraph.Repo
+  alias Cinegraph.Workers.{OMDbEnrichmentWorker, PersonTmdbRefreshWorker, TMDbMovieRefreshWorker}
+
+  require Logger
+
+  @movie_tmdb_sources ~w(tmdb_details watch_providers imdb_id)
+
+  @type entity :: %{type: :movie | :person, id: integer()}
+  @type result :: {:enqueued, [atom()]} | :fresh | :skipped
+
+  @spec refresh_if_stale(entity()) :: result()
+  def refresh_if_stale(entity)
+
+  def refresh_if_stale(%{type: :movie, id: id}) do
+    stale = Freshness.stale_sources(:movie, id)
+    stamp_checked(:movie, id)
+
+    []
+    |> enqueue_if(tmdb_movie_stale?(stale) and SpendGuard.allow?(:tmdb_details), fn ->
+      {TMDbMovieRefreshWorker.new(%{"movie_id" => id}, unique: movie_unique()), :tmdb_movie}
+    end)
+    |> enqueue_if("omdb" in stale and SpendGuard.allow?(:omdb), fn ->
+      {OMDbEnrichmentWorker.new(%{"movie_id" => id}, unique: movie_unique()), :omdb}
+    end)
+    |> result(stale)
+  end
+
+  def refresh_if_stale(%{type: :person, id: id}) do
+    stale = Freshness.stale_sources(:person, id)
+    stamp_checked(:person, id)
+
+    []
+    |> enqueue_if("tmdb_person" in stale and SpendGuard.allow?(:tmdb_person), fn ->
+      {PersonTmdbRefreshWorker.new(%{"person_id" => id}, unique: person_unique()), :tmdb_person}
+    end)
+    |> result(stale)
+  end
+
+  def refresh_if_stale(_), do: :skipped
+
+  # Scope uniqueness per-worker (the workers' own `unique` is args-only, so a
+  # movie's TMDb + OMDb jobs would otherwise dedup against each other). Still
+  # collapses repeated same-worker enqueues within the hour.
+  defp movie_unique, do: [fields: [:worker, :args], keys: [:movie_id], period: 3600]
+  defp person_unique, do: [fields: [:worker, :args], keys: [:person_id], period: 3600]
+
+  defp tmdb_movie_stale?(stale), do: Enum.any?(@movie_tmdb_sources, &(&1 in stale))
+
+  defp enqueue_if(acc, false, _fun), do: acc
+
+  defp enqueue_if(acc, true, fun) do
+    {changeset, tag} = fun.()
+
+    case Oban.insert(changeset) do
+      {:ok, _job} ->
+        acc ++ [tag]
+
+      {:error, reason} ->
+        Logger.warning("ReadThrough: enqueue #{tag} failed: #{inspect(reason)}")
+        acc
+    end
+  end
+
+  defp result([], []), do: :fresh
+  defp result([], _stale), do: :skipped
+  defp result(enqueued, _stale), do: {:enqueued, enqueued}
+
+  # Stamp last_checked_at on the entity's EXISTING ledger rows only — never insert
+  # (an inserted pending/empty row would corrupt stale? + explode the ledger).
+  defp stamp_checked(entity_type, entity_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    et = to_string(entity_type)
+
+    from(r in DataRefresh, where: r.entity_type == ^et and r.entity_id == ^entity_id)
+    |> Repo.update_all(set: [last_checked_at: now])
+  end
+end

--- a/lib/cinegraph/freshness/spend_guard.ex
+++ b/lib/cinegraph/freshness/spend_guard.ex
@@ -1,0 +1,95 @@
+defmodule Cinegraph.Freshness.SpendGuard do
+  @moduledoc """
+  Lightweight gatekeeper for demand-driven (read-through) refresh (#1108 §4).
+
+  Before enqueuing a background API-refresh job, `allow?/1` returns false when:
+
+    1. the master flag `:read_through_enabled` is off (the default),
+    2. the source's Oban queue has already completed its per-source daily cap, or
+    3. the source's queue is backpressured (too many in-flight jobs).
+
+  Deliberately **not** a budget ledger — the heavyweight #1090 Phase-4 governor
+  was dropped (#1108 §4). The daily cap is an approximation via
+  `ObanReader.count_completed_since/2`, which counts the *whole* queue (floor
+  sweepers included) — so read-through **yields to the floor**: it's the first
+  thing denied once the queue is busy. Both DB reads are memoized in Cachex
+  (`:health_cache`, 30s) so a page-view storm can't become a query storm.
+  """
+
+  alias Cinegraph.Health.ObanReader
+
+  @cache :health_cache
+  @cache_ttl :timer.seconds(30)
+  @backpressure_states [:available, :scheduled, :executing, :retryable]
+
+  # ledger source → the Oban queue its refresh worker lands on
+  @queue_for %{
+    "tmdb_details" => :tmdb,
+    "watch_providers" => :tmdb,
+    "imdb_id" => :tmdb,
+    "tmdb_person" => :tmdb,
+    "omdb" => :omdb
+  }
+
+  @doc "Whether the read-through master flag is on (default false)."
+  def enabled?, do: Application.get_env(:cinegraph, :read_through_enabled, false)
+
+  @doc """
+  True if a read-through refresh for `source` may be enqueued right now.
+  `source` is a ledger source (atom or string); unknown sources return false.
+  """
+  def allow?(source) do
+    with true <- enabled?(),
+         queue when not is_nil(queue) <- queue_for(source) do
+      not over_daily_cap?(queue) and not backpressured?(queue)
+    else
+      _ -> false
+    end
+  end
+
+  defp queue_for(source), do: Map.get(@queue_for, to_string(source))
+
+  defp over_daily_cap?(queue) do
+    cap = daily_cap(queue)
+    cap > 0 and completed_today(queue) >= cap
+  end
+
+  defp backpressured?(queue) do
+    limit = Application.get_env(:cinegraph, :read_through_queue_limit, 1_000)
+    queue_depth(queue) > limit
+  end
+
+  defp daily_cap(queue) do
+    :cinegraph
+    |> Application.get_env(:read_through_daily_caps, %{})
+    |> Map.get(queue, 0)
+  end
+
+  defp completed_today(queue) do
+    cached({:completed_today, queue}, fn ->
+      ObanReader.count_completed_since(start_of_utc_day(), queue)
+    end)
+  end
+
+  defp queue_depth(queue) do
+    cached({:queue_depth, queue}, fn ->
+      ObanReader.counts_by_queue_and_state([queue], @backpressure_states)
+      |> Map.get(queue, %{})
+      |> Map.values()
+      |> Enum.sum()
+    end)
+  end
+
+  defp start_of_utc_day do
+    DateTime.utc_now() |> DateTime.to_date() |> DateTime.new!(~T[00:00:00], "Etc/UTC")
+  end
+
+  # 30s memoization so a page-view storm collapses into one query per key.
+  defp cached(key, fun) do
+    case Cachex.fetch(@cache, {:spend_guard, key}, fn -> {:commit, fun.(), ttl: @cache_ttl} end) do
+      {:ok, v} -> v
+      {:commit, v} -> v
+      _ -> fun.()
+    end
+  end
+end

--- a/lib/cinegraph/health/surface_area.ex
+++ b/lib/cinegraph/health/surface_area.ex
@@ -77,6 +77,25 @@ defmodule Cinegraph.Health.SurfaceArea do
     }
   end
 
+  @cache :health_cache
+  @cache_key "surface_area:report"
+  @cache_ttl :timer.minutes(35)
+
+  @doc """
+  Cached `report/0` (#1108 §10c). The report is a multi-second replica scan, so
+  the `/admin/homeostasis` dashboard reads it from `:health_cache` (35-min TTL,
+  warmed by `SurfaceAreaCacheWarmer`). `bypass_cache: true` recomputes fresh.
+  """
+  def cached_report(opts \\ []) do
+    if Keyword.get(opts, :bypass_cache, false), do: Cachex.del(@cache, @cache_key)
+
+    case Cachex.fetch(@cache, @cache_key, fn -> {:commit, report(), ttl: @cache_ttl} end) do
+      {:ok, v} -> v
+      {:commit, v} -> v
+      _ -> report()
+    end
+  end
+
   # ── OMDb (the flagship terminal-state source) ─────────────────────────────────────
   defp omdb_row do
     eligible = count(from m in "movies", where: not is_nil(m.imdb_id) and m.imdb_id != "")

--- a/lib/cinegraph/workers/surface_area_cache_warmer.ex
+++ b/lib/cinegraph/workers/surface_area_cache_warmer.ex
@@ -1,0 +1,30 @@
+defmodule Cinegraph.Workers.SurfaceAreaCacheWarmer do
+  @moduledoc """
+  Keeps the surface-area report warm in `:health_cache` so `/admin/homeostasis`
+  cold-paint is sub-second (#1108 §10c).
+
+  `Cinegraph.Health.SurfaceArea.report/0` is a multi-second `Repo.replica` scan
+  across every source. Re-running it every 30 minutes (under the 35-min Cachex
+  TTL) means each dashboard request hits warm cache instead of triggering the
+  scan in the request path. Mirrors `HealthCacheWarmer`.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1, priority: 3
+
+  alias Cinegraph.Health.SurfaceArea
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    started_at = System.monotonic_time(:millisecond)
+    report = SurfaceArea.cached_report(bypass_cache: true)
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+
+    Logger.info(
+      "SurfaceAreaCacheWarmer: warmed in #{elapsed_ms}ms (#{length(report.sources)} sources)"
+    )
+
+    {:ok, %{warmed_in_ms: elapsed_ms, sources: length(report.sources)}}
+  end
+end

--- a/lib/cinegraph_web/live/admin/homeostasis_live.ex
+++ b/lib/cinegraph_web/live/admin/homeostasis_live.ex
@@ -1,0 +1,217 @@
+defmodule CinegraphWeb.Admin.HomeostasisLive do
+  @moduledoc """
+  `/admin/homeostasis` (#1108 §10c) — the surface-area + freshness dashboard.
+
+  Renders `Cinegraph.Health.SurfaceArea.cached_report/1` (per-source terminal
+  state), the freshness due-counts, the read-through spend panel (#1108 §4), and
+  the "viewed-but-stale" canary. Mirrors `AdminHealthLive.Show`: synchronous
+  cache-backed load + 30s auto-refresh + a force "Recompute" button.
+  """
+  use CinegraphWeb, :admin_live_view
+
+  import Ecto.Query
+
+  alias Cinegraph.Freshness
+  alias Cinegraph.Freshness.SpendGuard
+  alias Cinegraph.Health.{ObanReader, SurfaceArea}
+  alias Cinegraph.Repo
+
+  @refresh_interval 30_000
+  @freshness_sources ~w(tmdb_details watch_providers omdb imdb_id tmdb_person)
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Homeostasis")
+     |> load(force: false)
+     |> maybe_schedule_refresh()}
+  end
+
+  @impl true
+  def handle_info(:refresh, socket) do
+    {:noreply, socket |> load(force: false) |> maybe_schedule_refresh()}
+  end
+
+  @impl true
+  def handle_event("refresh", _params, socket) do
+    {:noreply, load(socket, force: true)}
+  end
+
+  # ===== load =====
+
+  defp load(socket, opts) do
+    force? = Keyword.get(opts, :force, false)
+
+    report = safe(fn -> SurfaceArea.cached_report(bypass_cache: force?) end)
+    due = safe(fn -> due_counts() end)
+    spend = safe(fn -> spend_snapshot() end)
+    canary = safe(fn -> viewed_but_stale_count() end)
+
+    socket
+    |> assign(:report, report)
+    |> assign(:due, ok(due, %{}))
+    |> assign(:spend, ok(spend, nil))
+    |> assign(:canary, ok(canary, nil))
+    |> assign(:loaded_at, DateTime.utc_now())
+    |> assign(:loading_error, error_msg(report))
+  end
+
+  defp due_counts do
+    Map.new(@freshness_sources, fn src -> {src, Freshness.due_count(src)} end)
+  end
+
+  defp spend_snapshot do
+    since = start_of_utc_day()
+
+    depths =
+      ObanReader.counts_by_queue_and_state(
+        [:tmdb, :omdb, :maintenance],
+        [:available, :scheduled, :executing, :retryable]
+      )
+
+    %{
+      enabled: SpendGuard.enabled?(),
+      caps: Application.get_env(:cinegraph, :read_through_daily_caps, %{}),
+      tmdb_today: ObanReader.count_completed_since(since, :tmdb),
+      omdb_today: ObanReader.count_completed_since(since, :omdb),
+      depths: Map.new(depths, fn {q, states} -> {q, states |> Map.values() |> Enum.sum()} end)
+    }
+  end
+
+  # viewed-but-stale (#1010 §10): read-through evaluated it recently but it's still due.
+  defp viewed_but_stale_count do
+    now = DateTime.utc_now()
+    cutoff = DateTime.add(now, -24 * 3600, :second)
+
+    from(r in "data_refreshes",
+      where:
+        not is_nil(r.last_checked_at) and r.last_checked_at > ^cutoff and
+          not is_nil(r.stale_after) and r.stale_after < ^now and r.status != "ineligible",
+      select: count(r.id)
+    )
+    |> Repo.replica().one()
+  end
+
+  defp start_of_utc_day do
+    DateTime.utc_now() |> DateTime.to_date() |> DateTime.new!(~T[00:00:00], "Etc/UTC")
+  end
+
+  defp safe(fun) do
+    fun.()
+  rescue
+    e -> {:error, Exception.message(e)}
+  catch
+    kind, reason -> {:error, "#{kind}: #{inspect(reason)}"}
+  end
+
+  defp ok({:error, _}, default), do: default
+  defp ok(v, _default), do: v
+
+  defp error_msg({:error, msg}), do: msg
+  defp error_msg(_), do: nil
+
+  defp maybe_schedule_refresh(socket) do
+    if connected?(socket), do: Process.send_after(self(), :refresh, @refresh_interval)
+    socket
+  end
+
+  # ===== render =====
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="p-6 space-y-6">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold">Homeostasis</h1>
+          <p class="text-sm text-gray-500">
+            Surface area · freshness · read-through spend
+            <span :if={@loaded_at}>· loaded {Calendar.strftime(@loaded_at, "%H:%M:%S UTC")}</span>
+          </p>
+        </div>
+        <button
+          phx-click="refresh"
+          class="px-3 py-2 text-sm bg-gray-800 text-white rounded hover:bg-gray-700"
+        >
+          Recompute
+        </button>
+      </div>
+
+      <div :if={@loading_error} class="p-3 bg-red-50 text-red-700 rounded text-sm">
+        Report error: {@loading_error}
+      </div>
+
+      <.spend_panel :if={@spend} spend={@spend} canary={@canary} />
+
+      <div :if={is_map(@report)} class="overflow-x-auto border rounded">
+        <table class="min-w-full text-sm">
+          <thead class="bg-gray-50 text-left">
+            <tr>
+              <th class="px-3 py-2">Source</th>
+              <th class="px-3 py-2">Kind</th>
+              <th class="px-3 py-2 text-right">Terminal</th>
+              <th class="px-3 py-2 text-right">Fetched</th>
+              <th class="px-3 py-2 text-right">Source-absent</th>
+              <th class="px-3 py-2 text-right">Needs fetch</th>
+              <th class="px-3 py-2 text-right">Due now</th>
+              <th class="px-3 py-2">Note</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <tr :for={s <- @report.sources} class="hover:bg-gray-50">
+              <td class="px-3 py-2 font-mono">{s.source}</td>
+              <td class="px-3 py-2 text-gray-500">{s.kind}</td>
+              <td class="px-3 py-2 text-right font-semibold">{pct(s.terminal_pct)}</td>
+              <td class="px-3 py-2 text-right">{num(s.fetched)}</td>
+              <td class="px-3 py-2 text-right">{num(s.source_absent)}</td>
+              <td class="px-3 py-2 text-right">{num(s.needs_fetch)}</td>
+              <td class="px-3 py-2 text-right">{num(Map.get(@due, s.source))}</td>
+              <td class="px-3 py-2 text-gray-400 text-xs max-w-md truncate" title={s.note}>
+                {s.note}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    """
+  end
+
+  defp spend_panel(assigns) do
+    ~H"""
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="p-4 border rounded">
+        <div class="text-xs text-gray-500 uppercase">Read-through</div>
+        <div class={["text-lg font-bold", (@spend.enabled && "text-green-600") || "text-gray-400"]}>
+          {(@spend.enabled && "ON") || "OFF"}
+        </div>
+        <div class="text-xs text-gray-500">
+          viewed-but-stale: <span class="font-mono">{num(@canary) || "—"}</span>
+        </div>
+      </div>
+      <div class="p-4 border rounded">
+        <div class="text-xs text-gray-500 uppercase">TMDb spend (today)</div>
+        <div class="text-lg font-bold font-mono">
+          {num(@spend.tmdb_today)} / {num(Map.get(@spend.caps, :tmdb))}
+        </div>
+        <div class="text-xs text-gray-500">queue depth: {num(Map.get(@spend.depths, :tmdb))}</div>
+      </div>
+      <div class="p-4 border rounded">
+        <div class="text-xs text-gray-500 uppercase">OMDb spend (today)</div>
+        <div class="text-lg font-bold font-mono">
+          {num(@spend.omdb_today)} / {num(Map.get(@spend.caps, :omdb))}
+        </div>
+        <div class="text-xs text-gray-500">queue depth: {num(Map.get(@spend.depths, :omdb))}</div>
+      </div>
+    </div>
+    """
+  end
+
+  defp pct(nil), do: "—"
+  defp pct(n) when is_number(n), do: "#{n}%"
+
+  defp num(nil), do: "—"
+  defp num(n) when is_integer(n), do: Number.Delimit.number_to_delimited(n, precision: 0)
+  defp num(n), do: to_string(n)
+end

--- a/lib/cinegraph_web/live/movie_live/show.ex
+++ b/lib/cinegraph_web/live/movie_live/show.ex
@@ -13,6 +13,7 @@ defmodule CinegraphWeb.MovieLive.Show do
   alias Cinegraph.Metrics.DisparityCalculator
   alias Cinegraph.Repo
   alias Cinegraph.Workers.MovieScoreCacheWorker
+  alias CinegraphWeb.ReadThroughHook
 
   require Logger
 
@@ -108,10 +109,15 @@ defmodule CinegraphWeb.MovieLive.Show do
           tl = MovieCollaborations.get_collaboration_timelines(loaded_movie, key)
           {key, rel, tl}
         end)
+        |> ReadThroughHook.schedule(%{type: :movie, id: loaded_movie.id})
       end
 
     {:noreply, socket}
   end
+
+  @impl true
+  def handle_info({:read_through, entity}, socket),
+    do: {:noreply, ReadThroughHook.run(socket, entity)}
 
   @impl true
   def handle_event("switch_tab", %{"tab" => tab}, socket) do

--- a/lib/cinegraph_web/live/movie_live/show_v2.ex
+++ b/lib/cinegraph_web/live/movie_live/show_v2.ex
@@ -21,6 +21,7 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
   alias CinegraphWeb.MovieLive.ShowV2.ProductionDetails
   alias CinegraphWeb.NeutralV2Components
   alias CinegraphWeb.MovieLive.ShowV2Availability
+  alias CinegraphWeb.ReadThroughHook
 
   require Logger
 
@@ -74,7 +75,8 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
          |> maybe_start_video_clerk_recommendation(data.movie.id)
          |> assign(empty_availability_assigns())
          |> start_async_availability(data.movie, socket.assigns[:availability_browser_region])
-         |> assign_movie_seo(data.movie)}
+         |> assign_movie_seo(data.movie)
+         |> ReadThroughHook.schedule(%{type: :movie, id: data.movie.id})}
 
       {:error, :not_found} ->
         {:noreply,
@@ -83,6 +85,10 @@ defmodule CinegraphWeb.MovieLive.ShowV2 do
          |> push_navigate(to: ~p"/movies")}
     end
   end
+
+  @impl true
+  def handle_info({:read_through, entity}, socket),
+    do: {:noreply, ReadThroughHook.run(socket, entity)}
 
   @impl true
   def handle_event("toggle_overview", _, socket),

--- a/lib/cinegraph_web/live/person_live/show.ex
+++ b/lib/cinegraph_web/live/person_live/show.ex
@@ -4,6 +4,7 @@ defmodule CinegraphWeb.PersonLive.Show do
   alias Cinegraph.People
   alias Cinegraph.Collaborations
   alias Cinegraph.Festivals
+  alias CinegraphWeb.ReadThroughHook
   import CinegraphWeb.CollaborationComponents
   import CinegraphWeb.PersonHelpers, only: [person_slug_or_id: 1]
   import CinegraphWeb.SEOHelpers
@@ -100,6 +101,7 @@ defmodule CinegraphWeb.PersonLive.Show do
     |> assign(:six_degrees_path, nil)
     |> assign(:six_degrees_loading, false)
     |> assign_person_seo(person)
+    |> ReadThroughHook.schedule(%{type: :person, id: person.id})
   end
 
   defp build_revenue_map(person) do
@@ -145,6 +147,9 @@ defmodule CinegraphWeb.PersonLive.Show do
   end
 
   @impl true
+  def handle_info({:read_through, entity}, socket),
+    do: {:noreply, ReadThroughHook.run(socket, entity)}
+
   def handle_info({:find_path, target_id}, socket) do
     from_id = socket.assigns.person.id
 

--- a/lib/cinegraph_web/live/person_live/show_v2.ex
+++ b/lib/cinegraph_web/live/person_live/show_v2.ex
@@ -18,6 +18,7 @@ defmodule CinegraphWeb.PersonLive.ShowV2 do
   alias Cinegraph.Festivals
   alias CinegraphWeb.Helpers.UrlHelpers
   alias CinegraphWeb.NeutralV2Components
+  alias CinegraphWeb.ReadThroughHook
 
   @impl true
   def mount(_params, _session, socket) do
@@ -64,6 +65,7 @@ defmodule CinegraphWeb.PersonLive.ShowV2 do
     |> assign(:role_filter, role_filter)
     |> assign(:params, params)
     |> assign_person_seo(person)
+    |> ReadThroughHook.schedule(%{type: :person, id: person.id})
   end
 
   @impl true
@@ -109,6 +111,9 @@ defmodule CinegraphWeb.PersonLive.ShowV2 do
   defp person_movies_cta_label(_role), do: "Open all films"
 
   @impl true
+  def handle_info({:read_through, entity}, socket),
+    do: {:noreply, ReadThroughHook.run(socket, entity)}
+
   def handle_info({:find_path, target_id}, socket) do
     from_id = socket.assigns.person.id
 

--- a/lib/cinegraph_web/read_through_hook.ex
+++ b/lib/cinegraph_web/read_through_hook.ex
@@ -1,0 +1,37 @@
+defmodule CinegraphWeb.ReadThroughHook do
+  @moduledoc """
+  Shared read-through trigger for the movie/person show LiveViews (#1108 §10b).
+
+  On the **connected** socket only, schedules a fire-and-forget freshness refresh
+  so the page self-freshens without blocking render (the static first render
+  never fires it). Use from both `handle_params` (schedule) and `handle_info`
+  (run):
+
+      socket |> ReadThroughHook.schedule(%{type: :movie, id: movie.id})
+
+      def handle_info({:read_through, entity}, socket),
+        do: {:noreply, ReadThroughHook.run(socket, entity)}
+  """
+  import Phoenix.LiveView, only: [connected?: 1]
+
+  alias Cinegraph.Freshness.ReadThrough
+
+  @doc "Schedule a read-through pass for `entity` (`%{type:, id:}`) — connected socket only."
+  def schedule(socket, %{type: _, id: _} = entity) do
+    if connected?(socket), do: send(self(), {:read_through, entity})
+    socket
+  end
+
+  def schedule(socket, _entity), do: socket
+
+  @doc "Run the read-through pass (fire-and-forget; called from handle_info)."
+  def run(socket, entity) do
+    ReadThrough.refresh_if_stale(entity)
+    socket
+  rescue
+    e ->
+      require Logger
+      Logger.warning("ReadThroughHook: #{Exception.message(e)}")
+      socket
+  end
+end

--- a/lib/cinegraph_web/router.ex
+++ b/lib/cinegraph_web/router.ex
@@ -278,6 +278,9 @@ defmodule CinegraphWeb.Router do
       # Homeostasis dashboard (#723) — replaces the import-era trio
       live "/health", AdminHealthLive.Show, :show
 
+      # Surface-area + freshness + read-through spend (#1108 §10c)
+      live "/homeostasis", Admin.HomeostasisLive, :index
+
       # Shared-Postgres connection health (#1018 Session 5)
       live "/connections", Admin.ConnectionsLive, :index
 

--- a/test/cinegraph/freshness/read_through_test.exs
+++ b/test/cinegraph/freshness/read_through_test.exs
@@ -1,0 +1,157 @@
+defmodule Cinegraph.Freshness.ReadThroughTest do
+  @moduledoc "#1108 §10b — demand-driven read-through refresh."
+  use Cinegraph.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Cinegraph.Freshness
+  alias Cinegraph.Freshness.{DataRefresh, ReadThrough}
+  alias Cinegraph.Movies.{Movie, Person}
+  alias Cinegraph.Repo
+  alias Cinegraph.Workers.{OMDbEnrichmentWorker, PersonTmdbRefreshWorker, TMDbMovieRefreshWorker}
+
+  setup do
+    Cachex.clear(:health_cache)
+    prev = Application.get_env(:cinegraph, :read_through_enabled)
+    Application.put_env(:cinegraph, :read_through_enabled, true)
+    on_exit(fn -> Application.put_env(:cinegraph, :read_through_enabled, prev) end)
+    :ok
+  end
+
+  defp movie! do
+    %Movie{}
+    |> Movie.changeset(%{tmdb_id: System.unique_integer([:positive]), title: "M"})
+    |> Repo.insert!()
+  end
+
+  defp person! do
+    %Person{}
+    |> Person.changeset(%{tmdb_id: System.unique_integer([:positive]), name: "P"})
+    |> Repo.insert!()
+  end
+
+  # mark a source FRESH (stale_after far future) so it's not stale
+  defp fresh!(type, id, source) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %DataRefresh{}
+    |> DataRefresh.changeset(%{
+      entity_type: to_string(type),
+      entity_id: id,
+      source: source,
+      status: "ok",
+      fetched_at: now,
+      stale_after: DateTime.add(now, 365 * 86_400, :second)
+    })
+    |> Repo.insert!()
+  end
+
+  defp enqueued(worker), do: Repo.all(from(j in Oban.Job, where: j.worker == ^inspect(worker)))
+
+  test "movie with no ledger rows → stale → enqueues one TMDbMovieRefreshWorker + one OMDb" do
+    m = movie!()
+    assert {:enqueued, tags} = ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+    assert :tmdb_movie in tags and :omdb in tags
+    assert length(enqueued(TMDbMovieRefreshWorker)) == 1
+    assert length(enqueued(OMDbEnrichmentWorker)) == 1
+    # ≤3 invariant
+    assert length(tags) <= 3
+  end
+
+  test "all sources fresh → :fresh, no enqueues" do
+    m = movie!()
+    for src <- ~w(tmdb_details watch_providers omdb imdb_id), do: fresh!(:movie, m.id, src)
+
+    assert :fresh = ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+    assert enqueued(TMDbMovieRefreshWorker) == []
+    assert enqueued(OMDbEnrichmentWorker) == []
+  end
+
+  test "spend-guard off → :skipped, nothing enqueued, but canary still stamped" do
+    Application.put_env(:cinegraph, :read_through_enabled, false)
+    m = movie!()
+    # a tracked row (other sources remain nil→stale, so the result is :skipped)
+    fresh!(:movie, m.id, "tmdb_details")
+
+    assert :skipped = ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+    assert enqueued(TMDbMovieRefreshWorker) == []
+
+    row = Repo.get_by(DataRefresh, entity_type: "movie", entity_id: m.id, source: "tmdb_details")
+    refute is_nil(row.last_checked_at)
+  end
+
+  test "person stale → one PersonTmdbRefreshWorker" do
+    p = person!()
+    assert {:enqueued, [:tmdb_person]} = ReadThrough.refresh_if_stale(%{type: :person, id: p.id})
+    assert length(enqueued(PersonTmdbRefreshWorker)) == 1
+  end
+
+  test "Oban unique dedups two consecutive calls into one job" do
+    m = movie!()
+    ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+    ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+    assert length(enqueued(TMDbMovieRefreshWorker)) == 1
+  end
+
+  test "stamp_checked updates existing rows only — never inserts for an untracked entity" do
+    m = movie!()
+    Application.put_env(:cinegraph, :read_through_enabled, false)
+
+    ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+
+    count =
+      Repo.one(
+        from(r in DataRefresh,
+          where: r.entity_type == "movie" and r.entity_id == ^m.id,
+          select: count(r.id)
+        )
+      )
+
+    assert count == 0
+  end
+
+  test "stamp_checked sets last_checked_at on a tracked row (the canary)" do
+    m = movie!()
+    fresh!(:movie, m.id, "tmdb_details")
+
+    ReadThrough.refresh_if_stale(%{type: :movie, id: m.id})
+
+    row = Repo.get_by(DataRefresh, entity_type: "movie", entity_id: m.id, source: "tmdb_details")
+    refute is_nil(row.last_checked_at)
+  end
+
+  test "stale_sources: nil→stale, ineligible→fresh, future→fresh, past→stale" do
+    m = movie!()
+    fresh!(:movie, m.id, "tmdb_details")
+    # ineligible
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %DataRefresh{}
+    |> DataRefresh.changeset(%{
+      entity_type: "movie",
+      entity_id: m.id,
+      source: "omdb",
+      status: "ineligible"
+    })
+    |> Repo.insert!()
+
+    # past-due watch_providers
+    %DataRefresh{}
+    |> DataRefresh.changeset(%{
+      entity_type: "movie",
+      entity_id: m.id,
+      source: "watch_providers",
+      status: "ok",
+      fetched_at: DateTime.add(now, -10 * 86_400, :second),
+      stale_after: DateTime.add(now, -86_400, :second)
+    })
+    |> Repo.insert!()
+
+    stale = Freshness.stale_sources(:movie, m.id)
+    refute "tmdb_details" in stale
+    refute "omdb" in stale
+    assert "watch_providers" in stale
+    # imdb_id has no row → stale
+    assert "imdb_id" in stale
+  end
+end

--- a/test/cinegraph/freshness/spend_guard_test.exs
+++ b/test/cinegraph/freshness/spend_guard_test.exs
@@ -1,0 +1,94 @@
+defmodule Cinegraph.Freshness.SpendGuardTest do
+  @moduledoc "#1108 §4 — lightweight read-through spend-guard."
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Freshness.SpendGuard
+  alias Cinegraph.Repo
+
+  setup do
+    # Cachex is not sandboxed — start each test with cold spend-guard memo.
+    Cachex.clear(:health_cache)
+
+    prev = %{
+      enabled: Application.get_env(:cinegraph, :read_through_enabled),
+      caps: Application.get_env(:cinegraph, :read_through_daily_caps),
+      limit: Application.get_env(:cinegraph, :read_through_queue_limit)
+    }
+
+    on_exit(fn ->
+      put(:read_through_enabled, prev.enabled)
+      put(:read_through_daily_caps, prev.caps)
+      put(:read_through_queue_limit, prev.limit)
+    end)
+
+    :ok
+  end
+
+  defp put(k, v), do: Application.put_env(:cinegraph, k, v)
+
+  defp job!(attrs) do
+    now = DateTime.utc_now()
+
+    %Oban.Job{}
+    |> Ecto.Changeset.change(
+      Map.merge(
+        %{worker: "T", queue: "tmdb", args: %{}, inserted_at: now, scheduled_at: now},
+        attrs
+      )
+    )
+    |> Repo.insert!()
+  end
+
+  defp enable!(opts \\ []) do
+    put(:read_through_enabled, true)
+    put(:read_through_daily_caps, Keyword.get(opts, :caps, %{tmdb: 40_000, omdb: 90_000}))
+    put(:read_through_queue_limit, Keyword.get(opts, :limit, 1_000))
+    Cachex.clear(:health_cache)
+  end
+
+  test "denied when the master flag is off (default)" do
+    put(:read_through_enabled, false)
+    refute SpendGuard.allow?(:tmdb_details)
+  end
+
+  test "denied for an unknown source even when enabled" do
+    enable!()
+    refute SpendGuard.allow?(:bogus)
+  end
+
+  test "allowed when enabled, under cap, low queue depth" do
+    enable!()
+    assert SpendGuard.allow?(:tmdb_details)
+    assert SpendGuard.allow?(:omdb)
+  end
+
+  test "denied when the queue is at/over its daily cap" do
+    enable!(caps: %{tmdb: 2})
+    job!(%{state: "completed", completed_at: DateTime.utc_now()})
+    job!(%{state: "completed", completed_at: DateTime.utc_now()})
+
+    refute SpendGuard.allow?(:tmdb_details)
+  end
+
+  test "denied when the queue is backpressured (depth over limit)" do
+    enable!(limit: 0)
+    job!(%{state: "available"})
+
+    refute SpendGuard.allow?(:tmdb_details)
+  end
+
+  test "memoizes for 30s — a DB change within the window does not flip the verdict" do
+    enable!(caps: %{tmdb: 2})
+    # cold: 0 completed → allowed (this caches count=0)
+    assert SpendGuard.allow?(:tmdb_details)
+
+    # push over cap, but the cached count is stale within the 30s window
+    job!(%{state: "completed", completed_at: DateTime.utc_now()})
+    job!(%{state: "completed", completed_at: DateTime.utc_now()})
+    assert SpendGuard.allow?(:tmdb_details)
+
+    # after the memo is cleared, the cap is enforced
+    Cachex.clear(:health_cache)
+    refute SpendGuard.allow?(:tmdb_details)
+  end
+end

--- a/test/cinegraph/workers/surface_area_cache_warmer_test.exs
+++ b/test/cinegraph/workers/surface_area_cache_warmer_test.exs
@@ -1,0 +1,18 @@
+defmodule Cinegraph.Workers.SurfaceAreaCacheWarmerTest do
+  @moduledoc "#1108 §10c — warms SurfaceArea.report into :health_cache."
+  use Cinegraph.DataCase, async: false
+
+  alias Cinegraph.Workers.SurfaceAreaCacheWarmer
+
+  setup do
+    Cachex.clear(:health_cache)
+    :ok
+  end
+
+  test "warms the surface-area report into :health_cache" do
+    assert {:ok, %{sources: n}} = SurfaceAreaCacheWarmer.perform(%Oban.Job{args: %{}})
+    assert n > 0
+    assert {:ok, cached} = Cachex.get(:health_cache, "surface_area:report")
+    assert is_map(cached) and is_list(cached.sources)
+  end
+end

--- a/test/cinegraph_web/live/admin/homeostasis_live_test.exs
+++ b/test/cinegraph_web/live/admin/homeostasis_live_test.exs
@@ -1,0 +1,28 @@
+defmodule CinegraphWeb.Admin.HomeostasisLiveTest do
+  @moduledoc "#1108 §10c — /admin/homeostasis dashboard."
+  use CinegraphWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup do
+    Cachex.clear(:health_cache)
+    :ok
+  end
+
+  test "renders the surface-area grid + spend panel", %{conn: conn} do
+    {:ok, _live, html} = live(conn, ~p"/admin/homeostasis")
+
+    assert html =~ "Homeostasis"
+    assert html =~ "Read-through"
+    assert html =~ "TMDb spend"
+    # a static source row from the report
+    assert html =~ "tmdb_details"
+    assert html =~ "imdb_id"
+  end
+
+  test "Recompute button bypasses the cache and re-renders", %{conn: conn} do
+    {:ok, live, _html} = live(conn, ~p"/admin/homeostasis")
+    html = live |> element("button", "Recompute") |> render_click()
+    assert html =~ "Homeostasis"
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New /admin/homeostasis dashboard showing health, per-source freshness, and refresh spend metrics
  * On-view “read-through” refreshes for movie and person pages, gated by a runtime feature flag and per-queue daily caps/queue-depth limits

* **Chores**
  * Periodic cache warming of the surface-area health report

* **Tests**
  * Added test coverage for read-through behavior, spend-guard decisions, cache warmer, and the homeostasis LiveView
<!-- end of auto-generated comment: release notes by coderabbit.ai -->