### PR TITLE
session 2

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,48 @@ rm ~/Library/LaunchAgents/com.cinegraph.docker-prune.plist
 Logs: `~/Library/Logs/cinegraph-docker-prune.log` (script) and
 `/tmp/cinegraph-docker-prune.{out,err}.log` (launchd stdout/stderr).
 
+## Database reclaim (#1122 Session 2)
+
+One-time host-side reclaim of the ~8.5–11 GB of dead JSONB payloads left in old rows
+after #1122 Session 1 capped the writers. Both scripts run against the **direct**
+Postgres port 5432 (never PgBouncer 6432) and are safe to pipe in over SSH without a
+host-side git pull:
+
+```bash
+HOST=192.168.1.205
+ssh "$HOST" 'bash -s' < scripts/db_size_report.sh                      # baseline / verification (read-only)
+```
+
+### `strip_availability_payloads.sh`
+
+Batched, idempotent, resumable strip of the write-only `region_payload` /
+`provider_payload` blobs from `metadata`. Nothing in `lib/` reads them; error rows
+(`metadata = {"error": ...}`) and already-stripped rows are preserved because the
+`WHERE metadata ? '<key>'` filter skips them. Models the id-range / half-open-window /
+sleep discipline of `lib/cinegraph/maintenance/backfill_freshness.ex:297`, with a
+periodic `CHECKPOINT` + plain `VACUUM` so the file doesn't balloon before the final
+`VACUUM FULL` compacts it.
+
+```bash
+# Dry-run first (counts only), then the real strip. Smaller table first as a rehearsal.
+ssh "$HOST" 'bash -s' < scripts/strip_availability_payloads.sh -- \
+  --table movie_watch_providers --key provider_payload --dry-run
+ssh "$HOST" 'bash -s' < scripts/strip_availability_payloads.sh -- \
+  --table movie_watch_providers --key provider_payload
+ssh "$HOST" 'bash -s' < scripts/strip_availability_payloads.sh -- \
+  --table movie_availability_refreshes --key region_payload
+```
+
+After each strip: pause the writer queue in `kamal console`
+(`Oban.pause_queue(queue: :movie_availability)`), run
+`VACUUM FULL <table>;` on port 5432 to reclaim the heap, then
+`Oban.resume_queue(queue: :movie_availability)`. Full runbook: issue #1122.
+
+### `db_size_report.sh`
+
+Read-only snapshot of the four #1122 tables + `pg_database_size` + `df -h`. Run daily
+through the 7-day verification window to confirm the curves stay flat.
+
 ## Guidelines
 
 - Keep the project root clean of temporary files

--- a/scripts/db_size_report.sh
+++ b/scripts/db_size_report.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# db_size_report.sh — #1122 Session 2 size snapshot (READ-ONLY)
+#
+# Prints the table/index/total sizes for the four #1122 tables plus the whole
+# database and host free disk. Used for the day-0 baseline and the 7-day
+# flat-curve verification. Safe to run any time — pure reads.
+#
+# Usage (host-side, or `ssh $HOST 'bash -s' < this_file`):
+#   scripts/db_size_report.sh
+#   scripts/db_size_report.sh --db cinegraph_prod --port 5432
+#
+set -euo pipefail
+
+# launchd runs with a minimal PATH; psql lives in the Homebrew keg on the host.
+command -v psql >/dev/null 2>&1 || export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
+
+DB=cinegraph_prod
+PORT=5432
+PGHOST=127.0.0.1
+PGUSER=holden
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db)   DB="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    --host) PGHOST="$2"; shift 2 ;;
+    --user) PGUSER="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+CONN="host=$PGHOST port=$PORT user=$PGUSER dbname=$DB"
+
+echo "== db_size_report $(date -u '+%Y-%m-%dT%H:%M:%SZ') db=$DB =="
+
+psql "$CONN" -X -c "
+SELECT c.relname                                        AS table,
+       pg_size_pretty(pg_table_size(c.oid))             AS table_incl_toast,
+       pg_size_pretty(pg_indexes_size(c.oid))           AS indexes,
+       pg_size_pretty(pg_total_relation_size(c.oid))    AS total,
+       c.reltuples::bigint                              AS rows_est
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND c.relname IN ('movie_availability_refreshes','movie_watch_providers',
+                    'api_lookup_metrics','data_refreshes')
+ORDER BY pg_total_relation_size(c.oid) DESC;"
+
+psql "$CONN" -X -c "SELECT pg_size_pretty(pg_database_size('${DB}')) AS database_total;"
+
+echo "-- host free disk --"
+df -h / 2>/dev/null || true

--- a/scripts/launchd/com.cinegraph.dbsize-snapshot.plist
+++ b/scripts/launchd/com.cinegraph.dbsize-snapshot.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Daily DB-size snapshot for the #1122 Session 2 flat-curve verification.
+
+  Appends scripts/db_size_report.sh output (the four #1122 tables + database
+  total + host free disk) to a log once a day, so the 7-day "growth curves stay
+  flat" proof accrues without manual effort. Read-only. Times are host-LOCAL.
+  RunAtLoad is true so loading it records a day-0 snapshot immediately.
+
+  This is a TEMPORARY verification aid — unload it once the week is confirmed
+  flat (the writers are already capped at the source, so nothing needs an
+  ongoing prune). Leaving it loaded is harmless (a tiny append-only log).
+
+  Install (host):
+    cp ~/ops/cinegraph/db_size_report.sh ~/ops/cinegraph/   # already placed there
+    cp scripts/launchd/com.cinegraph.dbsize-snapshot.plist ~/Library/LaunchAgents/
+    launchctl load -w ~/Library/LaunchAgents/com.cinegraph.dbsize-snapshot.plist
+
+  Read the accruing series:
+    cat ~/Library/Logs/cinegraph-dbsize-snapshot.log
+
+  Uninstall (after the week):
+    launchctl unload -w ~/Library/LaunchAgents/com.cinegraph.dbsize-snapshot.plist
+    rm ~/Library/LaunchAgents/com.cinegraph.dbsize-snapshot.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cinegraph.dbsize-snapshot</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/holden/ops/cinegraph/db_size_report.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>15</integer>
+        <key>Minute</key>
+        <integer>5</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/holden/Library/Logs/cinegraph-dbsize-snapshot.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/holden/Library/Logs/cinegraph-dbsize-snapshot.log</string>
+</dict>
+</plist>

--- a/scripts/strip_availability_payloads.sh
+++ b/scripts/strip_availability_payloads.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# strip_availability_payloads.sh — #1122 Session 2 batched JSONB payload strip
+#
+# One-time reclaim: remove the write-only `region_payload` / `provider_payload`
+# blobs left in the `metadata` JSONB of the two churn-heaviest tables by rows
+# written before #1122 Session 1 capped the writers (commit cb2ff2d1).
+#
+# Nothing in lib/ reads these payloads (verified twice); product reads touch only
+# scalar columns. Error rows written by `record_availability_error` carry
+# metadata = {"error": ...} and are PRESERVED — the WHERE clause keys on the
+# payload key existing, so error rows and already-stripped ('{}') rows are skipped.
+#
+# Runs host-side against the DIRECT Postgres port 5432 (never PgBouncer 6432 —
+# these are plain autocommit UPDATEs, but we keep the maintenance-port discipline
+# so a follow-on VACUUM/VACUUM FULL uses the same session semantics). Each batch
+# is its own autocommit statement over a half-open id window [lo, hi); a short
+# sleep throttles, and every N batches a CHECKPOINT + plain VACUUM lets the dead
+# tuples be reused in-file so the table doesn't balloon before the final
+# VACUUM FULL compacts it (the #1121 CHECKPOINT discipline).
+#
+# Idempotent + resumable: re-running skips rows already at '{}' via the
+# `metadata ? '<key>'` filter, so an interrupted run just continues.
+#
+# Model: lib/cinegraph/maintenance/backfill_freshness.ex:297 (id-range / half-open
+# window / sleep), reimplemented as host psql.
+#
+# Usage (run FROM the host, or piped in via `ssh $HOST 'bash -s' < this_file -- ...`):
+#
+#   scripts/strip_availability_payloads.sh \
+#     --table movie_watch_providers --key provider_payload
+#
+#   scripts/strip_availability_payloads.sh \
+#     --table movie_availability_refreshes --key region_payload
+#
+# Options:
+#   --table T          target table (required): movie_watch_providers | movie_availability_refreshes
+#   --key K            JSONB key to strip (required): provider_payload | region_payload
+#   --batch N          id-window width per statement (default 100000)
+#   --sleep S          seconds to sleep between batches (default 0.2)
+#   --vacuum-every N   CHECKPOINT + VACUUM the table every N batches (default 50; 0 disables)
+#   --min-id N         start id (default 0; use to resume)
+#   --dry-run          count matching rows per window, update nothing
+#   --db NAME          database (default cinegraph_prod)
+#   --port P           port (default 5432 — the DIRECT port; do NOT use 6432)
+#   --host H           psql host (default 127.0.0.1)
+#   --user U           psql user (default holden)
+#
+set -euo pipefail
+
+TABLE=""
+KEY=""
+BATCH=100000
+SLEEP=0.2
+VACUUM_EVERY=50
+MIN_ID=0
+DRY_RUN=0
+DB=cinegraph_prod
+PORT=5432
+PGHOST=127.0.0.1
+PGUSER=holden
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --table)        TABLE="$2"; shift 2 ;;
+    --key)          KEY="$2"; shift 2 ;;
+    --batch)        BATCH="$2"; shift 2 ;;
+    --sleep)        SLEEP="$2"; shift 2 ;;
+    --vacuum-every) VACUUM_EVERY="$2"; shift 2 ;;
+    --min-id)       MIN_ID="$2"; shift 2 ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    --db)           DB="$2"; shift 2 ;;
+    --port)         PORT="$2"; shift 2 ;;
+    --host)         PGHOST="$2"; shift 2 ;;
+    --user)         PGUSER="$2"; shift 2 ;;
+    --)             shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- validate: whitelist table + key so nothing arbitrary is interpolated into SQL ---
+case "$TABLE:$KEY" in
+  movie_watch_providers:provider_payload) ;;
+  movie_availability_refreshes:region_payload) ;;
+  *)
+    echo "refusing: --table/--key must be one of the two known pairs" >&2
+    echo "  movie_watch_providers        provider_payload" >&2
+    echo "  movie_availability_refreshes region_payload" >&2
+    exit 2 ;;
+esac
+if [[ "$PORT" == "6432" ]]; then
+  echo "refusing: port 6432 is PgBouncer; maintenance must use the direct port 5432" >&2
+  exit 2
+fi
+if [[ ! "$BATCH" =~ ^[1-9][0-9]*$ ]]; then
+  echo "refusing: --batch must be a positive integer (got '${BATCH}')" >&2
+  exit 2
+fi
+
+PSQL=(psql "host=$PGHOST port=$PORT user=$PGUSER dbname=$DB" -v ON_ERROR_STOP=1 -qtAX)
+
+# scalar helper
+q() { "${PSQL[@]}" -c "$1"; }
+
+# Preflight CHECKPOINT authority before touching any rows. A real strip issues
+# CHECKPOINT (superuser or pg_checkpoint only); if the role lacks it, the first
+# checkpoint would abort mid-run after rows are already updated. Dry-runs and
+# runs with vacuuming disabled never checkpoint, so they skip this guard.
+if [[ "$DRY_RUN" -ne 1 && "$VACUUM_EVERY" -ne 0 ]]; then
+  can_checkpoint="$(q "SELECT rolsuper OR pg_has_role(current_user, 'pg_checkpoint', 'member') FROM pg_roles WHERE rolname = current_user;")"
+  if [[ "$can_checkpoint" != "t" ]]; then
+    echo "refusing: role '${PGUSER}' lacks CHECKPOINT privilege (needs superuser or pg_checkpoint)." >&2
+    echo "  grant it, or re-run with --vacuum-every 0 to skip the in-run CHECKPOINT+VACUUM." >&2
+    exit 2
+  fi
+fi
+
+MAX_ID="$(q "SELECT COALESCE(MAX(id), 0) FROM ${TABLE};")"
+echo "== ${TABLE}: strip '${KEY}' =="
+echo "   max(id)=${MAX_ID} batch=${BATCH} sleep=${SLEEP}s vacuum_every=${VACUUM_EVERY} dry_run=${DRY_RUN}"
+TOTAL_MATCH="$(q "SELECT count(*) FROM ${TABLE} WHERE metadata ? '${KEY}';")"
+echo "   rows still holding '${KEY}': ${TOTAL_MATCH}"
+
+if [[ "$MAX_ID" -eq 0 || "$TOTAL_MATCH" -eq 0 ]]; then
+  echo "   nothing to do."
+  exit 0
+fi
+
+changed_total=0
+batch_no=0
+lo="$MIN_ID"
+while [[ "$lo" -le "$MAX_ID" ]]; do
+  hi=$(( lo + BATCH ))
+  batch_no=$(( batch_no + 1 ))
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    n="$(q "SELECT count(*) FROM ${TABLE} WHERE id >= ${lo} AND id < ${hi} AND metadata ? '${KEY}';")"
+    [[ "$n" -gt 0 ]] && printf '   [dry] id [%d,%d): %d rows\n' "$lo" "$hi" "$n"
+    changed_total=$(( changed_total + n ))
+  else
+    # RETURNING-count via a CTE; autocommit (single statement).
+    n="$(q "WITH upd AS (
+              UPDATE ${TABLE}
+                 SET metadata = metadata - '${KEY}'
+               WHERE id >= ${lo} AND id < ${hi}
+                 AND metadata ? '${KEY}'
+             RETURNING 1)
+            SELECT count(*) FROM upd;")"
+    if [[ "$n" -gt 0 ]]; then
+      changed_total=$(( changed_total + n ))
+      printf '   id [%d,%d): stripped %d (running total %d)\n' "$lo" "$hi" "$n" "$changed_total"
+    fi
+    if [[ "$VACUUM_EVERY" -gt 0 && $(( batch_no % VACUUM_EVERY )) -eq 0 ]]; then
+      echo "   -- checkpoint + vacuum ${TABLE} (batch ${batch_no}) --"
+      q "CHECKPOINT;" >/dev/null
+      q "VACUUM ${TABLE};" >/dev/null
+    fi
+  fi
+
+  lo="$hi"
+  # sleep only when there is more work
+  if [[ "$lo" -le "$MAX_ID" ]]; then
+    sleep "$SLEEP"
+  fi
+done
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "== dry-run done: would strip ${changed_total} rows from ${TABLE} =="
+else
+  if [[ "$VACUUM_EVERY" -ne 0 ]]; then
+    echo "   -- final checkpoint + vacuum ${TABLE} --"
+    q "CHECKPOINT;" >/dev/null
+    q "VACUUM ${TABLE};" >/dev/null
+  fi
+  remaining="$(q "SELECT count(*) FROM ${TABLE} WHERE metadata ? '${KEY}';")"
+  echo "== done: stripped ${changed_total} rows from ${TABLE}; remaining with '${KEY}': ${remaining} =="
+  echo "   next: pause :movie_availability, then VACUUM FULL ${TABLE};"
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added read-only reporting for table/database size and host disk space, with configurable connection options.
  - Added a resumable, batched maintenance tool to strip obsolete JSONB availability payloads (id-window batching, dry-run, throttling, and idempotent reruns).
  - Added a scheduled daily macOS task to capture database size snapshots and log results.

- **Documentation**
  - Documented the one-time database reclaim workflow, including safe execution steps, verification window expectations, and operational batching/maintenance guidance.

- **Chores**
  - Added a macOS LaunchAgent to automate snapshot execution and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->